### PR TITLE
Fix for displaying counts as float

### DIFF
--- a/_notebooks/2020-03-18-case-count-estimation-us-states.ipynb
+++ b/_notebooks/2020-03-18-case-count-estimation-us-states.ipynb
@@ -43,7 +43,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "WARNING (theano.tensor.blas): Using NumPy C-API based implementation for BLAS functions.\n"
+      "WARNING (theano.configdefaults): install mkl with `conda install mkl-service`: No module named 'mkl'\n"
      ]
     }
    ],
@@ -170,6 +170,9 @@
     "    print('Dropping %i/%i states in prediction data due to lack of tests: %s' %\n",
     "          (len(to_drop_idx), len(df_pred), ', '.join(to_drop_idx)))\n",
     "    df_pred.drop(to_drop_idx, axis=0, inplace=True)\n",
+    "    # Cast counts to int\n",
+    "    df_pred['negative'] = df_pred['negative'].astype(int)\n",
+    "    df_pred['positive'] = df_pred['positive'].astype(int)\n",
     "\n",
     "    return df_out, df_pred\n",
     "\n",
@@ -291,6952 +294,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Auto-assigning NUTS sampler...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Initializing NUTS using jitter+adapt_diag...\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Sequential sampling (1 chains in 1 job)\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "NUTS: [tau_logit, sigma, beta, alpha, mu_0]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   0%|          | 0/1000 [00:00<?, ?it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   0%|          | 1/1000 [00:01<18:56,  1.14s/it]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   1%|          | 9/1000 [00:01<13:13,  1.25it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   1%|          | 12/1000 [00:01<09:26,  1.74it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   2%|▏         | 15/1000 [00:01<06:47,  2.41it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   2%|▏         | 18/1000 [00:01<04:57,  3.31it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   2%|▏         | 21/1000 [00:01<03:39,  4.46it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   2%|▏         | 24/1000 [00:01<02:45,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   3%|▎         | 27/1000 [00:02<02:07,  7.62it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   3%|▎         | 30/1000 [00:02<01:41,  9.59it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   3%|▎         | 33/1000 [00:02<01:23, 11.61it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   4%|▎         | 36/1000 [00:02<01:11, 13.51it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   4%|▍         | 39/1000 [00:02<01:01, 15.61it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   4%|▍         | 42/1000 [00:02<00:54, 17.46it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   4%|▍         | 45/1000 [00:02<00:50, 18.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   5%|▍         | 48/1000 [00:02<00:47, 20.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   5%|▌         | 51/1000 [00:03<00:45, 20.88it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   5%|▌         | 54/1000 [00:03<00:43, 21.56it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   6%|▌         | 57/1000 [00:03<00:43, 21.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   6%|▌         | 60/1000 [00:03<00:42, 22.18it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   6%|▋         | 63/1000 [00:03<00:41, 22.49it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   7%|▋         | 66/1000 [00:03<00:41, 22.70it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   7%|▋         | 69/1000 [00:03<00:41, 22.61it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   7%|▋         | 72/1000 [00:03<00:41, 22.52it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   8%|▊         | 75/1000 [00:04<00:40, 22.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   8%|▊         | 78/1000 [00:04<00:40, 22.72it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   8%|▊         | 81/1000 [00:04<00:41, 21.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   8%|▊         | 84/1000 [00:04<00:40, 22.35it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   9%|▊         | 87/1000 [00:04<00:40, 22.58it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   9%|▉         | 90/1000 [00:04<00:40, 22.64it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:   9%|▉         | 93/1000 [00:04<00:39, 22.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  10%|▉         | 96/1000 [00:05<00:39, 22.72it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  10%|▉         | 99/1000 [00:05<00:39, 22.75it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  10%|█         | 102/1000 [00:05<00:39, 23.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  10%|█         | 105/1000 [00:05<00:38, 23.34it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  11%|█         | 108/1000 [00:05<00:38, 23.38it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  11%|█         | 111/1000 [00:05<00:37, 23.49it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  11%|█▏        | 114/1000 [00:05<00:37, 23.62it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  12%|█▏        | 117/1000 [00:05<00:37, 23.29it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  12%|█▏        | 120/1000 [00:06<00:37, 23.47it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  12%|█▏        | 123/1000 [00:06<00:37, 23.62it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  13%|█▎        | 126/1000 [00:06<00:37, 23.47it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  13%|█▎        | 129/1000 [00:06<00:37, 23.29it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  13%|█▎        | 132/1000 [00:06<00:37, 23.35it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  14%|█▎        | 135/1000 [00:06<00:36, 23.49it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  14%|█▍        | 138/1000 [00:06<00:36, 23.59it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  14%|█▍        | 141/1000 [00:06<00:36, 23.67it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  14%|█▍        | 144/1000 [00:07<00:36, 23.49it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  15%|█▍        | 147/1000 [00:07<00:36, 23.67it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  15%|█▌        | 150/1000 [00:07<00:36, 23.54it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  15%|█▌        | 153/1000 [00:07<00:35, 23.53it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  16%|█▌        | 156/1000 [00:07<00:36, 23.44it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  16%|█▌        | 159/1000 [00:07<00:37, 22.49it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  16%|█▌        | 162/1000 [00:07<00:36, 22.81it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  16%|█▋        | 165/1000 [00:07<00:36, 23.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  17%|█▋        | 168/1000 [00:08<00:35, 23.16it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  17%|█▋        | 171/1000 [00:08<00:36, 22.45it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  17%|█▋        | 174/1000 [00:08<00:37, 22.31it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  18%|█▊        | 177/1000 [00:08<00:36, 22.55it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  18%|█▊        | 180/1000 [00:08<00:35, 22.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  18%|█▊        | 183/1000 [00:08<00:35, 23.20it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  19%|█▊        | 186/1000 [00:08<00:34, 23.46it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  19%|█▉        | 189/1000 [00:09<00:34, 23.49it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  19%|█▉        | 192/1000 [00:09<00:34, 23.31it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  20%|█▉        | 195/1000 [00:09<00:34, 23.22it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  20%|█▉        | 198/1000 [00:09<00:34, 23.26it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  20%|██        | 201/1000 [00:09<00:44, 18.14it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  20%|██        | 203/1000 [00:09<01:10, 11.39it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  20%|██        | 205/1000 [00:10<01:30,  8.78it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  21%|██        | 207/1000 [00:10<01:41,  7.78it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  21%|██        | 209/1000 [00:10<01:51,  7.12it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  21%|██        | 210/1000 [00:11<01:56,  6.77it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  21%|██        | 211/1000 [00:11<02:00,  6.55it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  21%|██        | 212/1000 [00:11<02:03,  6.36it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  21%|██▏       | 213/1000 [00:11<02:06,  6.24it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  21%|██▏       | 214/1000 [00:11<02:06,  6.19it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  22%|██▏       | 215/1000 [00:12<02:10,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  22%|██▏       | 216/1000 [00:12<02:10,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  22%|██▏       | 217/1000 [00:12<02:19,  5.61it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  22%|██▏       | 218/1000 [00:12<02:25,  5.37it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  22%|██▏       | 219/1000 [00:12<02:20,  5.55it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  22%|██▏       | 220/1000 [00:12<02:20,  5.55it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  22%|██▏       | 221/1000 [00:13<02:17,  5.69it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  22%|██▏       | 222/1000 [00:13<02:14,  5.76it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  22%|██▏       | 223/1000 [00:13<02:14,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  22%|██▏       | 224/1000 [00:13<02:13,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  22%|██▎       | 225/1000 [00:13<02:12,  5.86it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  23%|██▎       | 226/1000 [00:13<02:14,  5.77it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  23%|██▎       | 227/1000 [00:14<02:16,  5.67it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  23%|██▎       | 228/1000 [00:14<02:19,  5.54it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  23%|██▎       | 229/1000 [00:14<02:19,  5.51it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  23%|██▎       | 230/1000 [00:14<02:15,  5.66it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  23%|██▎       | 231/1000 [00:14<02:14,  5.70it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  23%|██▎       | 232/1000 [00:15<02:17,  5.57it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  23%|██▎       | 233/1000 [00:15<02:14,  5.70it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  23%|██▎       | 234/1000 [00:15<02:12,  5.76it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  24%|██▎       | 235/1000 [00:15<02:10,  5.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  24%|██▎       | 236/1000 [00:15<02:10,  5.84it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  24%|██▎       | 237/1000 [00:15<02:11,  5.81it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  24%|██▍       | 238/1000 [00:16<02:11,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  24%|██▍       | 239/1000 [00:16<02:09,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  24%|██▍       | 240/1000 [00:16<02:08,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  24%|██▍       | 241/1000 [00:16<02:06,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  24%|██▍       | 242/1000 [00:16<02:06,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  24%|██▍       | 243/1000 [00:16<02:05,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  24%|██▍       | 244/1000 [00:17<02:04,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  24%|██▍       | 245/1000 [00:17<02:05,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  25%|██▍       | 246/1000 [00:17<02:04,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  25%|██▍       | 247/1000 [00:17<02:05,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  25%|██▍       | 248/1000 [00:17<02:05,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  25%|██▍       | 249/1000 [00:17<02:04,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  25%|██▌       | 250/1000 [00:18<02:04,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  25%|██▌       | 251/1000 [00:18<02:04,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  25%|██▌       | 252/1000 [00:18<02:04,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  25%|██▌       | 253/1000 [00:18<02:07,  5.86it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  25%|██▌       | 254/1000 [00:18<02:07,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  26%|██▌       | 255/1000 [00:18<02:08,  5.79it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  26%|██▌       | 256/1000 [00:19<02:06,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  26%|██▌       | 257/1000 [00:19<02:05,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  26%|██▌       | 258/1000 [00:19<02:05,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  26%|██▌       | 259/1000 [00:19<02:04,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  26%|██▌       | 260/1000 [00:19<02:03,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  26%|██▌       | 261/1000 [00:19<02:03,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  26%|██▌       | 262/1000 [00:20<02:02,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  26%|██▋       | 263/1000 [00:20<02:02,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  26%|██▋       | 264/1000 [00:20<02:02,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  26%|██▋       | 265/1000 [00:20<02:01,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  27%|██▋       | 266/1000 [00:20<02:01,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  27%|██▋       | 267/1000 [00:20<02:02,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  27%|██▋       | 268/1000 [00:21<02:03,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  27%|██▋       | 269/1000 [00:21<02:02,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  27%|██▋       | 270/1000 [00:21<02:01,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  27%|██▋       | 271/1000 [00:21<02:01,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  27%|██▋       | 272/1000 [00:21<02:05,  5.82it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  27%|██▋       | 273/1000 [00:21<02:03,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  27%|██▋       | 274/1000 [00:22<02:02,  5.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  28%|██▊       | 275/1000 [00:22<02:02,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  28%|██▊       | 276/1000 [00:22<02:01,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  28%|██▊       | 277/1000 [00:22<02:11,  5.51it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  28%|██▊       | 278/1000 [00:22<02:15,  5.34it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  28%|██▊       | 279/1000 [00:22<02:10,  5.51it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  28%|██▊       | 280/1000 [00:23<02:07,  5.63it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  28%|██▊       | 281/1000 [00:23<02:06,  5.69it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  28%|██▊       | 282/1000 [00:23<02:03,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  28%|██▊       | 283/1000 [00:23<02:05,  5.71it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  28%|██▊       | 284/1000 [00:23<02:05,  5.68it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  28%|██▊       | 285/1000 [00:24<02:03,  5.78it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  29%|██▊       | 286/1000 [00:24<02:02,  5.82it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  29%|██▊       | 287/1000 [00:24<02:01,  5.86it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  29%|██▉       | 288/1000 [00:24<02:00,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  29%|██▉       | 289/1000 [00:24<01:59,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  29%|██▉       | 290/1000 [00:24<01:58,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  29%|██▉       | 291/1000 [00:25<01:57,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  29%|██▉       | 292/1000 [00:25<01:58,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  29%|██▉       | 293/1000 [00:25<01:58,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  29%|██▉       | 294/1000 [00:25<01:58,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  30%|██▉       | 295/1000 [00:25<01:57,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  30%|██▉       | 296/1000 [00:25<02:02,  5.73it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  30%|██▉       | 297/1000 [00:26<02:10,  5.41it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  30%|██▉       | 298/1000 [00:26<02:11,  5.34it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  30%|██▉       | 299/1000 [00:26<02:06,  5.54it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  30%|███       | 300/1000 [00:26<02:03,  5.68it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  30%|███       | 301/1000 [00:26<02:00,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  30%|███       | 302/1000 [00:26<02:00,  5.81it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  30%|███       | 303/1000 [00:27<02:06,  5.50it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  30%|███       | 304/1000 [00:27<02:03,  5.65it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  30%|███       | 305/1000 [00:27<02:00,  5.77it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  31%|███       | 306/1000 [00:27<01:58,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  31%|███       | 307/1000 [00:27<01:58,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  31%|███       | 308/1000 [00:27<01:57,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  31%|███       | 309/1000 [00:28<01:56,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  31%|███       | 310/1000 [00:28<01:56,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  31%|███       | 311/1000 [00:28<02:04,  5.52it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  31%|███       | 312/1000 [00:28<02:01,  5.65it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  31%|███▏      | 313/1000 [00:28<02:02,  5.59it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  31%|███▏      | 314/1000 [00:29<02:02,  5.62it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  32%|███▏      | 315/1000 [00:29<02:04,  5.51it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  32%|███▏      | 316/1000 [00:29<02:02,  5.57it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  32%|███▏      | 317/1000 [00:29<02:01,  5.62it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  32%|███▏      | 318/1000 [00:29<02:02,  5.55it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  32%|███▏      | 319/1000 [00:29<02:00,  5.67it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  32%|███▏      | 320/1000 [00:30<01:58,  5.73it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  32%|███▏      | 321/1000 [00:30<02:02,  5.55it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  32%|███▏      | 322/1000 [00:30<02:04,  5.46it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  32%|███▏      | 323/1000 [00:30<02:00,  5.64it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  32%|███▏      | 324/1000 [00:30<02:00,  5.63it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  32%|███▎      | 325/1000 [00:31<01:57,  5.75it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  33%|███▎      | 326/1000 [00:31<01:55,  5.82it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  33%|███▎      | 327/1000 [00:31<01:53,  5.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  33%|███▎      | 328/1000 [00:31<02:01,  5.52it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  33%|███▎      | 329/1000 [00:31<02:04,  5.37it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  33%|███▎      | 330/1000 [00:31<02:00,  5.57it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  33%|███▎      | 331/1000 [00:32<01:57,  5.69it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  33%|███▎      | 332/1000 [00:32<01:59,  5.61it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  33%|███▎      | 333/1000 [00:32<01:56,  5.73it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  33%|███▎      | 334/1000 [00:32<01:54,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  34%|███▎      | 335/1000 [00:32<01:52,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  34%|███▎      | 336/1000 [00:32<01:55,  5.74it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  34%|███▎      | 337/1000 [00:33<02:01,  5.47it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  34%|███▍      | 338/1000 [00:33<01:57,  5.64it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  34%|███▍      | 339/1000 [00:33<01:56,  5.67it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  34%|███▍      | 340/1000 [00:33<01:54,  5.75it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  34%|███▍      | 341/1000 [00:33<01:52,  5.84it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  34%|███▍      | 342/1000 [00:33<01:52,  5.87it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  34%|███▍      | 343/1000 [00:34<01:51,  5.87it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  34%|███▍      | 344/1000 [00:34<01:51,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  34%|███▍      | 345/1000 [00:34<01:50,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  35%|███▍      | 346/1000 [00:34<01:49,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  35%|███▍      | 347/1000 [00:34<01:48,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  35%|███▍      | 348/1000 [00:34<01:48,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  35%|███▍      | 349/1000 [00:35<01:47,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  35%|███▌      | 350/1000 [00:35<01:51,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  35%|███▌      | 351/1000 [00:35<01:51,  5.84it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  35%|███▌      | 352/1000 [00:35<01:49,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  35%|███▌      | 353/1000 [00:35<01:48,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  35%|███▌      | 354/1000 [00:36<01:54,  5.63it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  36%|███▌      | 355/1000 [00:36<01:54,  5.61it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  36%|███▌      | 356/1000 [00:36<01:52,  5.70it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  36%|███▌      | 357/1000 [00:36<01:51,  5.74it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  36%|███▌      | 358/1000 [00:36<01:53,  5.66it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  36%|███▌      | 359/1000 [00:36<01:51,  5.74it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  36%|███▌      | 360/1000 [00:37<01:49,  5.82it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  36%|███▌      | 361/1000 [00:37<01:48,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  36%|███▌      | 362/1000 [00:37<01:47,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  36%|███▋      | 363/1000 [00:37<01:48,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  36%|███▋      | 364/1000 [00:37<01:47,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  36%|███▋      | 365/1000 [00:37<01:47,  5.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  37%|███▋      | 366/1000 [00:38<01:46,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  37%|███▋      | 367/1000 [00:38<01:46,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  37%|███▋      | 368/1000 [00:38<01:50,  5.72it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  37%|███▋      | 369/1000 [00:38<01:49,  5.79it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  37%|███▋      | 370/1000 [00:38<01:47,  5.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  37%|███▋      | 371/1000 [00:38<01:46,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  37%|███▋      | 372/1000 [00:39<01:45,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  37%|███▋      | 373/1000 [00:39<01:52,  5.55it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  37%|███▋      | 374/1000 [00:39<01:53,  5.52it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  38%|███▊      | 375/1000 [00:39<01:51,  5.61it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  38%|███▊      | 376/1000 [00:39<01:50,  5.62it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  38%|███▊      | 377/1000 [00:40<01:48,  5.73it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  38%|███▊      | 378/1000 [00:40<01:49,  5.71it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  38%|███▊      | 379/1000 [00:40<01:47,  5.79it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  38%|███▊      | 380/1000 [00:40<01:45,  5.88it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  38%|███▊      | 381/1000 [00:40<01:49,  5.64it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  38%|███▊      | 382/1000 [00:40<01:47,  5.76it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  38%|███▊      | 383/1000 [00:41<01:46,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  38%|███▊      | 384/1000 [00:41<01:47,  5.71it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  38%|███▊      | 385/1000 [00:41<01:46,  5.79it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  39%|███▊      | 386/1000 [00:41<01:44,  5.86it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  39%|███▊      | 387/1000 [00:41<01:44,  5.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  39%|███▉      | 388/1000 [00:41<01:42,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  39%|███▉      | 389/1000 [00:42<01:41,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  39%|███▉      | 390/1000 [00:42<01:42,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  39%|███▉      | 391/1000 [00:42<01:41,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  39%|███▉      | 392/1000 [00:42<01:41,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  39%|███▉      | 393/1000 [00:42<01:40,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  39%|███▉      | 394/1000 [00:42<01:44,  5.81it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  40%|███▉      | 395/1000 [00:43<01:46,  5.70it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  40%|███▉      | 396/1000 [00:43<01:43,  5.81it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  40%|███▉      | 397/1000 [00:43<01:43,  5.84it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  40%|███▉      | 398/1000 [00:43<01:42,  5.86it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  40%|███▉      | 399/1000 [00:43<01:41,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  40%|████      | 400/1000 [00:43<01:41,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  40%|████      | 401/1000 [00:44<01:42,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  40%|████      | 402/1000 [00:44<01:49,  5.47it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  40%|████      | 403/1000 [00:44<01:50,  5.40it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  40%|████      | 404/1000 [00:44<01:49,  5.46it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  40%|████      | 405/1000 [00:44<01:45,  5.64it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  41%|████      | 406/1000 [00:45<01:47,  5.53it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  41%|████      | 407/1000 [00:45<01:44,  5.68it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  41%|████      | 408/1000 [00:45<01:45,  5.60it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  41%|████      | 409/1000 [00:45<01:43,  5.72it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  41%|████      | 410/1000 [00:45<01:41,  5.79it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  41%|████      | 411/1000 [00:45<01:40,  5.88it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  41%|████      | 412/1000 [00:46<01:38,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  41%|████▏     | 413/1000 [00:46<01:39,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  41%|████▏     | 414/1000 [00:46<01:38,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  42%|████▏     | 415/1000 [00:46<01:38,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  42%|████▏     | 416/1000 [00:46<01:37,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  42%|████▏     | 417/1000 [00:46<01:37,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  42%|████▏     | 418/1000 [00:47<01:36,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  42%|████▏     | 419/1000 [00:47<01:36,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  42%|████▏     | 420/1000 [00:47<01:35,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  42%|████▏     | 421/1000 [00:47<01:36,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  42%|████▏     | 422/1000 [00:47<01:35,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  42%|████▏     | 423/1000 [00:47<01:42,  5.61it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  42%|████▏     | 424/1000 [00:48<01:40,  5.72it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  42%|████▎     | 425/1000 [00:48<01:39,  5.78it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  43%|████▎     | 426/1000 [00:48<01:38,  5.81it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  43%|████▎     | 427/1000 [00:48<01:38,  5.81it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  43%|████▎     | 428/1000 [00:48<01:38,  5.79it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  43%|████▎     | 429/1000 [00:48<01:36,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  43%|████▎     | 430/1000 [00:49<01:38,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  43%|████▎     | 431/1000 [00:49<01:39,  5.69it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  43%|████▎     | 432/1000 [00:49<01:38,  5.79it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  43%|████▎     | 433/1000 [00:49<01:37,  5.79it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  43%|████▎     | 434/1000 [00:49<01:36,  5.86it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  44%|████▎     | 435/1000 [00:49<01:35,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  44%|████▎     | 436/1000 [00:50<01:34,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  44%|████▎     | 437/1000 [00:50<01:34,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  44%|████▍     | 438/1000 [00:50<01:33,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  44%|████▍     | 439/1000 [00:50<01:33,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  44%|████▍     | 440/1000 [00:50<01:33,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  44%|████▍     | 441/1000 [00:50<01:33,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  44%|████▍     | 442/1000 [00:51<01:35,  5.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  44%|████▍     | 443/1000 [00:51<01:42,  5.41it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  44%|████▍     | 444/1000 [00:51<01:46,  5.20it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  44%|████▍     | 445/1000 [00:51<01:49,  5.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  45%|████▍     | 446/1000 [00:51<01:50,  5.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  45%|████▍     | 447/1000 [00:52<01:51,  4.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  45%|████▍     | 448/1000 [00:52<01:52,  4.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  45%|████▍     | 449/1000 [00:52<01:46,  5.17it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  45%|████▌     | 450/1000 [00:52<01:41,  5.39it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  45%|████▌     | 451/1000 [00:52<01:38,  5.55it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  45%|████▌     | 452/1000 [00:53<01:36,  5.68it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  45%|████▌     | 453/1000 [00:53<01:34,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  45%|████▌     | 454/1000 [00:53<01:36,  5.68it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  46%|████▌     | 455/1000 [00:53<01:35,  5.69it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  46%|████▌     | 456/1000 [00:53<01:38,  5.52it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  46%|████▌     | 457/1000 [00:53<01:35,  5.67it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  46%|████▌     | 458/1000 [00:54<01:35,  5.69it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  46%|████▌     | 459/1000 [00:54<01:40,  5.36it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  46%|████▌     | 460/1000 [00:54<01:39,  5.43it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  46%|████▌     | 461/1000 [00:54<01:35,  5.63it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  46%|████▌     | 462/1000 [00:54<01:33,  5.75it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  46%|████▋     | 463/1000 [00:55<01:31,  5.84it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  46%|████▋     | 464/1000 [00:55<01:30,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  46%|████▋     | 465/1000 [00:55<01:30,  5.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  47%|████▋     | 466/1000 [00:55<01:32,  5.78it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  47%|████▋     | 467/1000 [00:55<01:30,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  47%|████▋     | 468/1000 [00:55<01:29,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  47%|████▋     | 469/1000 [00:56<01:29,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  47%|████▋     | 470/1000 [00:56<01:28,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  47%|████▋     | 471/1000 [00:56<01:28,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  47%|████▋     | 472/1000 [00:56<01:27,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  47%|████▋     | 473/1000 [00:56<01:27,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  47%|████▋     | 474/1000 [00:56<01:27,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  48%|████▊     | 475/1000 [00:57<01:27,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  48%|████▊     | 476/1000 [00:57<01:27,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  48%|████▊     | 477/1000 [00:57<01:27,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  48%|████▊     | 478/1000 [00:57<01:29,  5.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  48%|████▊     | 479/1000 [00:57<01:28,  5.87it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  48%|████▊     | 480/1000 [00:57<01:27,  5.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  48%|████▊     | 481/1000 [00:58<01:27,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  48%|████▊     | 482/1000 [00:58<01:27,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  48%|████▊     | 483/1000 [00:58<01:27,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  48%|████▊     | 484/1000 [00:58<01:30,  5.71it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  48%|████▊     | 485/1000 [00:58<01:28,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  49%|████▊     | 486/1000 [00:58<01:31,  5.65it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  49%|████▊     | 487/1000 [00:59<01:28,  5.79it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  49%|████▉     | 488/1000 [00:59<01:27,  5.87it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  49%|████▉     | 489/1000 [00:59<01:26,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  49%|████▉     | 490/1000 [00:59<01:26,  5.88it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  49%|████▉     | 491/1000 [00:59<01:25,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  49%|████▉     | 492/1000 [00:59<01:25,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  49%|████▉     | 493/1000 [01:00<01:25,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  49%|████▉     | 494/1000 [01:00<01:24,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  50%|████▉     | 495/1000 [01:00<01:25,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  50%|████▉     | 496/1000 [01:00<01:24,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  50%|████▉     | 497/1000 [01:00<01:23,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  50%|████▉     | 498/1000 [01:00<01:23,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  50%|████▉     | 499/1000 [01:01<01:22,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  50%|█████     | 500/1000 [01:01<01:22,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  50%|█████     | 501/1000 [01:01<01:22,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  50%|█████     | 502/1000 [01:01<01:22,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  50%|█████     | 503/1000 [01:01<01:22,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  50%|█████     | 504/1000 [01:01<01:23,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  50%|█████     | 505/1000 [01:02<01:22,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  51%|█████     | 506/1000 [01:02<01:21,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  51%|█████     | 507/1000 [01:02<01:21,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  51%|█████     | 508/1000 [01:02<01:20,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  51%|█████     | 509/1000 [01:02<01:20,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  51%|█████     | 510/1000 [01:02<01:20,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  51%|█████     | 511/1000 [01:03<01:21,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  51%|█████     | 512/1000 [01:03<01:21,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  51%|█████▏    | 513/1000 [01:03<01:21,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  51%|█████▏    | 514/1000 [01:03<01:21,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  52%|█████▏    | 515/1000 [01:03<01:21,  5.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  52%|█████▏    | 516/1000 [01:03<01:22,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  52%|█████▏    | 517/1000 [01:04<01:22,  5.88it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  52%|█████▏    | 518/1000 [01:04<01:22,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  52%|█████▏    | 519/1000 [01:04<01:22,  5.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  52%|█████▏    | 520/1000 [01:04<01:22,  5.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  52%|█████▏    | 521/1000 [01:04<01:20,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  52%|█████▏    | 522/1000 [01:04<01:20,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  52%|█████▏    | 523/1000 [01:05<01:19,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  52%|█████▏    | 524/1000 [01:05<01:19,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  52%|█████▎    | 525/1000 [01:05<01:19,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  53%|█████▎    | 526/1000 [01:05<01:18,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  53%|█████▎    | 527/1000 [01:05<01:18,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  53%|█████▎    | 528/1000 [01:05<01:18,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  53%|█████▎    | 529/1000 [01:06<01:17,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  53%|█████▎    | 530/1000 [01:06<01:17,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  53%|█████▎    | 531/1000 [01:06<01:17,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  53%|█████▎    | 532/1000 [01:06<01:18,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  53%|█████▎    | 533/1000 [01:06<01:18,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  53%|█████▎    | 534/1000 [01:06<01:17,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  54%|█████▎    | 535/1000 [01:07<01:17,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  54%|█████▎    | 536/1000 [01:07<01:16,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  54%|█████▎    | 537/1000 [01:07<01:16,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  54%|█████▍    | 538/1000 [01:07<01:17,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  54%|█████▍    | 539/1000 [01:07<01:18,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  54%|█████▍    | 540/1000 [01:07<01:17,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  54%|█████▍    | 541/1000 [01:08<01:16,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  54%|█████▍    | 542/1000 [01:08<01:15,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  54%|█████▍    | 543/1000 [01:08<01:15,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  54%|█████▍    | 544/1000 [01:08<01:15,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  55%|█████▍    | 545/1000 [01:08<01:15,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  55%|█████▍    | 546/1000 [01:08<01:14,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  55%|█████▍    | 547/1000 [01:09<01:14,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  55%|█████▍    | 548/1000 [01:09<01:14,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  55%|█████▍    | 549/1000 [01:09<01:14,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  55%|█████▌    | 550/1000 [01:09<01:14,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  55%|█████▌    | 551/1000 [01:09<01:15,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  55%|█████▌    | 552/1000 [01:09<01:14,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  55%|█████▌    | 553/1000 [01:10<01:15,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  55%|█████▌    | 554/1000 [01:10<01:14,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  56%|█████▌    | 555/1000 [01:10<01:14,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  56%|█████▌    | 556/1000 [01:10<01:13,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  56%|█████▌    | 557/1000 [01:10<01:18,  5.64it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  56%|█████▌    | 558/1000 [01:10<01:16,  5.77it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  56%|█████▌    | 559/1000 [01:11<01:15,  5.86it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  56%|█████▌    | 560/1000 [01:11<01:14,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  56%|█████▌    | 561/1000 [01:11<01:13,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  56%|█████▌    | 562/1000 [01:11<01:16,  5.72it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  56%|█████▋    | 563/1000 [01:11<01:14,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  56%|█████▋    | 564/1000 [01:11<01:13,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  56%|█████▋    | 565/1000 [01:12<01:14,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  57%|█████▋    | 566/1000 [01:12<01:13,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  57%|█████▋    | 567/1000 [01:12<01:14,  5.78it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  57%|█████▋    | 568/1000 [01:12<01:13,  5.86it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  57%|█████▋    | 569/1000 [01:12<01:13,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  57%|█████▋    | 570/1000 [01:12<01:12,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  57%|█████▋    | 571/1000 [01:13<01:11,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  57%|█████▋    | 572/1000 [01:13<01:10,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  57%|█████▋    | 573/1000 [01:13<01:10,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  57%|█████▋    | 574/1000 [01:13<01:11,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  57%|█████▊    | 575/1000 [01:13<01:11,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  58%|█████▊    | 576/1000 [01:13<01:11,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  58%|█████▊    | 577/1000 [01:14<01:10,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  58%|█████▊    | 578/1000 [01:14<01:10,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  58%|█████▊    | 579/1000 [01:14<01:10,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  58%|█████▊    | 580/1000 [01:14<01:10,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  58%|█████▊    | 581/1000 [01:14<01:09,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  58%|█████▊    | 582/1000 [01:14<01:08,  6.10it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  58%|█████▊    | 583/1000 [01:15<01:08,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  58%|█████▊    | 584/1000 [01:15<01:10,  5.88it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  58%|█████▊    | 585/1000 [01:15<01:09,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  59%|█████▊    | 586/1000 [01:15<01:09,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  59%|█████▊    | 587/1000 [01:15<01:09,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  59%|█████▉    | 588/1000 [01:15<01:10,  5.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  59%|█████▉    | 589/1000 [01:16<01:09,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  59%|█████▉    | 590/1000 [01:16<01:08,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  59%|█████▉    | 591/1000 [01:16<01:07,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  59%|█████▉    | 592/1000 [01:16<01:08,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  59%|█████▉    | 593/1000 [01:16<01:06,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  59%|█████▉    | 594/1000 [01:16<01:07,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  60%|█████▉    | 595/1000 [01:17<01:07,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  60%|█████▉    | 596/1000 [01:17<01:07,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  60%|█████▉    | 597/1000 [01:17<01:06,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  60%|█████▉    | 598/1000 [01:17<01:06,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  60%|█████▉    | 599/1000 [01:17<01:06,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  60%|██████    | 600/1000 [01:17<01:06,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  60%|██████    | 601/1000 [01:18<01:06,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  60%|██████    | 602/1000 [01:18<01:05,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  60%|██████    | 603/1000 [01:18<01:06,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  60%|██████    | 604/1000 [01:18<01:06,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  60%|██████    | 605/1000 [01:18<01:05,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  61%|██████    | 606/1000 [01:18<01:04,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  61%|██████    | 607/1000 [01:19<01:04,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  61%|██████    | 608/1000 [01:19<01:05,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  61%|██████    | 609/1000 [01:19<01:04,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  61%|██████    | 610/1000 [01:19<01:04,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  61%|██████    | 611/1000 [01:19<01:04,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  61%|██████    | 612/1000 [01:19<01:04,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  61%|██████▏   | 613/1000 [01:20<01:04,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  61%|██████▏   | 614/1000 [01:20<01:04,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  62%|██████▏   | 615/1000 [01:20<01:06,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  62%|██████▏   | 616/1000 [01:20<01:06,  5.79it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  62%|██████▏   | 617/1000 [01:20<01:05,  5.82it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  62%|██████▏   | 618/1000 [01:21<01:05,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  62%|██████▏   | 619/1000 [01:21<01:06,  5.76it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  62%|██████▏   | 620/1000 [01:21<01:06,  5.72it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  62%|██████▏   | 621/1000 [01:21<01:05,  5.77it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  62%|██████▏   | 622/1000 [01:21<01:05,  5.74it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  62%|██████▏   | 623/1000 [01:21<01:05,  5.74it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  62%|██████▏   | 624/1000 [01:22<01:04,  5.87it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  62%|██████▎   | 625/1000 [01:22<01:02,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  63%|██████▎   | 626/1000 [01:22<01:02,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  63%|██████▎   | 627/1000 [01:22<01:02,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  63%|██████▎   | 628/1000 [01:22<01:01,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  63%|██████▎   | 629/1000 [01:22<01:01,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  63%|██████▎   | 630/1000 [01:23<01:01,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  63%|██████▎   | 631/1000 [01:23<01:01,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  63%|██████▎   | 632/1000 [01:23<01:01,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  63%|██████▎   | 633/1000 [01:23<01:00,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  63%|██████▎   | 634/1000 [01:23<01:01,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  64%|██████▎   | 635/1000 [01:23<01:00,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  64%|██████▎   | 636/1000 [01:24<01:00,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  64%|██████▎   | 637/1000 [01:24<01:01,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  64%|██████▍   | 638/1000 [01:24<01:02,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  64%|██████▍   | 639/1000 [01:24<01:01,  5.84it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  64%|██████▍   | 640/1000 [01:24<01:02,  5.77it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  64%|██████▍   | 641/1000 [01:24<01:02,  5.76it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  64%|██████▍   | 642/1000 [01:25<01:01,  5.78it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  64%|██████▍   | 643/1000 [01:25<01:00,  5.87it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  64%|██████▍   | 644/1000 [01:25<00:59,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  64%|██████▍   | 645/1000 [01:25<00:59,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  65%|██████▍   | 646/1000 [01:25<00:59,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  65%|██████▍   | 647/1000 [01:25<00:59,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  65%|██████▍   | 648/1000 [01:26<00:59,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  65%|██████▍   | 649/1000 [01:26<00:59,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  65%|██████▌   | 650/1000 [01:26<00:58,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  65%|██████▌   | 651/1000 [01:26<00:57,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  65%|██████▌   | 652/1000 [01:26<00:57,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  65%|██████▌   | 653/1000 [01:26<00:57,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  65%|██████▌   | 654/1000 [01:27<00:57,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  66%|██████▌   | 655/1000 [01:27<00:57,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  66%|██████▌   | 656/1000 [01:27<00:56,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  66%|██████▌   | 657/1000 [01:27<00:55,  6.13it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  66%|██████▌   | 658/1000 [01:27<00:57,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  66%|██████▌   | 659/1000 [01:27<00:57,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  66%|██████▌   | 660/1000 [01:28<00:56,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  66%|██████▌   | 661/1000 [01:28<00:56,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  66%|██████▌   | 662/1000 [01:28<00:55,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  66%|██████▋   | 663/1000 [01:28<00:55,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  66%|██████▋   | 664/1000 [01:28<00:54,  6.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  66%|██████▋   | 665/1000 [01:28<00:55,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  67%|██████▋   | 666/1000 [01:29<00:55,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  67%|██████▋   | 667/1000 [01:29<00:54,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  67%|██████▋   | 668/1000 [01:29<00:55,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  67%|██████▋   | 669/1000 [01:29<00:54,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  67%|██████▋   | 670/1000 [01:29<00:54,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  67%|██████▋   | 671/1000 [01:29<00:54,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  67%|██████▋   | 672/1000 [01:30<00:54,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  67%|██████▋   | 673/1000 [01:30<00:54,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  67%|██████▋   | 674/1000 [01:30<00:54,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  68%|██████▊   | 675/1000 [01:30<00:53,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  68%|██████▊   | 676/1000 [01:30<00:53,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  68%|██████▊   | 677/1000 [01:30<00:53,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  68%|██████▊   | 678/1000 [01:31<00:52,  6.13it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  68%|██████▊   | 679/1000 [01:31<00:52,  6.10it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  68%|██████▊   | 680/1000 [01:31<00:52,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  68%|██████▊   | 681/1000 [01:31<00:51,  6.14it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  68%|██████▊   | 682/1000 [01:31<00:52,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  68%|██████▊   | 683/1000 [01:31<00:52,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  68%|██████▊   | 684/1000 [01:32<00:52,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  68%|██████▊   | 685/1000 [01:32<00:52,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  69%|██████▊   | 686/1000 [01:32<00:53,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  69%|██████▊   | 687/1000 [01:32<00:53,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  69%|██████▉   | 688/1000 [01:32<00:52,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  69%|██████▉   | 689/1000 [01:32<00:52,  5.87it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  69%|██████▉   | 690/1000 [01:33<00:52,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  69%|██████▉   | 691/1000 [01:33<00:51,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  69%|██████▉   | 692/1000 [01:33<00:52,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  69%|██████▉   | 693/1000 [01:33<00:52,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  69%|██████▉   | 694/1000 [01:33<00:51,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  70%|██████▉   | 695/1000 [01:33<00:51,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  70%|██████▉   | 696/1000 [01:34<00:50,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  70%|██████▉   | 697/1000 [01:34<00:49,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  70%|██████▉   | 698/1000 [01:34<00:50,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  70%|██████▉   | 699/1000 [01:34<00:49,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  70%|███████   | 700/1000 [01:34<00:49,  6.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  70%|███████   | 701/1000 [01:34<00:48,  6.13it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  70%|███████   | 702/1000 [01:35<00:48,  6.17it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  70%|███████   | 703/1000 [01:35<00:48,  6.12it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  70%|███████   | 704/1000 [01:35<00:48,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  70%|███████   | 705/1000 [01:35<00:48,  6.14it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  71%|███████   | 706/1000 [01:35<00:48,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  71%|███████   | 707/1000 [01:35<00:47,  6.13it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  71%|███████   | 708/1000 [01:36<00:47,  6.10it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  71%|███████   | 709/1000 [01:36<00:47,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  71%|███████   | 710/1000 [01:36<00:47,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  71%|███████   | 711/1000 [01:36<00:47,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  71%|███████   | 712/1000 [01:36<00:48,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  71%|███████▏  | 713/1000 [01:36<00:47,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  71%|███████▏  | 714/1000 [01:37<00:47,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  72%|███████▏  | 715/1000 [01:37<00:46,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  72%|███████▏  | 716/1000 [01:37<00:46,  6.12it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  72%|███████▏  | 717/1000 [01:37<00:46,  6.14it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  72%|███████▏  | 718/1000 [01:37<00:46,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  72%|███████▏  | 719/1000 [01:37<00:45,  6.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  72%|███████▏  | 720/1000 [01:38<00:45,  6.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  72%|███████▏  | 721/1000 [01:38<00:45,  6.14it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  72%|███████▏  | 722/1000 [01:38<00:45,  6.12it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  72%|███████▏  | 723/1000 [01:38<00:45,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  72%|███████▏  | 724/1000 [01:38<00:45,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  72%|███████▎  | 725/1000 [01:38<00:45,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  73%|███████▎  | 726/1000 [01:38<00:45,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  73%|███████▎  | 727/1000 [01:39<00:46,  5.88it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  73%|███████▎  | 728/1000 [01:39<00:46,  5.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  73%|███████▎  | 729/1000 [01:39<00:45,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  73%|███████▎  | 730/1000 [01:39<00:45,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  73%|███████▎  | 731/1000 [01:39<00:45,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  73%|███████▎  | 732/1000 [01:40<00:45,  5.86it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  73%|███████▎  | 733/1000 [01:40<00:44,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  73%|███████▎  | 734/1000 [01:40<00:44,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  74%|███████▎  | 735/1000 [01:40<00:44,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  74%|███████▎  | 736/1000 [01:40<00:44,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  74%|███████▎  | 737/1000 [01:40<00:44,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  74%|███████▍  | 738/1000 [01:41<00:45,  5.81it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  74%|███████▍  | 739/1000 [01:41<00:45,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  74%|███████▍  | 740/1000 [01:41<00:44,  5.79it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  74%|███████▍  | 741/1000 [01:41<00:44,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  74%|███████▍  | 742/1000 [01:41<00:44,  5.77it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  74%|███████▍  | 743/1000 [01:41<00:43,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  74%|███████▍  | 744/1000 [01:42<00:43,  5.87it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  74%|███████▍  | 745/1000 [01:42<00:43,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  75%|███████▍  | 746/1000 [01:42<00:42,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  75%|███████▍  | 747/1000 [01:42<00:41,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  75%|███████▍  | 748/1000 [01:42<00:41,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  75%|███████▍  | 749/1000 [01:42<00:41,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  75%|███████▌  | 750/1000 [01:43<00:41,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  75%|███████▌  | 751/1000 [01:43<00:41,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  75%|███████▌  | 752/1000 [01:43<00:41,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  75%|███████▌  | 753/1000 [01:43<00:41,  5.88it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  75%|███████▌  | 754/1000 [01:43<00:41,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  76%|███████▌  | 755/1000 [01:43<00:41,  5.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  76%|███████▌  | 756/1000 [01:44<00:41,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  76%|███████▌  | 757/1000 [01:44<00:41,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  76%|███████▌  | 758/1000 [01:44<00:40,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  76%|███████▌  | 759/1000 [01:44<00:40,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  76%|███████▌  | 760/1000 [01:44<00:41,  5.82it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  76%|███████▌  | 761/1000 [01:44<00:41,  5.81it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  76%|███████▌  | 762/1000 [01:45<00:40,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  76%|███████▋  | 763/1000 [01:45<00:40,  5.87it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  76%|███████▋  | 764/1000 [01:45<00:39,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  76%|███████▋  | 765/1000 [01:45<00:39,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  77%|███████▋  | 766/1000 [01:45<00:39,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  77%|███████▋  | 767/1000 [01:45<00:38,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  77%|███████▋  | 768/1000 [01:46<00:38,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  77%|███████▋  | 769/1000 [01:46<00:37,  6.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  77%|███████▋  | 770/1000 [01:46<00:37,  6.12it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  77%|███████▋  | 771/1000 [01:46<00:37,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  77%|███████▋  | 772/1000 [01:46<00:37,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  77%|███████▋  | 773/1000 [01:46<00:37,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  77%|███████▋  | 774/1000 [01:47<00:37,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  78%|███████▊  | 775/1000 [01:47<00:37,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  78%|███████▊  | 776/1000 [01:47<00:37,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  78%|███████▊  | 777/1000 [01:47<00:36,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  78%|███████▊  | 778/1000 [01:47<00:36,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  78%|███████▊  | 779/1000 [01:47<00:36,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  78%|███████▊  | 780/1000 [01:48<00:35,  6.13it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  78%|███████▊  | 781/1000 [01:48<00:35,  6.14it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  78%|███████▊  | 782/1000 [01:48<00:35,  6.18it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  78%|███████▊  | 783/1000 [01:48<00:35,  6.19it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  78%|███████▊  | 784/1000 [01:48<00:35,  6.15it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  78%|███████▊  | 785/1000 [01:48<00:35,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  79%|███████▊  | 786/1000 [01:49<00:35,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  79%|███████▊  | 787/1000 [01:49<00:36,  5.86it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  79%|███████▉  | 788/1000 [01:49<00:35,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  79%|███████▉  | 789/1000 [01:49<00:35,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  79%|███████▉  | 790/1000 [01:49<00:35,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  79%|███████▉  | 791/1000 [01:49<00:35,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  79%|███████▉  | 792/1000 [01:50<00:34,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  79%|███████▉  | 793/1000 [01:50<00:35,  5.84it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  79%|███████▉  | 794/1000 [01:50<00:35,  5.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  80%|███████▉  | 795/1000 [01:50<00:34,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  80%|███████▉  | 796/1000 [01:50<00:34,  5.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  80%|███████▉  | 797/1000 [01:50<00:33,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  80%|███████▉  | 798/1000 [01:51<00:34,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  80%|███████▉  | 799/1000 [01:51<00:34,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  80%|████████  | 800/1000 [01:51<00:33,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  80%|████████  | 801/1000 [01:51<00:33,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  80%|████████  | 802/1000 [01:51<00:33,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  80%|████████  | 803/1000 [01:51<00:32,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  80%|████████  | 804/1000 [01:52<00:32,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  80%|████████  | 805/1000 [01:52<00:32,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  81%|████████  | 806/1000 [01:52<00:31,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  81%|████████  | 807/1000 [01:52<00:32,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  81%|████████  | 808/1000 [01:52<00:31,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  81%|████████  | 809/1000 [01:52<00:31,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  81%|████████  | 810/1000 [01:53<00:31,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  81%|████████  | 811/1000 [01:53<00:31,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  81%|████████  | 812/1000 [01:53<00:30,  6.10it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  81%|████████▏ | 813/1000 [01:53<00:30,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  81%|████████▏ | 814/1000 [01:53<00:30,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  82%|████████▏ | 815/1000 [01:53<00:30,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  82%|████████▏ | 816/1000 [01:54<00:30,  6.10it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  82%|████████▏ | 817/1000 [01:54<00:30,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  82%|████████▏ | 818/1000 [01:54<00:30,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  82%|████████▏ | 819/1000 [01:54<00:30,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  82%|████████▏ | 820/1000 [01:54<00:30,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  82%|████████▏ | 821/1000 [01:54<00:30,  5.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  82%|████████▏ | 822/1000 [01:55<00:30,  5.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  82%|████████▏ | 823/1000 [01:55<00:29,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  82%|████████▏ | 824/1000 [01:55<00:29,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  82%|████████▎ | 825/1000 [01:55<00:28,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  83%|████████▎ | 826/1000 [01:55<00:28,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  83%|████████▎ | 827/1000 [01:55<00:28,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  83%|████████▎ | 828/1000 [01:56<00:28,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  83%|████████▎ | 829/1000 [01:56<00:28,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  83%|████████▎ | 830/1000 [01:56<00:28,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  83%|████████▎ | 831/1000 [01:56<00:27,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  83%|████████▎ | 832/1000 [01:56<00:28,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  83%|████████▎ | 833/1000 [01:56<00:28,  5.82it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  83%|████████▎ | 834/1000 [01:57<00:29,  5.62it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  84%|████████▎ | 835/1000 [01:57<00:29,  5.57it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  84%|████████▎ | 836/1000 [01:57<00:28,  5.69it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  84%|████████▎ | 837/1000 [01:57<00:28,  5.82it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  84%|████████▍ | 838/1000 [01:57<00:27,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  84%|████████▍ | 839/1000 [01:57<00:27,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  84%|████████▍ | 840/1000 [01:58<00:26,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  84%|████████▍ | 841/1000 [01:58<00:26,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  84%|████████▍ | 842/1000 [01:58<00:26,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  84%|████████▍ | 843/1000 [01:58<00:25,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  84%|████████▍ | 844/1000 [01:58<00:26,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  84%|████████▍ | 845/1000 [01:58<00:25,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  85%|████████▍ | 846/1000 [01:59<00:25,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  85%|████████▍ | 847/1000 [01:59<00:25,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  85%|████████▍ | 848/1000 [01:59<00:25,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  85%|████████▍ | 849/1000 [01:59<00:24,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  85%|████████▌ | 850/1000 [01:59<00:24,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  85%|████████▌ | 851/1000 [01:59<00:24,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  85%|████████▌ | 852/1000 [02:00<00:24,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  85%|████████▌ | 853/1000 [02:00<00:24,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  85%|████████▌ | 854/1000 [02:00<00:24,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  86%|████████▌ | 855/1000 [02:00<00:23,  6.13it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  86%|████████▌ | 856/1000 [02:00<00:23,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  86%|████████▌ | 857/1000 [02:00<00:23,  6.10it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  86%|████████▌ | 858/1000 [02:01<00:23,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  86%|████████▌ | 859/1000 [02:01<00:23,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  86%|████████▌ | 860/1000 [02:01<00:23,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  86%|████████▌ | 861/1000 [02:01<00:23,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  86%|████████▌ | 862/1000 [02:01<00:22,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  86%|████████▋ | 863/1000 [02:01<00:22,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  86%|████████▋ | 864/1000 [02:02<00:23,  5.75it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  86%|████████▋ | 865/1000 [02:02<00:23,  5.76it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  87%|████████▋ | 866/1000 [02:02<00:23,  5.77it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  87%|████████▋ | 867/1000 [02:02<00:22,  5.84it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  87%|████████▋ | 868/1000 [02:02<00:22,  5.85it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  87%|████████▋ | 869/1000 [02:02<00:22,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  87%|████████▋ | 870/1000 [02:03<00:21,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  87%|████████▋ | 871/1000 [02:03<00:21,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  87%|████████▋ | 872/1000 [02:03<00:21,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  87%|████████▋ | 873/1000 [02:03<00:20,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  87%|████████▋ | 874/1000 [02:03<00:20,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  88%|████████▊ | 875/1000 [02:03<00:21,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  88%|████████▊ | 876/1000 [02:04<00:21,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  88%|████████▊ | 877/1000 [02:04<00:21,  5.76it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  88%|████████▊ | 878/1000 [02:04<00:20,  5.82it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  88%|████████▊ | 879/1000 [02:04<00:20,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  88%|████████▊ | 880/1000 [02:04<00:20,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  88%|████████▊ | 881/1000 [02:04<00:19,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  88%|████████▊ | 882/1000 [02:05<00:19,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  88%|████████▊ | 883/1000 [02:05<00:19,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  88%|████████▊ | 884/1000 [02:05<00:19,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  88%|████████▊ | 885/1000 [02:05<00:19,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  89%|████████▊ | 886/1000 [02:05<00:19,  5.88it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  89%|████████▊ | 887/1000 [02:05<00:19,  5.88it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  89%|████████▉ | 888/1000 [02:06<00:18,  5.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  89%|████████▉ | 889/1000 [02:06<00:18,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  89%|████████▉ | 890/1000 [02:06<00:18,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  89%|████████▉ | 891/1000 [02:06<00:18,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  89%|████████▉ | 892/1000 [02:06<00:18,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  89%|████████▉ | 893/1000 [02:06<00:17,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  89%|████████▉ | 894/1000 [02:07<00:17,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  90%|████████▉ | 895/1000 [02:07<00:17,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  90%|████████▉ | 896/1000 [02:07<00:17,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  90%|████████▉ | 897/1000 [02:07<00:17,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  90%|████████▉ | 898/1000 [02:07<00:16,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  90%|████████▉ | 899/1000 [02:07<00:17,  5.93it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  90%|█████████ | 900/1000 [02:08<00:16,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  90%|█████████ | 901/1000 [02:08<00:16,  5.97it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  90%|█████████ | 902/1000 [02:08<00:16,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  90%|█████████ | 903/1000 [02:08<00:16,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  90%|█████████ | 904/1000 [02:08<00:15,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  90%|█████████ | 905/1000 [02:08<00:15,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  91%|█████████ | 906/1000 [02:09<00:15,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  91%|█████████ | 907/1000 [02:09<00:15,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  91%|█████████ | 908/1000 [02:09<00:15,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  91%|█████████ | 909/1000 [02:09<00:14,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  91%|█████████ | 910/1000 [02:09<00:14,  6.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  91%|█████████ | 911/1000 [02:09<00:14,  6.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  91%|█████████ | 912/1000 [02:10<00:14,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  91%|█████████▏| 913/1000 [02:10<00:14,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  91%|█████████▏| 914/1000 [02:10<00:14,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  92%|█████████▏| 915/1000 [02:10<00:13,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  92%|█████████▏| 916/1000 [02:10<00:13,  6.12it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  92%|█████████▏| 917/1000 [02:10<00:13,  6.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  92%|█████████▏| 918/1000 [02:11<00:13,  6.12it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  92%|█████████▏| 919/1000 [02:11<00:13,  6.14it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  92%|█████████▏| 920/1000 [02:11<00:13,  6.15it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  92%|█████████▏| 921/1000 [02:11<00:12,  6.17it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  92%|█████████▏| 922/1000 [02:11<00:12,  6.16it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  92%|█████████▏| 923/1000 [02:11<00:12,  6.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  92%|█████████▏| 924/1000 [02:12<00:12,  6.12it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  92%|█████████▎| 925/1000 [02:12<00:12,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  93%|█████████▎| 926/1000 [02:12<00:12,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  93%|█████████▎| 927/1000 [02:12<00:12,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  93%|█████████▎| 928/1000 [02:12<00:12,  5.71it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  93%|█████████▎| 929/1000 [02:12<00:12,  5.73it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  93%|█████████▎| 930/1000 [02:13<00:12,  5.82it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  93%|█████████▎| 931/1000 [02:13<00:11,  5.80it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  93%|█████████▎| 932/1000 [02:13<00:11,  5.77it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  93%|█████████▎| 933/1000 [02:13<00:11,  5.88it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  93%|█████████▎| 934/1000 [02:13<00:11,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  94%|█████████▎| 935/1000 [02:13<00:11,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  94%|█████████▎| 936/1000 [02:14<00:11,  5.79it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  94%|█████████▎| 937/1000 [02:14<00:10,  5.77it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  94%|█████████▍| 938/1000 [02:14<00:10,  5.73it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  94%|█████████▍| 939/1000 [02:14<00:10,  5.72it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  94%|█████████▍| 940/1000 [02:14<00:10,  5.75it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  94%|█████████▍| 941/1000 [02:15<00:10,  5.78it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  94%|█████████▍| 942/1000 [02:15<00:09,  5.92it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  94%|█████████▍| 943/1000 [02:15<00:09,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  94%|█████████▍| 944/1000 [02:15<00:09,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  94%|█████████▍| 945/1000 [02:15<00:09,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  95%|█████████▍| 946/1000 [02:15<00:09,  5.95it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  95%|█████████▍| 947/1000 [02:16<00:08,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  95%|█████████▍| 948/1000 [02:16<00:08,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  95%|█████████▍| 949/1000 [02:16<00:08,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  95%|█████████▌| 950/1000 [02:16<00:08,  5.89it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  95%|█████████▌| 951/1000 [02:16<00:08,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  95%|█████████▌| 952/1000 [02:16<00:08,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  95%|█████████▌| 953/1000 [02:17<00:07,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  95%|█████████▌| 954/1000 [02:17<00:07,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  96%|█████████▌| 955/1000 [02:17<00:07,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  96%|█████████▌| 956/1000 [02:17<00:07,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  96%|█████████▌| 957/1000 [02:17<00:07,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  96%|█████████▌| 958/1000 [02:17<00:06,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  96%|█████████▌| 959/1000 [02:18<00:06,  6.07it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  96%|█████████▌| 960/1000 [02:18<00:06,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  96%|█████████▌| 961/1000 [02:18<00:06,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  96%|█████████▌| 962/1000 [02:18<00:06,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  96%|█████████▋| 963/1000 [02:18<00:06,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  96%|█████████▋| 964/1000 [02:18<00:05,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  96%|█████████▋| 965/1000 [02:19<00:05,  6.01it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  97%|█████████▋| 966/1000 [02:19<00:05,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  97%|█████████▋| 967/1000 [02:19<00:05,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  97%|█████████▋| 968/1000 [02:19<00:05,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  97%|█████████▋| 969/1000 [02:19<00:05,  6.05it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  97%|█████████▋| 970/1000 [02:19<00:04,  6.08it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  97%|█████████▋| 971/1000 [02:19<00:04,  6.09it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  97%|█████████▋| 972/1000 [02:20<00:04,  6.13it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  97%|█████████▋| 973/1000 [02:20<00:04,  6.17it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  97%|█████████▋| 974/1000 [02:20<00:04,  6.19it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  98%|█████████▊| 975/1000 [02:20<00:04,  6.17it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  98%|█████████▊| 976/1000 [02:20<00:03,  6.17it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  98%|█████████▊| 977/1000 [02:20<00:03,  6.12it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  98%|█████████▊| 978/1000 [02:21<00:03,  6.12it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  98%|█████████▊| 979/1000 [02:21<00:03,  6.11it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  98%|█████████▊| 980/1000 [02:21<00:03,  6.15it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  98%|█████████▊| 981/1000 [02:21<00:03,  6.06it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  98%|█████████▊| 982/1000 [02:21<00:03,  5.99it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  98%|█████████▊| 983/1000 [02:21<00:02,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  98%|█████████▊| 984/1000 [02:22<00:02,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  98%|█████████▊| 985/1000 [02:22<00:02,  6.02it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  99%|█████████▊| 986/1000 [02:22<00:02,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  99%|█████████▊| 987/1000 [02:22<00:02,  5.76it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  99%|█████████▉| 988/1000 [02:22<00:02,  5.76it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  99%|█████████▉| 989/1000 [02:22<00:01,  5.77it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  99%|█████████▉| 990/1000 [02:23<00:01,  5.84it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  99%|█████████▉| 991/1000 [02:23<00:01,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  99%|█████████▉| 992/1000 [02:23<00:01,  6.03it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  99%|█████████▉| 993/1000 [02:23<00:01,  6.04it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences:  99%|█████████▉| 994/1000 [02:23<00:01,  6.00it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences: 100%|█████████▉| 995/1000 [02:23<00:00,  5.94it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences: 100%|█████████▉| 996/1000 [02:24<00:00,  5.91it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences: 100%|█████████▉| 997/1000 [02:24<00:00,  5.83it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences: 100%|█████████▉| 998/1000 [02:24<00:00,  5.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences: 100%|█████████▉| 999/1000 [02:24<00:00,  5.96it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences: 100%|██████████| 1000/1000 [02:24<00:00,  5.98it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\r",
-      "Sampling chain 0, 0 divergences: 100%|██████████| 1000/1000 [02:24<00:00,  6.90it/s]"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "The chain reached the maximum tree depth. Increase max_treedepth, increase target_accept or reparameterize.\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "Auto-assigning NUTS sampler...\n",
+      "Initializing NUTS using jitter+adapt_diag...\n",
+      "Sequential sampling (1 chains in 1 job)\n",
+      "NUTS: [tau_logit, sigma, beta, alpha, mu_0]\n",
+      "Sampling chain 0, 0 divergences: 100%|██████████| 1000/1000 [03:17<00:00,  5.07it/s]\n",
+      "The chain reached the maximum tree depth. Increase max_treedepth, increase target_accept or reparameterize.\n",
       "Only one chain was sampled, this makes it impossible to run some convergence checks\n"
      ]
     }
@@ -7284,7 +347,7 @@
     {
      "data": {
       "text/markdown": [
-       "**Reported Case Count:**  31,855.0"
+       "**Reported Case Count:**  31,855"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -7296,7 +359,7 @@
     {
      "data": {
       "text/markdown": [
-       "**Predicted Case Count:**  52,836"
+       "**Predicted Case Count:**  57,439"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -7308,7 +371,7 @@
     {
      "data": {
       "text/markdown": [
-       "**Percentage Underreporting in Case Count:**  39.7%"
+       "**Percentage Underreporting in Case Count:**  44.5%"
       ],
       "text/plain": [
        "<IPython.core.display.Markdown object>"
@@ -7426,1051 +489,1051 @@
      "data": {
       "text/html": [
        "<style  type=\"text/css\" >\n",
-       "    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow0_col0 {\n",
+       "    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row0_col0 {\n",
        "            background-color:  #7f2704;\n",
        "            color:  #f1f1f1;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow0_col1 {\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row0_col1 {\n",
        "            background-color:  #7f2704;\n",
        "            color:  #f1f1f1;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow0_col3 {\n",
-       "            background-color:  #fff4e8;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row0_col3 {\n",
+       "            background-color:  #fff2e6;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow0_col4 {\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row0_col4 {\n",
        "            background-color:  #d34601;\n",
        "            color:  #f1f1f1;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow1_col0 {\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row1_col0 {\n",
        "            background-color:  #fee6ce;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow1_col1 {\n",
-       "            background-color:  #fdd8b2;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row1_col1 {\n",
+       "            background-color:  #fddab6;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow1_col3 {\n",
-       "            background-color:  #fdad69;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow1_col4 {\n",
-       "            background-color:  #ffefe0;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow2_col0 {\n",
-       "            background-color:  #fee9d4;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow2_col1 {\n",
-       "            background-color:  #fee2c7;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow2_col3 {\n",
-       "            background-color:  #fdc895;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow2_col4 {\n",
-       "            background-color:  #feead5;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow3_col0 {\n",
-       "            background-color:  #fee7d0;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow3_col1 {\n",
-       "            background-color:  #fee7d1;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow3_col3 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow3_col4 {\n",
-       "            background-color:  #7f2704;\n",
-       "            color:  #f1f1f1;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow4_col0 {\n",
-       "            background-color:  #feeddc;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow4_col1 {\n",
-       "            background-color:  #fee9d4;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow4_col3 {\n",
-       "            background-color:  #fdc48f;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow4_col4 {\n",
-       "            background-color:  #feebd8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow5_col0 {\n",
-       "            background-color:  #feeddc;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow5_col1 {\n",
-       "            background-color:  #feebd7;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow5_col3 {\n",
-       "            background-color:  #fedcb9;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow5_col4 {\n",
-       "            background-color:  #fee1c4;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow6_col0 {\n",
-       "            background-color:  #ffefdf;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow6_col1 {\n",
-       "            background-color:  #feecda;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow6_col3 {\n",
-       "            background-color:  #fdd1a4;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow6_col4 {\n",
-       "            background-color:  #fee9d4;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow7_col0 {\n",
-       "            background-color:  #ffefdf;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow7_col1 {\n",
-       "            background-color:  #feeddc;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow7_col3 {\n",
-       "            background-color:  #feddbc;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow7_col4 {\n",
-       "            background-color:  #fedcb9;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow8_col0 {\n",
-       "            background-color:  #fff3e6;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow8_col1 {\n",
-       "            background-color:  #ffeedd;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow8_col3 {\n",
-       "            background-color:  #812804;\n",
-       "            color:  #f1f1f1;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow8_col4 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow9_col0 {\n",
-       "            background-color:  #fff1e3;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow9_col1 {\n",
-       "            background-color:  #ffeede;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow9_col3 {\n",
-       "            background-color:  #fdca99;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow9_col4 {\n",
-       "            background-color:  #feebd8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow10_col0 {\n",
-       "            background-color:  #fff0e2;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow10_col1 {\n",
-       "            background-color:  #ffefe0;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow10_col3 {\n",
-       "            background-color:  #fee7d0;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow10_col4 {\n",
-       "            background-color:  #fdc794;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow11_col0 {\n",
-       "            background-color:  #fff2e5;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow11_col1 {\n",
-       "            background-color:  #fff0e1;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow11_col3 {\n",
-       "            background-color:  #fdca99;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow11_col4 {\n",
-       "            background-color:  #feead5;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow12_col0 {\n",
-       "            background-color:  #fff1e4;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow12_col1 {\n",
-       "            background-color:  #fff0e2;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow12_col3 {\n",
-       "            background-color:  #fedfc0;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow12_col4 {\n",
-       "            background-color:  #fedfc0;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow13_col0 {\n",
-       "            background-color:  #fff4e8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow13_col1 {\n",
-       "            background-color:  #fff0e2;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow13_col3 {\n",
-       "            background-color:  #a43503;\n",
-       "            color:  #f1f1f1;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow13_col4 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow14_col0 {\n",
-       "            background-color:  #fff2e5;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow14_col1 {\n",
-       "            background-color:  #fff1e3;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow14_col3 {\n",
-       "            background-color:  #fee0c3;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow14_col4 {\n",
-       "            background-color:  #fdd9b4;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow15_col0 {\n",
-       "            background-color:  #fff3e6;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow15_col1 {\n",
-       "            background-color:  #fff1e4;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow15_col3 {\n",
-       "            background-color:  #fdb576;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow15_col4 {\n",
-       "            background-color:  #feeddc;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow16_col0 {\n",
-       "            background-color:  #fff2e6;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow16_col1 {\n",
-       "            background-color:  #fff2e5;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow16_col3 {\n",
-       "            background-color:  #fee7d0;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow16_col4 {\n",
-       "            background-color:  #fdcb9b;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow17_col0 {\n",
-       "            background-color:  #fff4e9;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow17_col1 {\n",
-       "            background-color:  #fff2e6;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow17_col3 {\n",
-       "            background-color:  #a53603;\n",
-       "            color:  #f1f1f1;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow17_col4 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow18_col0 {\n",
-       "            background-color:  #fff4e9;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow18_col1 {\n",
-       "            background-color:  #fff2e6;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow18_col3 {\n",
-       "            background-color:  #7f2704;\n",
-       "            color:  #f1f1f1;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow18_col4 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow19_col0 {\n",
-       "            background-color:  #fff4e8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow19_col1 {\n",
-       "            background-color:  #fff3e6;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow19_col3 {\n",
-       "            background-color:  #fc8b3a;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow19_col4 {\n",
-       "            background-color:  #fff2e5;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow20_col0 {\n",
-       "            background-color:  #fff3e7;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow20_col1 {\n",
-       "            background-color:  #fff3e6;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow20_col3 {\n",
-       "            background-color:  #fdd9b5;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow20_col4 {\n",
-       "            background-color:  #fee1c4;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow21_col0 {\n",
-       "            background-color:  #fff4e8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow21_col1 {\n",
-       "            background-color:  #fff3e7;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow21_col3 {\n",
-       "            background-color:  #fdcfa0;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow21_col4 {\n",
-       "            background-color:  #fee9d4;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow22_col0 {\n",
-       "            background-color:  #fff4e8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow22_col1 {\n",
-       "            background-color:  #fff3e7;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow22_col3 {\n",
-       "            background-color:  #fdc590;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow22_col4 {\n",
-       "            background-color:  #feebd8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow23_col0 {\n",
-       "            background-color:  #fff4e8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow23_col1 {\n",
-       "            background-color:  #fff3e7;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow23_col3 {\n",
-       "            background-color:  #fdc48f;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow23_col4 {\n",
-       "            background-color:  #feecd9;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow24_col0 {\n",
-       "            background-color:  #fff4e8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow24_col1 {\n",
-       "            background-color:  #fff3e7;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow24_col3 {\n",
-       "            background-color:  #fee3c8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow24_col4 {\n",
-       "            background-color:  #fdd8b2;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow25_col0 {\n",
-       "            background-color:  #fff4e9;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow25_col1 {\n",
-       "            background-color:  #fff3e7;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow25_col3 {\n",
-       "            background-color:  #fdb97d;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow25_col4 {\n",
-       "            background-color:  #feeddc;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow26_col0 {\n",
-       "            background-color:  #fff4e8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow26_col1 {\n",
-       "            background-color:  #fff4e8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow26_col3 {\n",
-       "            background-color:  #fee6cf;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow26_col4 {\n",
-       "            background-color:  #fdce9e;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow27_col0 {\n",
-       "            background-color:  #fff4e9;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow27_col1 {\n",
-       "            background-color:  #fff4e8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow27_col3 {\n",
-       "            background-color:  #fee7d0;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow27_col4 {\n",
-       "            background-color:  #fdcfa0;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow28_col0 {\n",
-       "            background-color:  #fff4e9;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow28_col1 {\n",
-       "            background-color:  #fff4e8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow28_col3 {\n",
-       "            background-color:  #feddbc;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow28_col4 {\n",
-       "            background-color:  #fee1c4;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow29_col0 {\n",
-       "            background-color:  #fff4e9;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow29_col1 {\n",
-       "            background-color:  #fff4e8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow29_col3 {\n",
-       "            background-color:  #fee3c8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow29_col4 {\n",
-       "            background-color:  #fdd4aa;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow30_col0 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow30_col1 {\n",
-       "            background-color:  #fff4e9;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow30_col3 {\n",
-       "            background-color:  #eb610f;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow30_col4 {\n",
-       "            background-color:  #fff4e8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow31_col0 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow31_col1 {\n",
-       "            background-color:  #fff4e9;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow31_col3 {\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row1_col3 {\n",
        "            background-color:  #fda762;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow31_col4 {\n",
-       "            background-color:  #fff0e1;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow32_col0 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow32_col1 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow32_col3 {\n",
-       "            background-color:  #fdd2a6;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow32_col4 {\n",
-       "            background-color:  #fee8d2;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow33_col0 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow33_col1 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow33_col3 {\n",
-       "            background-color:  #fee6ce;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow33_col4 {\n",
-       "            background-color:  #fdcd9c;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow34_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow34_col1 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow34_col3 {\n",
-       "            background-color:  #fda25a;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow34_col4 {\n",
-       "            background-color:  #fff0e2;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow35_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow35_col1 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow35_col3 {\n",
-       "            background-color:  #f26d17;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow35_col4 {\n",
-       "            background-color:  #fff3e7;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow36_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow36_col1 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow36_col3 {\n",
-       "            background-color:  #fd9b50;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow36_col4 {\n",
-       "            background-color:  #fff0e1;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow37_col0 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow37_col1 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow37_col3 {\n",
-       "            background-color:  #fee7d1;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow37_col4 {\n",
-       "            background-color:  #fdc895;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow38_col0 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow38_col1 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow38_col3 {\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row1_col4 {\n",
        "            background-color:  #ffefe0;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow38_col4 {\n",
-       "            background-color:  #f77a27;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row2_col0 {\n",
+       "            background-color:  #fee9d4;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow39_col0 {\n",
-       "            background-color:  #fff5eb;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row2_col1 {\n",
+       "            background-color:  #fee4ca;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow39_col1 {\n",
-       "            background-color:  #fff5ea;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row2_col3 {\n",
+       "            background-color:  #fdc590;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow39_col3 {\n",
-       "            background-color:  #fb8836;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow39_col4 {\n",
-       "            background-color:  #fff2e5;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow40_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow40_col1 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow40_col3 {\n",
-       "            background-color:  #fee5cb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow40_col4 {\n",
-       "            background-color:  #fdd2a6;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow41_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow41_col1 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow41_col3 {\n",
-       "            background-color:  #fdb373;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow41_col4 {\n",
-       "            background-color:  #ffeede;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow42_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow42_col1 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow42_col3 {\n",
-       "            background-color:  #fff0e1;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow42_col4 {\n",
-       "            background-color:  #f4711c;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow43_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow43_col1 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow43_col3 {\n",
-       "            background-color:  #feeddc;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow43_col4 {\n",
-       "            background-color:  #fda25a;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow44_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow44_col1 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow44_col3 {\n",
-       "            background-color:  #fdd9b5;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow44_col4 {\n",
-       "            background-color:  #fee0c3;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow45_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow45_col1 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow45_col3 {\n",
-       "            background-color:  #c34002;\n",
-       "            color:  #f1f1f1;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow45_col4 {\n",
-       "            background-color:  #fff5ea;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow46_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow46_col1 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow46_col3 {\n",
-       "            background-color:  #feebd8;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow46_col4 {\n",
-       "            background-color:  #fdb576;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow47_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow47_col1 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow47_col3 {\n",
-       "            background-color:  #ffefe0;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow47_col4 {\n",
-       "            background-color:  #fd8e3d;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow48_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow48_col1 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow48_col3 {\n",
-       "            background-color:  #fee5cc;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow48_col4 {\n",
-       "            background-color:  #fdd0a2;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow49_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow49_col1 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow49_col3 {\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row2_col4 {\n",
        "            background-color:  #feead5;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow49_col4 {\n",
-       "            background-color:  #fdb87c;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row3_col0 {\n",
+       "            background-color:  #fee7d0;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow50_col0 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow50_col1 {\n",
-       "            background-color:  #fff5eb;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow50_col3 {\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row3_col1 {\n",
        "            background-color:  #fee8d2;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow50_col4 {\n",
-       "            background-color:  #fdd0a2;\n",
-       "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow51_col0 {\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row3_col3 {\n",
        "            background-color:  #fff5eb;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow51_col1 {\n",
-       "            background-color:  #fff5eb;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row3_col4 {\n",
+       "            background-color:  #7f2704;\n",
+       "            color:  #f1f1f1;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row4_col0 {\n",
+       "            background-color:  #feeddc;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow51_col3 {\n",
-       "            background-color:  #fda965;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row4_col1 {\n",
+       "            background-color:  #feead5;\n",
        "            color:  #000000;\n",
-       "        }    #T_569fc05e_6c83_11ea_8a74_000d3a10b68crow51_col4 {\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row4_col3 {\n",
+       "            background-color:  #fdbb81;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row4_col4 {\n",
+       "            background-color:  #feebd8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row5_col0 {\n",
+       "            background-color:  #feeddc;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row5_col1 {\n",
+       "            background-color:  #feebd7;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row5_col3 {\n",
+       "            background-color:  #fdd7af;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row5_col4 {\n",
+       "            background-color:  #fee1c4;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row6_col0 {\n",
        "            background-color:  #ffefdf;\n",
        "            color:  #000000;\n",
-       "        }</style><table id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68c\" ><thead>    <tr>        <th class=\"blank level0\" ></th>        <th class=\"col_heading level0 col0\" >Reported Cases</th>        <th class=\"col_heading level0 col1\" >Estimated Cases</th>        <th class=\"col_heading level0 col2\" >Estimated Range</th>        <th class=\"col_heading level0 col3\" >Ratio</th>        <th class=\"col_heading level0 col4\" >Tests per Million</th>    </tr>    <tr>        <th class=\"index_name level0\" >state</th>        <th class=\"blank\" ></th>        <th class=\"blank\" ></th>        <th class=\"blank\" ></th>        <th class=\"blank\" ></th>        <th class=\"blank\" ></th>    </tr></thead><tbody>\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row6_col1 {\n",
+       "            background-color:  #feeddb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row6_col3 {\n",
+       "            background-color:  #fdd0a2;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row6_col4 {\n",
+       "            background-color:  #fee9d4;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row7_col0 {\n",
+       "            background-color:  #ffefdf;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row7_col1 {\n",
+       "            background-color:  #feeddc;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row7_col3 {\n",
+       "            background-color:  #fedcbb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row7_col4 {\n",
+       "            background-color:  #fedcb9;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row8_col0 {\n",
+       "            background-color:  #fff1e3;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row8_col1 {\n",
+       "            background-color:  #ffefdf;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row8_col3 {\n",
+       "            background-color:  #fdc590;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row8_col4 {\n",
+       "            background-color:  #feebd8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row9_col0 {\n",
+       "            background-color:  #fff3e6;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row9_col1 {\n",
+       "            background-color:  #ffefe0;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row9_col3 {\n",
+       "            background-color:  #a93703;\n",
+       "            color:  #f1f1f1;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row9_col4 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row10_col0 {\n",
+       "            background-color:  #fff0e2;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row10_col1 {\n",
+       "            background-color:  #ffefe0;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row10_col3 {\n",
+       "            background-color:  #fee6ce;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row10_col4 {\n",
+       "            background-color:  #fdc794;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row11_col0 {\n",
+       "            background-color:  #fff2e5;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row11_col1 {\n",
+       "            background-color:  #fff0e2;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row11_col3 {\n",
+       "            background-color:  #fdce9e;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row11_col4 {\n",
+       "            background-color:  #feead5;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row12_col0 {\n",
+       "            background-color:  #fff1e4;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row12_col1 {\n",
+       "            background-color:  #fff0e2;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row12_col3 {\n",
+       "            background-color:  #fddab6;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row12_col4 {\n",
+       "            background-color:  #fedfc0;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row13_col0 {\n",
+       "            background-color:  #fff2e5;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row13_col1 {\n",
+       "            background-color:  #fff1e3;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row13_col3 {\n",
+       "            background-color:  #fedebf;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row13_col4 {\n",
+       "            background-color:  #fdd9b4;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row14_col0 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row14_col1 {\n",
+       "            background-color:  #fff1e4;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row14_col3 {\n",
+       "            background-color:  #d84801;\n",
+       "            color:  #f1f1f1;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row14_col4 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row15_col0 {\n",
+       "            background-color:  #fff3e6;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row15_col1 {\n",
+       "            background-color:  #fff2e5;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row15_col3 {\n",
+       "            background-color:  #fdb678;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row15_col4 {\n",
+       "            background-color:  #feeddc;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row16_col0 {\n",
+       "            background-color:  #fff2e6;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row16_col1 {\n",
+       "            background-color:  #fff2e5;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row16_col3 {\n",
+       "            background-color:  #fee4ca;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row16_col4 {\n",
+       "            background-color:  #fdcb9b;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row17_col0 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row17_col1 {\n",
+       "            background-color:  #fff3e6;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row17_col3 {\n",
+       "            background-color:  #fd8f3e;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row17_col4 {\n",
+       "            background-color:  #fff2e5;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row18_col0 {\n",
+       "            background-color:  #fff4e9;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row18_col1 {\n",
+       "            background-color:  #fff3e6;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row18_col3 {\n",
+       "            background-color:  #7f2704;\n",
+       "            color:  #f1f1f1;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row18_col4 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row19_col0 {\n",
+       "            background-color:  #fff3e7;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row19_col1 {\n",
+       "            background-color:  #fff3e6;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row19_col3 {\n",
+       "            background-color:  #fdd6ae;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row19_col4 {\n",
+       "            background-color:  #fee1c4;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row20_col0 {\n",
+       "            background-color:  #fff4e9;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row20_col1 {\n",
+       "            background-color:  #fff3e7;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row20_col3 {\n",
+       "            background-color:  #cd4401;\n",
+       "            color:  #f1f1f1;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row20_col4 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row21_col0 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row21_col1 {\n",
+       "            background-color:  #fff3e7;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row21_col3 {\n",
+       "            background-color:  #fdcfa0;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row21_col4 {\n",
+       "            background-color:  #fee9d4;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row22_col0 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row22_col1 {\n",
+       "            background-color:  #fff3e7;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row22_col3 {\n",
+       "            background-color:  #fdc189;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row22_col4 {\n",
+       "            background-color:  #feebd8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row23_col0 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row23_col1 {\n",
+       "            background-color:  #fff3e7;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row23_col3 {\n",
+       "            background-color:  #fedcb9;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row23_col4 {\n",
+       "            background-color:  #fdd8b2;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row24_col0 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row24_col1 {\n",
+       "            background-color:  #fff3e7;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row24_col3 {\n",
+       "            background-color:  #fdc692;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row24_col4 {\n",
+       "            background-color:  #feecd9;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row25_col0 {\n",
+       "            background-color:  #fff4e9;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row25_col1 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row25_col3 {\n",
+       "            background-color:  #fdb373;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row25_col4 {\n",
+       "            background-color:  #feeddc;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row26_col0 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row26_col1 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row26_col3 {\n",
+       "            background-color:  #fee5cb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row26_col4 {\n",
+       "            background-color:  #fdce9e;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row27_col0 {\n",
+       "            background-color:  #fff4e9;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row27_col1 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row27_col3 {\n",
+       "            background-color:  #fee1c4;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row27_col4 {\n",
+       "            background-color:  #fdcfa0;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row28_col0 {\n",
+       "            background-color:  #fff4e9;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row28_col1 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row28_col3 {\n",
+       "            background-color:  #fdd6ae;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row28_col4 {\n",
+       "            background-color:  #fee1c4;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row29_col0 {\n",
+       "            background-color:  #fff4e9;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row29_col1 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row29_col3 {\n",
+       "            background-color:  #fee0c3;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row29_col4 {\n",
+       "            background-color:  #fdd4aa;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row30_col0 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row30_col1 {\n",
+       "            background-color:  #fff4e9;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row30_col3 {\n",
+       "            background-color:  #ee6410;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row30_col4 {\n",
+       "            background-color:  #fff4e8;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row31_col0 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row31_col1 {\n",
+       "            background-color:  #fff4e9;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row31_col3 {\n",
+       "            background-color:  #fda762;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row31_col4 {\n",
+       "            background-color:  #fff0e1;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row32_col0 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row32_col1 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row32_col3 {\n",
+       "            background-color:  #fdcd9c;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row32_col4 {\n",
+       "            background-color:  #fee8d2;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row33_col0 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row33_col1 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row33_col3 {\n",
+       "            background-color:  #fee0c3;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row33_col4 {\n",
+       "            background-color:  #fdcd9c;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row34_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row34_col1 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row34_col3 {\n",
+       "            background-color:  #fd9547;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row34_col4 {\n",
+       "            background-color:  #fff0e1;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row35_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row35_col1 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row35_col3 {\n",
+       "            background-color:  #fda45d;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row35_col4 {\n",
+       "            background-color:  #fff0e2;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row36_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row36_col1 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row36_col3 {\n",
+       "            background-color:  #f57520;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row36_col4 {\n",
+       "            background-color:  #fff3e7;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row37_col0 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row37_col1 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row37_col3 {\n",
+       "            background-color:  #ffeedd;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row37_col4 {\n",
+       "            background-color:  #f77a27;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row38_col0 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row38_col1 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row38_col3 {\n",
+       "            background-color:  #fee8d2;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row38_col4 {\n",
+       "            background-color:  #fdc895;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row39_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row39_col1 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row39_col3 {\n",
+       "            background-color:  #fc8b3a;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row39_col4 {\n",
+       "            background-color:  #fff2e5;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row40_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row40_col1 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row40_col3 {\n",
+       "            background-color:  #fee2c6;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row40_col4 {\n",
+       "            background-color:  #fdd2a6;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row41_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row41_col1 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row41_col3 {\n",
+       "            background-color:  #fdab66;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row41_col4 {\n",
+       "            background-color:  #ffeede;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row42_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row42_col1 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row42_col3 {\n",
+       "            background-color:  #ffeede;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row42_col4 {\n",
+       "            background-color:  #f4711c;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row43_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row43_col1 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row43_col3 {\n",
+       "            background-color:  #fee9d4;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row43_col4 {\n",
+       "            background-color:  #fda25a;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row44_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row44_col1 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row44_col3 {\n",
+       "            background-color:  #fdd7af;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row44_col4 {\n",
+       "            background-color:  #fee0c3;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row45_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row45_col1 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row45_col3 {\n",
+       "            background-color:  #dd4d04;\n",
+       "            color:  #f1f1f1;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row45_col4 {\n",
+       "            background-color:  #fff5ea;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row46_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row46_col1 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row46_col3 {\n",
+       "            background-color:  #feead5;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row46_col4 {\n",
+       "            background-color:  #fdb576;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row47_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row47_col1 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row47_col3 {\n",
+       "            background-color:  #ffeedd;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row47_col4 {\n",
+       "            background-color:  #fd8e3d;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row48_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row48_col1 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row48_col3 {\n",
+       "            background-color:  #fedfc0;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row48_col4 {\n",
+       "            background-color:  #fdd0a2;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row49_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row49_col1 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row49_col3 {\n",
+       "            background-color:  #fee1c4;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row49_col4 {\n",
+       "            background-color:  #fdd0a2;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row50_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row50_col1 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row50_col3 {\n",
+       "            background-color:  #feead5;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row50_col4 {\n",
+       "            background-color:  #fdb87c;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row51_col0 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row51_col1 {\n",
+       "            background-color:  #fff5eb;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row51_col3 {\n",
+       "            background-color:  #fda762;\n",
+       "            color:  #000000;\n",
+       "        }    #T_f8916324_6c90_11ea_91d0_5cf9388e0158row51_col4 {\n",
+       "            background-color:  #ffefdf;\n",
+       "            color:  #000000;\n",
+       "        }</style><table id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158\" ><thead>    <tr>        <th class=\"blank level0\" ></th>        <th class=\"col_heading level0 col0\" >Reported Cases</th>        <th class=\"col_heading level0 col1\" >Estimated Cases</th>        <th class=\"col_heading level0 col2\" >Estimated Range</th>        <th class=\"col_heading level0 col3\" >Ratio</th>        <th class=\"col_heading level0 col4\" >Tests per Million</th>    </tr>    <tr>        <th class=\"index_name level0\" >state</th>        <th class=\"blank\" ></th>        <th class=\"blank\" ></th>        <th class=\"blank\" ></th>        <th class=\"blank\" ></th>        <th class=\"blank\" ></th>    </tr></thead><tbody>\n",
        "                <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row0\" class=\"row_heading level0 row0\" >NY</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow0_col0\" class=\"data row0 col0\" >15168.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow0_col1\" class=\"data row0 col1\" >20498</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow0_col2\" class=\"data row0 col2\" >(16359, 34844)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow0_col3\" class=\"data row0 col3\" >1.4</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow0_col4\" class=\"data row0 col4\" >2335.7</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row0\" class=\"row_heading level0 row0\" >NY</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row0_col0\" class=\"data row0 col0\" >15168</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row0_col1\" class=\"data row0 col1\" >23163</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row0_col2\" class=\"data row0 col2\" >(16445, 49647)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row0_col3\" class=\"data row0 col3\" >1.5</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row0_col4\" class=\"data row0 col4\" >2335.7</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row1\" class=\"row_heading level0 row1\" >NJ</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow1_col0\" class=\"data row1 col0\" >1914.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow1_col1\" class=\"data row1 col1\" >4239</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow1_col2\" class=\"data row1 col2\" >(2463, 11238)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow1_col3\" class=\"data row1 col3\" >2.2</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow1_col4\" class=\"data row1 col4\" >182.5</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row1\" class=\"row_heading level0 row1\" >NJ</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row1_col0\" class=\"data row1 col0\" >1914</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row1_col1\" class=\"data row1 col1\" >4476</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row1_col2\" class=\"data row1 col2\" >(2479, 14316)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row1_col3\" class=\"data row1 col3\" >2.3</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row1_col4\" class=\"data row1 col4\" >182.5</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row2\" class=\"row_heading level0 row2\" >CA</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow2_col0\" class=\"data row2 col0\" >1536.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow2_col1\" class=\"data row2 col1\" >3037</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow2_col2\" class=\"data row2 col2\" >(1894, 6569)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow2_col3\" class=\"data row2 col3\" >2.0</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow2_col4\" class=\"data row2 col4\" >317.1</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row2\" class=\"row_heading level0 row2\" >CA</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row2_col0\" class=\"data row2 col0\" >1536</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row2_col1\" class=\"data row2 col1\" >3224</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row2_col2\" class=\"data row2 col2\" >(1897, 9536)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row2_col3\" class=\"data row2 col3\" >2.1</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row2_col4\" class=\"data row2 col4\" >317.1</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row3\" class=\"row_heading level0 row3\" >WA</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow3_col0\" class=\"data row3 col0\" >1793.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow3_col1\" class=\"data row3 col1\" >2357</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow3_col2\" class=\"data row3 col2\" >(1906, 3587)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow3_col3\" class=\"data row3 col3\" >1.3</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow3_col4\" class=\"data row3 col4\" >3052.3</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row3\" class=\"row_heading level0 row3\" >WA</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row3_col0\" class=\"data row3 col0\" >1793</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row3_col1\" class=\"data row3 col1\" >2643</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row3_col2\" class=\"data row3 col2\" >(1935, 5103)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row3_col3\" class=\"data row3 col3\" >1.5</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row3_col4\" class=\"data row3 col4\" >3052.3</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row4\" class=\"row_heading level0 row4\" >MI</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow4_col0\" class=\"data row4 col0\" >1035.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow4_col1\" class=\"data row4 col1\" >2083</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow4_col2\" class=\"data row4 col2\" >(1298, 5248)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow4_col3\" class=\"data row4 col3\" >2.0</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow4_col4\" class=\"data row4 col4\" >286.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row4\" class=\"row_heading level0 row4\" >MI</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row4_col0\" class=\"data row4 col0\" >1035</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row4_col1\" class=\"data row4 col1\" >2248</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row4_col2\" class=\"data row4 col2\" >(1278, 7193)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row4_col3\" class=\"data row4 col3\" >2.2</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row4_col4\" class=\"data row4 col4\" >286.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row5\" class=\"row_heading level0 row5\" >IL</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow5_col0\" class=\"data row5 col0\" >1058.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow5_col1\" class=\"data row5 col1\" >1859</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow5_col2\" class=\"data row5 col2\" >(1230, 4033)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow5_col3\" class=\"data row5 col3\" >1.8</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow5_col4\" class=\"data row5 col4\" >493.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row5\" class=\"row_heading level0 row5\" >IL</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row5_col0\" class=\"data row5 col0\" >1058</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row5_col1\" class=\"data row5 col1\" >2041</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row5_col2\" class=\"data row5 col2\" >(1249, 6393)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row5_col3\" class=\"data row5 col3\" >1.9</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row5_col4\" class=\"data row5 col4\" >493.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row6\" class=\"row_heading level0 row6\" >FL</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow6_col0\" class=\"data row6 col0\" >830.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow6_col1\" class=\"data row6 col1\" >1574</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow6_col2\" class=\"data row6 col2\" >(1011, 3591)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow6_col3\" class=\"data row6 col3\" >1.9</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow6_col4\" class=\"data row6 col4\" >337.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row6\" class=\"row_heading level0 row6\" >FL</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row6_col0\" class=\"data row6 col0\" >830</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row6_col1\" class=\"data row6 col1\" >1676</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row6_col2\" class=\"data row6 col2\" >(989, 4349)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row6_col3\" class=\"data row6 col3\" >2.0</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row6_col4\" class=\"data row6 col4\" >337.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row7\" class=\"row_heading level0 row7\" >LA</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow7_col0\" class=\"data row7 col0\" >837.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow7_col1\" class=\"data row7 col1\" >1451</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow7_col2\" class=\"data row7 col2\" >(986, 3022)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow7_col3\" class=\"data row7 col3\" >1.7</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow7_col4\" class=\"data row7 col4\" >594.8</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row7\" class=\"row_heading level0 row7\" >LA</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row7_col0\" class=\"data row7 col0\" >837</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row7_col1\" class=\"data row7 col1\" >1562</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row7_col2\" class=\"data row7 col2\" >(974, 4300)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row7_col3\" class=\"data row7 col3\" >1.9</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row7_col4\" class=\"data row7 col4\" >594.8</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row8\" class=\"row_heading level0 row8\" >OH</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow8_col0\" class=\"data row8 col0\" >351.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow8_col1\" class=\"data row8 col1\" >1286</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow8_col2\" class=\"data row8 col2\" >(634, 3814)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow8_col3\" class=\"data row8 col3\" >3.7</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow8_col4\" class=\"data row8 col4\" >33.1</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row8\" class=\"row_heading level0 row8\" >GA</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row8_col0\" class=\"data row8 col0\" >600</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row8_col1\" class=\"data row8 col1\" >1259</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row8_col2\" class=\"data row8 col2\" >(705, 3814)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row8_col3\" class=\"data row8 col3\" >2.1</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row8_col4\" class=\"data row8 col4\" >288.6</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row9\" class=\"row_heading level0 row9\" >GA</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow9_col0\" class=\"data row9 col0\" >600.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow9_col1\" class=\"data row9 col1\" >1176</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow9_col2\" class=\"data row9 col2\" >(737, 2882)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow9_col3\" class=\"data row9 col3\" >2.0</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow9_col4\" class=\"data row9 col4\" >288.6</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row9\" class=\"row_heading level0 row9\" >OH</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row9_col0\" class=\"data row9 col0\" >351</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row9_col1\" class=\"data row9 col1\" >1169</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row9_col2\" class=\"data row9 col2\" >(518, 4643)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row9_col3\" class=\"data row9 col3\" >3.3</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row9_col4\" class=\"data row9 col4\" >33.1</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row10\" class=\"row_heading level0 row10\" >MA</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow10_col0\" class=\"data row10 col0\" >646.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow10_col1\" class=\"data row10 col1\" >1034</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow10_col2\" class=\"data row10 col2\" >(736, 2015)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow10_col3\" class=\"data row10 col3\" >1.6</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow10_col4\" class=\"data row10 col4\" >889.1</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row10\" class=\"row_heading level0 row10\" >MA</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row10_col0\" class=\"data row10 col0\" >646</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row10_col1\" class=\"data row10 col1\" >1126</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row10_col2\" class=\"data row10 col2\" >(726, 3195)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row10_col3\" class=\"data row10 col3\" >1.7</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row10_col4\" class=\"data row10 col4\" >889.1</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row11\" class=\"row_heading level0 row11\" >PA</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow11_col0\" class=\"data row11 col0\" >479.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow11_col1\" class=\"data row11 col1\" >937</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow11_col2\" class=\"data row11 col2\" >(590, 2218)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow11_col3\" class=\"data row11 col3\" >2.0</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow11_col4\" class=\"data row11 col4\" >323.2</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row11\" class=\"row_heading level0 row11\" >PA</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row11_col0\" class=\"data row11 col0\" >479</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row11_col1\" class=\"data row11 col1\" >972</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row11_col2\" class=\"data row11 col2\" >(580, 2841)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row11_col3\" class=\"data row11 col3\" >2.0</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row11_col4\" class=\"data row11 col4\" >323.2</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row12\" class=\"row_heading level0 row12\" >TN</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow12_col0\" class=\"data row12 col0\" >505.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow12_col1\" class=\"data row12 col1\" >865</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow12_col2\" class=\"data row12 col2\" >(598, 1816)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow12_col3\" class=\"data row12 col3\" >1.7</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow12_col4\" class=\"data row12 col4\" >533.4</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row12\" class=\"row_heading level0 row12\" >TN</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row12_col0\" class=\"data row12 col0\" >505</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row12_col1\" class=\"data row12 col1\" >954</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row12_col2\" class=\"data row12 col2\" >(590, 2409)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row12_col3\" class=\"data row12 col3\" >1.9</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row12_col4\" class=\"data row12 col4\" >533.4</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row13\" class=\"row_heading level0 row13\" >MD</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow13_col0\" class=\"data row13 col0\" >244.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow13_col1\" class=\"data row13 col1\" >830</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow13_col2\" class=\"data row13 col2\" >(431, 2838)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow13_col3\" class=\"data row13 col3\" >3.4</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow13_col4\" class=\"data row13 col4\" >47.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row13\" class=\"row_heading level0 row13\" >CO</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row13_col0\" class=\"data row13 col0\" >475</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row13_col1\" class=\"data row13 col1\" >873</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row13_col2\" class=\"data row13 col2\" >(545, 2358)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row13_col3\" class=\"data row13 col3\" >1.8</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row13_col4\" class=\"data row13 col4\" >639.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row14\" class=\"row_heading level0 row14\" >CO</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow14_col0\" class=\"data row14 col0\" >475.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow14_col1\" class=\"data row14 col1\" >802</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow14_col2\" class=\"data row14 col2\" >(567, 1698)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow14_col3\" class=\"data row14 col3\" >1.7</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow14_col4\" class=\"data row14 col4\" >639.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row14\" class=\"row_heading level0 row14\" >MD</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row14_col0\" class=\"data row14 col0\" >244</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row14_col1\" class=\"data row14 col1\" >754</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row14_col2\" class=\"data row14 col2\" >(361, 2779)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row14_col3\" class=\"data row14 col3\" >3.1</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row14_col4\" class=\"data row14 col4\" >47.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row15\" class=\"row_heading level0 row15\" >TX</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow15_col0\" class=\"data row15 col0\" >334.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow15_col1\" class=\"data row15 col1\" >715</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow15_col2\" class=\"data row15 col2\" >(430, 1687)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow15_col3\" class=\"data row15 col3\" >2.1</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow15_col4\" class=\"data row15 col4\" >224.9</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row15\" class=\"row_heading level0 row15\" >TX</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row15_col0\" class=\"data row15 col0\" >334</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row15_col1\" class=\"data row15 col1\" >740</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row15_col2\" class=\"data row15 col2\" >(424, 2479)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row15_col3\" class=\"data row15 col3\" >2.2</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row15_col4\" class=\"data row15 col4\" >224.9</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row16\" class=\"row_heading level0 row16\" >WI</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow16_col0\" class=\"data row16 col0\" >385.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow16_col1\" class=\"data row16 col1\" >616</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow16_col2\" class=\"data row16 col2\" >(443, 1208)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow16_col3\" class=\"data row16 col3\" >1.6</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow16_col4\" class=\"data row16 col4\" >843.1</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row16\" class=\"row_heading level0 row16\" >WI</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row16_col0\" class=\"data row16 col0\" >385</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row16_col1\" class=\"data row16 col1\" >683</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row16_col2\" class=\"data row16 col2\" >(445, 1880)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row16_col3\" class=\"data row16 col3\" >1.8</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row16_col4\" class=\"data row16 col4\" >843.1</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row17\" class=\"row_heading level0 row17\" >AZ</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow17_col0\" class=\"data row17 col0\" >152.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow17_col1\" class=\"data row17 col1\" >516</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow17_col2\" class=\"data row17 col2\" >(265, 1667)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow17_col3\" class=\"data row17 col3\" >3.4</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow17_col4\" class=\"data row17 col4\" >47.3</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row17\" class=\"row_heading level0 row17\" >IN</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row17_col0\" class=\"data row17 col0\" >201</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row17_col1\" class=\"data row17 col1\" >510</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row17_col2\" class=\"data row17 col2\" >(254, 1779)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row17_col3\" class=\"data row17 col3\" >2.5</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row17_col4\" class=\"data row17 col4\" >123.7</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row18\" class=\"row_heading level0 row18\" >AL</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow18_col0\" class=\"data row18 col0\" >138.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow18_col1\" class=\"data row18 col1\" >509</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow18_col2\" class=\"data row18 col2\" >(244, 1667)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow18_col3\" class=\"data row18 col3\" >3.7</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow18_col4\" class=\"data row18 col4\" >31.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row18\" class=\"row_heading level0 row18\" >AL</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row18_col0\" class=\"data row18 col0\" >138</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row18_col1\" class=\"data row18 col1\" >500</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row18_col2\" class=\"data row18 col2\" >(214, 2244)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row18_col3\" class=\"data row18 col3\" >3.6</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row18_col4\" class=\"data row18 col4\" >31.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row19\" class=\"row_heading level0 row19\" >IN</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow19_col0\" class=\"data row19 col0\" >201.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow19_col1\" class=\"data row19 col1\" >506</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow19_col2\" class=\"data row19 col2\" >(291, 1227)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow19_col3\" class=\"data row19 col3\" >2.5</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow19_col4\" class=\"data row19 col4\" >123.7</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row19\" class=\"row_heading level0 row19\" >NC</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row19_col0\" class=\"data row19 col0\" >255</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row19_col1\" class=\"data row19 col1\" >494</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row19_col2\" class=\"data row19 col2\" >(304, 1378)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row19_col3\" class=\"data row19 col3\" >1.9</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row19_col4\" class=\"data row19 col4\" >503.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row20\" class=\"row_heading level0 row20\" >NC</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow20_col0\" class=\"data row20 col0\" >255.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow20_col1\" class=\"data row20 col1\" >455</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow20_col2\" class=\"data row20 col2\" >(313, 979)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow20_col3\" class=\"data row20 col3\" >1.8</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow20_col4\" class=\"data row20 col4\" >503.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row20\" class=\"row_heading level0 row20\" >AZ</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row20_col0\" class=\"data row20 col0\" >152</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row20_col1\" class=\"data row20 col1\" >479</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row20_col2\" class=\"data row20 col2\" >(226, 2101)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row20_col3\" class=\"data row20 col3\" >3.2</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row20_col4\" class=\"data row20 col4\" >47.3</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row21\" class=\"row_heading level0 row21\" >VA</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow21_col0\" class=\"data row21 col0\" >219.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow21_col1\" class=\"data row21 col1\" >421</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow21_col2\" class=\"data row21 col2\" >(275, 895)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow21_col3\" class=\"data row21 col3\" >1.9</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow21_col4\" class=\"data row21 col4\" >326.9</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row21\" class=\"row_heading level0 row21\" >VA</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row21_col0\" class=\"data row21 col0\" >219</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row21_col1\" class=\"data row21 col1\" >443</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row21_col2\" class=\"data row21 col2\" >(260, 1286)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row21_col3\" class=\"data row21 col3\" >2.0</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row21_col4\" class=\"data row21 col4\" >326.9</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row22\" class=\"row_heading level0 row22\" >MS</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow22_col0\" class=\"data row22 col0\" >207.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow22_col1\" class=\"data row22 col1\" >416</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow22_col2\" class=\"data row22 col2\" >(256, 1006)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow22_col3\" class=\"data row22 col3\" >2.0</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow22_col4\" class=\"data row22 col4\" >280.6</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row22\" class=\"row_heading level0 row22\" >MS</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row22_col0\" class=\"data row22 col0\" >207</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row22_col1\" class=\"data row22 col1\" >442</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row22_col2\" class=\"data row22 col2\" >(252, 1459)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row22_col3\" class=\"data row22 col3\" >2.1</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row22_col4\" class=\"data row22 col4\" >280.6</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row23\" class=\"row_heading level0 row23\" >SC</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow23_col0\" class=\"data row23 col0\" >195.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow23_col1\" class=\"data row23 col1\" >393</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow23_col2\" class=\"data row23 col2\" >(243, 938)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow23_col3\" class=\"data row23 col3\" >2.0</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow23_col4\" class=\"data row23 col4\" >273.3</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row23\" class=\"row_heading level0 row23\" >CT</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row23_col0\" class=\"data row23 col0\" >223</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row23_col1\" class=\"data row23 col1\" >418</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row23_col2\" class=\"data row23 col2\" >(259, 1145)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row23_col3\" class=\"data row23 col3\" >1.9</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row23_col4\" class=\"data row23 col4\" >645.1</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row24\" class=\"row_heading level0 row24\" >CT</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow24_col0\" class=\"data row24 col0\" >223.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow24_col1\" class=\"data row24 col1\" >369</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow24_col2\" class=\"data row24 col2\" >(259, 707)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow24_col3\" class=\"data row24 col3\" >1.7</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow24_col4\" class=\"data row24 col4\" >645.1</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row24\" class=\"row_heading level0 row24\" >SC</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row24_col0\" class=\"data row24 col0\" >195</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row24_col1\" class=\"data row24 col1\" >408</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row24_col2\" class=\"data row24 col2\" >(239, 1295)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row24_col3\" class=\"data row24 col3\" >2.1</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row24_col4\" class=\"data row24 col4\" >273.3</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row25\" class=\"row_heading level0 row25\" >AR</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow25_col0\" class=\"data row25 col0\" >165.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow25_col1\" class=\"data row25 col1\" >348</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow25_col2\" class=\"data row25 col2\" >(214, 906)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow25_col3\" class=\"data row25 col3\" >2.1</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow25_col4\" class=\"data row25 col4\" >227.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row25\" class=\"row_heading level0 row25\" >AR</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row25_col0\" class=\"data row25 col0\" >165</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row25_col1\" class=\"data row25 col1\" >370</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row25_col2\" class=\"data row25 col2\" >(203, 1094)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row25_col3\" class=\"data row25 col3\" >2.2</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row25_col4\" class=\"data row25 col4\" >227.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row26\" class=\"row_heading level0 row26\" >NV</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow26_col0\" class=\"data row26 col0\" >190.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow26_col1\" class=\"data row26 col1\" >305</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow26_col2\" class=\"data row26 col2\" >(218, 592)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow26_col3\" class=\"data row26 col3\" >1.6</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow26_col4\" class=\"data row26 col4\" >814.2</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row26\" class=\"row_heading level0 row26\" >NV</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row26_col0\" class=\"data row26 col0\" >190</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row26_col1\" class=\"data row26 col1\" >335</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row26_col2\" class=\"data row26 col2\" >(221, 925)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row26_col3\" class=\"data row26 col3\" >1.8</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row26_col4\" class=\"data row26 col4\" >814.2</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row27\" class=\"row_heading level0 row27\" >UT</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow27_col0\" class=\"data row27 col0\" >181.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow27_col1\" class=\"data row27 col1\" >289</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow27_col2\" class=\"data row27 col2\" >(207, 591)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow27_col3\" class=\"data row27 col3\" >1.6</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow27_col4\" class=\"data row27 col4\" >798.5</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row27\" class=\"row_heading level0 row27\" >UT</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row27_col0\" class=\"data row27 col0\" >181</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row27_col1\" class=\"data row27 col1\" >327</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row27_col2\" class=\"data row27 col2\" >(207, 741)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row27_col3\" class=\"data row27 col3\" >1.8</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row27_col4\" class=\"data row27 col4\" >798.5</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row28\" class=\"row_heading level0 row28\" >OR</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow28_col0\" class=\"data row28 col0\" >161.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow28_col1\" class=\"data row28 col1\" >280</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow28_col2\" class=\"data row28 col2\" >(194, 556)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow28_col3\" class=\"data row28 col3\" >1.7</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow28_col4\" class=\"data row28 col4\" >501.9</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row28\" class=\"row_heading level0 row28\" >OR</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row28_col0\" class=\"data row28 col0\" >161</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row28_col1\" class=\"data row28 col1\" >313</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row28_col2\" class=\"data row28 col2\" >(190, 919)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row28_col3\" class=\"data row28 col3\" >1.9</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row28_col4\" class=\"data row28 col4\" >501.9</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row29\" class=\"row_heading level0 row29\" >MN</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow29_col0\" class=\"data row29 col0\" >169.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow29_col1\" class=\"data row29 col1\" >280</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow29_col2\" class=\"data row29 col2\" >(197, 581)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow29_col3\" class=\"data row29 col3\" >1.7</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow29_col4\" class=\"data row29 col4\" >725.2</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row29\" class=\"row_heading level0 row29\" >MN</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row29_col0\" class=\"data row29 col0\" >169</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row29_col1\" class=\"data row29 col1\" >307</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row29_col2\" class=\"data row29 col2\" >(194, 682)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row29_col3\" class=\"data row29 col3\" >1.8</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row29_col4\" class=\"data row29 col4\" >725.2</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row30\" class=\"row_heading level0 row30\" >MO</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow30_col0\" class=\"data row30 col0\" >90.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow30_col1\" class=\"data row30 col1\" >258</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow30_col2\" class=\"data row30 col2\" >(140, 819)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow30_col3\" class=\"data row30 col3\" >2.9</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow30_col4\" class=\"data row30 col4\" >72.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row30\" class=\"row_heading level0 row30\" >MO</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row30_col0\" class=\"data row30 col0\" >90</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row30_col1\" class=\"data row30 col1\" >257</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row30_col2\" class=\"data row30 col2\" >(129, 920)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row30_col3\" class=\"data row30 col3\" >2.9</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row30_col4\" class=\"data row30 col4\" >72.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row31\" class=\"row_heading level0 row31\" >KY</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow31_col0\" class=\"data row31 col0\" >99.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow31_col1\" class=\"data row31 col1\" >224</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow31_col2\" class=\"data row31 col2\" >(131, 568)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow31_col3\" class=\"data row31 col3\" >2.3</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow31_col4\" class=\"data row31 col4\" >171.9</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row31\" class=\"row_heading level0 row31\" >KY</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row31_col0\" class=\"data row31 col0\" >99</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row31_col1\" class=\"data row31 col1\" >231</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row31_col2\" class=\"data row31 col2\" >(127, 820)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row31_col3\" class=\"data row31 col3\" >2.3</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row31_col4\" class=\"data row31 col4\" >171.9</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row32\" class=\"row_heading level0 row32\" >IA</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow32_col0\" class=\"data row32 col0\" >90.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow32_col1\" class=\"data row32 col1\" >170</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow32_col2\" class=\"data row32 col2\" >(110, 365)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow32_col3\" class=\"data row32 col3\" >1.9</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow32_col4\" class=\"data row32 col4\" >354.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row32\" class=\"row_heading level0 row32\" >IA</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row32_col0\" class=\"data row32 col0\" >90</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row32_col1\" class=\"data row32 col1\" >184</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row32_col2\" class=\"data row32 col2\" >(109, 492)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row32_col3\" class=\"data row32 col3\" >2.0</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row32_col4\" class=\"data row32 col4\" >354.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row33\" class=\"row_heading level0 row33\" >DC</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow33_col0\" class=\"data row33 col0\" >98.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow33_col1\" class=\"data row33 col1\" >158</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow33_col2\" class=\"data row33 col2\" >(113, 296)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow33_col3\" class=\"data row33 col3\" >1.6</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow33_col4\" class=\"data row33 col4\" >826.1</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row33\" class=\"row_heading level0 row33\" >DC</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row33_col0\" class=\"data row33 col0\" >98</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row33_col1\" class=\"data row33 col1\" >178</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row33_col2\" class=\"data row33 col2\" >(112, 533)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row33_col3\" class=\"data row33 col3\" >1.8</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row33_col4\" class=\"data row33 col4\" >826.1</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row34\" class=\"row_heading level0 row34\" >OK</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow34_col0\" class=\"data row34 col0\" >67.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow34_col1\" class=\"data row34 col1\" >155</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow34_col2\" class=\"data row34 col2\" >(91, 379)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow34_col3\" class=\"data row34 col3\" >2.3</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow34_col4\" class=\"data row34 col4\" >154.9</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row34\" class=\"row_heading level0 row34\" >KS</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row34_col0\" class=\"data row34 col0\" >64</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row34_col1\" class=\"data row34 col1\" >159</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row34_col2\" class=\"data row34 col2\" >(85, 643)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row34_col3\" class=\"data row34 col3\" >2.5</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row34_col4\" class=\"data row34 col4\" >162.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row35\" class=\"row_heading level0 row35\" >DE</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow35_col0\" class=\"data row35 col0\" >56.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow35_col1\" class=\"data row35 col1\" >155</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow35_col2\" class=\"data row35 col2\" >(83, 477)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow35_col3\" class=\"data row35 col3\" >2.8</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow35_col4\" class=\"data row35 col4\" >83.2</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row35\" class=\"row_heading level0 row35\" >OK</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row35_col0\" class=\"data row35 col0\" >67</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row35_col1\" class=\"data row35 col1\" >158</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row35_col2\" class=\"data row35 col2\" >(86, 534)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row35_col3\" class=\"data row35 col3\" >2.4</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row35_col4\" class=\"data row35 col4\" >154.9</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row36\" class=\"row_heading level0 row36\" >KS</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow36_col0\" class=\"data row36 col0\" >64.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow36_col1\" class=\"data row36 col1\" >152</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow36_col2\" class=\"data row36 col2\" >(89, 358)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow36_col3\" class=\"data row36 col3\" >2.4</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow36_col4\" class=\"data row36 col4\" >162.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row36\" class=\"row_heading level0 row36\" >DE</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row36_col0\" class=\"data row36 col0\" >56</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row36_col1\" class=\"data row36 col1\" >153</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row36_col2\" class=\"data row36 col2\" >(76, 503)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row36_col3\" class=\"data row36 col3\" >2.7</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row36_col4\" class=\"data row36 col4\" >83.2</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row37\" class=\"row_heading level0 row37\" >RI</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow37_col0\" class=\"data row37 col0\" >83.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow37_col1\" class=\"data row37 col1\" >132</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow37_col2\" class=\"data row37 col2\" >(96, 237)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow37_col3\" class=\"data row37 col3\" >1.6</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow37_col4\" class=\"data row37 col4\" >876.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row37\" class=\"row_heading level0 row37\" >ME</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row37_col0\" class=\"data row37 col0\" >89</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row37_col1\" class=\"data row37 col1\" >143</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row37_col2\" class=\"data row37 col2\" >(99, 346)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row37_col3\" class=\"data row37 col3\" >1.6</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row37_col4\" class=\"data row37 col4\" >1738.6</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row38\" class=\"row_heading level0 row38\" >ME</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow38_col0\" class=\"data row38 col0\" >89.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow38_col1\" class=\"data row38 col1\" >127</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow38_col2\" class=\"data row38 col2\" >(100, 207)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow38_col3\" class=\"data row38 col3\" >1.4</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow38_col4\" class=\"data row38 col4\" >1738.6</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row38\" class=\"row_heading level0 row38\" >RI</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row38_col0\" class=\"data row38 col0\" >83</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row38_col1\" class=\"data row38 col1\" >142</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row38_col2\" class=\"data row38 col2\" >(93, 386)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row38_col3\" class=\"data row38 col3\" >1.7</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row38_col4\" class=\"data row38 col4\" >876.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row39\" class=\"row_heading level0 row39\" >HI</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow39_col0\" class=\"data row39 col0\" >48.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow39_col1\" class=\"data row39 col1\" >122</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow39_col2\" class=\"data row39 col2\" >(65, 331)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow39_col3\" class=\"data row39 col3\" >2.5</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow39_col4\" class=\"data row39 col4\" >113.7</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row39\" class=\"row_heading level0 row39\" >HI</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row39_col0\" class=\"data row39 col0\" >48</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row39_col1\" class=\"data row39 col1\" >123</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row39_col2\" class=\"data row39 col2\" >(64, 485)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row39_col3\" class=\"data row39 col3\" >2.6</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row39_col4\" class=\"data row39 col4\" >113.7</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row40\" class=\"row_heading level0 row40\" >NH</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow40_col0\" class=\"data row40 col0\" >65.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow40_col1\" class=\"data row40 col1\" >106</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow40_col2\" class=\"data row40 col2\" >(77, 192)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow40_col3\" class=\"data row40 col3\" >1.6</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow40_col4\" class=\"data row40 col4\" >756.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row40\" class=\"row_heading level0 row40\" >NH</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row40_col0\" class=\"data row40 col0\" >65</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row40_col1\" class=\"data row40 col1\" >117</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row40_col2\" class=\"data row40 col2\" >(74, 310)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row40_col3\" class=\"data row40 col3\" >1.8</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row40_col4\" class=\"data row40 col4\" >756.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row41\" class=\"row_heading level0 row41\" >NE</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow41_col0\" class=\"data row41 col0\" >48.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow41_col1\" class=\"data row41 col1\" >104</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow41_col2\" class=\"data row41 col2\" >(64, 247)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow41_col3\" class=\"data row41 col3\" >2.2</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow41_col4\" class=\"data row41 col4\" >203.7</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row41\" class=\"row_heading level0 row41\" >NE</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row41_col0\" class=\"data row41 col0\" >48</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row41_col1\" class=\"data row41 col1\" >111</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row41_col2\" class=\"data row41 col2\" >(62, 468)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row41_col3\" class=\"data row41 col3\" >2.3</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row41_col4\" class=\"data row41 col4\" >203.7</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row42\" class=\"row_heading level0 row42\" >NM</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow42_col0\" class=\"data row42 col0\" >57.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow42_col1\" class=\"data row42 col1\" >81</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow42_col2\" class=\"data row42 col2\" >(62, 139)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow42_col3\" class=\"data row42 col3\" >1.4</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow42_col4\" class=\"data row42 col4\" >1825.6</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row42\" class=\"row_heading level0 row42\" >NM</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row42_col0\" class=\"data row42 col0\" >57</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row42_col1\" class=\"data row42 col1\" >91</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row42_col2\" class=\"data row42 col2\" >(64, 205)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row42_col3\" class=\"data row42 col3\" >1.6</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row42_col4\" class=\"data row42 col4\" >1825.6</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row43\" class=\"row_heading level0 row43\" >VT</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow43_col0\" class=\"data row43 col0\" >52.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow43_col1\" class=\"data row43 col1\" >77</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow43_col2\" class=\"data row43 col2\" >(59, 143)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow43_col3\" class=\"data row43 col3\" >1.5</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow43_col4\" class=\"data row43 col4\" >1294.9</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row43\" class=\"row_heading level0 row43\" >VT</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row43_col0\" class=\"data row43 col0\" >52</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row43_col1\" class=\"data row43 col1\" >88</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row43_col2\" class=\"data row43 col2\" >(57, 231)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row43_col3\" class=\"data row43 col3\" >1.7</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row43_col4\" class=\"data row43 col4\" >1294.9</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row44\" class=\"row_heading level0 row44\" >ID</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow44_col0\" class=\"data row44 col0\" >42.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow44_col1\" class=\"data row44 col1\" >75</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow44_col2\" class=\"data row44 col2\" >(49, 159)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow44_col3\" class=\"data row44 col3\" >1.8</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow44_col4\" class=\"data row44 col4\" >509.8</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row44\" class=\"row_heading level0 row44\" >ID</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row44_col0\" class=\"data row44 col0\" >42</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row44_col1\" class=\"data row44 col1\" >81</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row44_col2\" class=\"data row44 col2\" >(48, 237)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row44_col3\" class=\"data row44 col3\" >1.9</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row44_col4\" class=\"data row44 col4\" >509.8</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row45\" class=\"row_heading level0 row45\" >PR</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow45_col0\" class=\"data row45 col0\" >23.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow45_col1\" class=\"data row45 col1\" >74</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow45_col2\" class=\"data row45 col2\" >(37, 204)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow45_col3\" class=\"data row45 col3\" >3.2</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow45_col4\" class=\"data row45 col4\" >51.4</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row45\" class=\"row_heading level0 row45\" >PR</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row45_col0\" class=\"data row45 col0\" >23</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row45_col1\" class=\"data row45 col1\" >70</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row45_col2\" class=\"data row45 col2\" >(34, 250)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row45_col3\" class=\"data row45 col3\" >3.0</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row45_col4\" class=\"data row45 col4\" >51.4</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row46\" class=\"row_heading level0 row46\" >MT</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow46_col0\" class=\"data row46 col0\" >31.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow46_col1\" class=\"data row46 col1\" >47</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow46_col2\" class=\"data row46 col2\" >(36, 88)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow46_col3\" class=\"data row46 col3\" >1.5</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow46_col4\" class=\"data row46 col4\" >1091.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row46\" class=\"row_heading level0 row46\" >MT</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row46_col0\" class=\"data row46 col0\" >31</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row46_col1\" class=\"data row46 col1\" >52</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row46_col2\" class=\"data row46 col2\" >(35, 137)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row46_col3\" class=\"data row46 col3\" >1.7</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row46_col4\" class=\"data row46 col4\" >1091.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row47\" class=\"row_heading level0 row47\" >ND</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow47_col0\" class=\"data row47 col0\" >28.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow47_col1\" class=\"data row47 col1\" >40</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow47_col2\" class=\"data row47 col2\" >(31, 66)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow47_col3\" class=\"data row47 col3\" >1.4</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow47_col4\" class=\"data row47 col4\" >1534.0</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row47\" class=\"row_heading level0 row47\" >ND</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row47_col0\" class=\"data row47 col0\" >28</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row47_col1\" class=\"data row47 col1\" >45</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row47_col2\" class=\"data row47 col2\" >(31, 111)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row47_col3\" class=\"data row47 col3\" >1.6</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row47_col4\" class=\"data row47 col4\" >1534.0</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row48\" class=\"row_heading level0 row48\" >WY</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow48_col0\" class=\"data row48 col0\" >24.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow48_col1\" class=\"data row48 col1\" >39</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow48_col2\" class=\"data row48 col2\" >(27, 77)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow48_col3\" class=\"data row48 col3\" >1.6</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow48_col4\" class=\"data row48 col4\" >796.5</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row48\" class=\"row_heading level0 row48\" >WY</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row48_col0\" class=\"data row48 col0\" >24</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row48_col1\" class=\"data row48 col1\" >44</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row48_col2\" class=\"data row48 col2\" >(28, 119)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row48_col3\" class=\"data row48 col3\" >1.8</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row48_col4\" class=\"data row48 col4\" >796.5</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row49\" class=\"row_heading level0 row49\" >AK</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow49_col0\" class=\"data row49 col0\" >22.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow49_col1\" class=\"data row49 col1\" >34</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow49_col2\" class=\"data row49 col2\" >(25, 71)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow49_col3\" class=\"data row49 col3\" >1.5</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow49_col4\" class=\"data row49 col4\" >1055.3</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row49\" class=\"row_heading level0 row49\" >SD</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row49_col0\" class=\"data row49 col0\" >21</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row49_col1\" class=\"data row49 col1\" >38</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row49_col2\" class=\"data row49 col2\" >(25, 102)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row49_col3\" class=\"data row49 col3\" >1.8</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row49_col4\" class=\"data row49 col4\" >796.9</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row50\" class=\"row_heading level0 row50\" >SD</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow50_col0\" class=\"data row50 col0\" >21.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow50_col1\" class=\"data row50 col1\" >33</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow50_col2\" class=\"data row50 col2\" >(24, 63)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow50_col3\" class=\"data row50 col3\" >1.6</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow50_col4\" class=\"data row50 col4\" >796.9</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row50\" class=\"row_heading level0 row50\" >AK</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row50_col0\" class=\"data row50 col0\" >22</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row50_col1\" class=\"data row50 col1\" >37</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row50_col2\" class=\"data row50 col2\" >(25, 85)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row50_col3\" class=\"data row50 col3\" >1.7</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row50_col4\" class=\"data row50 col4\" >1055.3</td>\n",
        "            </tr>\n",
        "            <tr>\n",
-       "                        <th id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68clevel0_row51\" class=\"row_heading level0 row51\" >WV</th>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow51_col0\" class=\"data row51 col0\" >12.000000</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow51_col1\" class=\"data row51 col1\" >27</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow51_col2\" class=\"data row51 col2\" >(16, 60)</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow51_col3\" class=\"data row51 col3\" >2.2</td>\n",
-       "                        <td id=\"T_569fc05e_6c83_11ea_8a74_000d3a10b68crow51_col4\" class=\"data row51 col4\" >190.3</td>\n",
+       "                        <th id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158level0_row51\" class=\"row_heading level0 row51\" >WV</th>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row51_col0\" class=\"data row51 col0\" >12</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row51_col1\" class=\"data row51 col1\" >28</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row51_col2\" class=\"data row51 col2\" >(15, 92)</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row51_col3\" class=\"data row51 col3\" >2.3</td>\n",
+       "                        <td id=\"T_f8916324_6c90_11ea_91d0_5cf9388e0158row51_col4\" class=\"data row51 col4\" >190.3</td>\n",
        "            </tr>\n",
        "    </tbody></table>"
       ],
       "text/plain": [
-       "<pandas.io.formats.style.Styler at 0x7f2156cc4cf8>"
+       "<pandas.io.formats.style.Styler at 0x104b06080>"
       ]
      },
      "execution_count": 7,
@@ -8553,7 +1616,7 @@
    "outputs": [
     {
      "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0QAAAIeCAYAAACbe88LAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjEsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy+j8jraAAAgAElEQVR4nOzdd3xUxf74/9dmky3Z1M1ueiUYkhACSBOkiwULiIoiRUBBBP3JvV+9CAiCfriiggUvoogKCBZAml4MCCSE0ElCM4nUUBJIJZtN2fT5/cGH82FNAZSmzPPx2Mcj55w5c+bMLmHfmZn3UQkhkCRJkiRJkiRJuh053OwGSJIkSZIkSZIk3SwyIJIkSZIkSZIk6bYlAyJJkiRJkiRJkm5bMiCSJEmSJEmSJOm2JQMiSZIkSZIkSZJuWzIgkiRJkiRJkiTptuV4sxvwZ5lMJhEaGnqzmyFJkiRJkiRJ0i0qJSWlQAhhbujYXz4gCg0NJTk5+WY3Q5IkSZIkSZKkW5RKpTrV2DE5ZU6SJEmSJEmSpNuWDIgkSZIkSZIkSbptyYBIkiRJkiRJkqTblgyIJEmSJEmSJEm6bcmASJIkSZIkSZKk29ZfPsucJEmSJN3qrFYreXl5VFdX3+ymSJIk/e04OTnh7e2Nm5vbHzpfBkSSJEmSdB1ZrVZyc3MJCAhAr9ejUqludpMkSZL+NoQQ2Gw2srOzAf5QUCSnzEmSJEnSdZSXl0dAQADOzs7XLBiaPn36NalHkiTpr06lUuHs7ExAQAB5eXl/qA4ZEEmSJEnSdVRdXY1er7+mdb755pvXtD5JkqS/Or1e/4enJcuASJIkSZKuMzlNTpIk6fr6M79nZUAkSZIkSZIkSdJtSwZEkiRJkiRJN8GiRYtwdJT5rW5FI0aMoE+fPje7GdINIgMiSZIkSZIa1LNnT0aNGlVv/8mTJ1GpVGzbtq3Rc202G1OnTuWOO+5Ar9djNBrp0KEDH3/88VW3Y+HChbRr1w43NzdcXV2Jiopi9OjRyvGlS5f+4ekyjo6OLFq06A+d+2c99dRTSmas62H69OmoVKomX3/m3q+233fu3MmAAQPw8fFBp9MRHh7O0KFDSU1N/cNtuF7mzJnDihUrlO1Ro0bRs2fPa1J3z549UalUzJs3z27/tm3bUKlUnDx58ppcR7pyMiCSJEmSJOmaGzt2LF9//TWzZs0iPT2dhIQEXnzxRSwWy1XVs2jRIsaOHcvIkSNJTk4mJSWFd955h9ra2uvU8htHr9fj4+Nz3ep/9dVXOXfunPLq3LkzgwcPttv31FNPXbfrX2rhwoV069YNjUbDN998Q0ZGBsuWLSM0NJTx48ffkDZcDXd3dzw9Pa9b/TqdjjfffJOSkpLrdg3pKggh/tKvdu3aCUmSJEm6VaWnp1/zOi/893399ejRQzz33HP19mdmZgpAJCUlNXquu7u7+M9//vOn29C/f3/x+OOPN3o8ISFBAHav4cOHCyGE+OWXX0SPHj2Ep6encHNzE927dxe7d+9Wzg0JCal37kXJycni3nvvFQaDQZhMJjFgwABx8uTJJtvatWtXMXnyZGX7jTfeEIDYuHGjsq9Lly5i4sSJQgghFi5cKNRqtXKsuLhYjBgxQvj4+AiNRiMCAwPFP//5T7trfPzxx6JFixZCq9WK5s2bixkzZojq6uom23XR79/PqqoqMW3aNBEaGiq0Wq2Ijo4Wn332md05CxYsEJGRkUKr1QpPT0/RrVs3cebMmSb7/feys7OFVqsVY8aMafD4+fPnlZ8nT54sIiMjhV6vF4GBgWLMmDHCYrEoxy/22caNG0V0dLTQarWiY8eOYt++fXb1DRkyRAQFBQmdTiciIiLE7NmzRV1dnd11v//+e3HnnXcKrVYrjEajeOCBB5S2DB8+XNxzzz1CCCGmTZtW714XLlwohg8fLu69995699OrVy/x7LPPNnivQlx4Hy6279LPS1JSkgBEZmamsm/nzp2iW7duQqfTCQ8PD/H000+L3NxcIYQQ5eXlQqPRiF9++UUp3717d6HRaERZWZkQQoiysjLh5OQk1q9f32h7/k6a+n0LJItG4gk5QiRJkiRJ0jXn5+fH+vXrOX/+/J+uJzk5mSNHjjR4vEuXLsydOxdAGfWYM2cOAKWlpYwbN46dO3eyY8cO7rjjDh544AEKCwsB2Lt3L2q1mo8++kg5FyA9PZ0ePXrQuXNnkpOTiY+PR61Wc++991JRUdFoW3v16kV8fLyyHR8fj9lsVvaVlpayd+9eevfu3eD5U6ZMITU1lbVr13L06FGWLVtGVFSUcnz69OnMnj2bmTNnkpGRwZw5c5g/f/4fTsM+evRoVq1axfz588nIyOCNN97gtdde48svvwQgJSWFF154gUmTJnH48GESExN55plnLtvvv7d8+XIqKyuZMmVKg8cvHYnR6/V8/vnnpKens2jRIrZs2cLLL79sV76uro4JEyYwb9489uzZg9ls5qGHHsJmswFQWVlJTEwMa9asIT09nalTpzJt2jS76YELFy5k6NChPProo6SmppKQkMADDzzQ4Mjjq6++yuDBg+ncubPdyNqYMWPYtGkTmZmZStljx46xZcsWnn/++Sb7XqfT8e9//5sPP/yQrKysBsvk5ORw3333ERgYyJ49e/jpp5/49ddfeeKJJ5S+6tSpk/L5stls7Nq1C3d3d2U6a1JSEgDdunVrsj23vcYipb/KS44QSZIkSbey23WEaNu2bSI4OFg4ODiIVq1aidGjR4vVq1fX+yv95Zw7d07cfffdAhAhISHiySefFPPnzxelpaVKmSVLllxRn9TW1goPDw+xdOlSZZ9arRYLFy60Kzd8+HDx1FNP2e2rqKgQer1erF69utH6ExIShKOjo7BaraKsrExoNBoxe/Zs0alTJyGEED///LPQaDSivLxcCFF/hKhfv36NjrKUlZUJvV4v4uLi7PYvXrxYuLu7X/behbB/P0+cOCFUKpXIyMiwK/Pmm2+K1q1bCyGEWLVqlXBzcxPFxcUN1nel/T527Fjh5uZ2RW38vVWrVgmNRiNqa2uFEBf6DBCbNm1Sypw/f14YDAbxxRdfNFrPyy+/LPr06aNsBwUFiRdffLHR8peOEAkhxHPPPSd69OhRr1yrVq3E66+/rmxPnDhRxMbGNnlPF9+Huro6ceedd4pnnnlGCFF/hGjKlCkiICBAVFZWKufu379fACIxMVEIcWH0qkOHDkKICyOizZo1E2PHjhWvvfaaEEKICRMmiK5duzbZnr8TOUIkSZIkSdIt4+677+b48eMkJSUxfPhwcnNzeeKJJ+jXrx8XvptcGV9fX7Zt20Z6ejqTJk3CYDAwYcIEYmJiLvtU+szMTIYNG0bz5s1xc3PDzc2N4uJiTp061eR5e/fuZfXq1bi4uCgvLy8vKioqOHr0KIDdsb59+wLQuXNnHB0dSUxMJCkpiZCQEIYNG0ZqaiolJSXEx8dz1113Nfqg3nHjxvHDDz8QExPD+PHjiYuLo66uDoC0tDRsNhuPP/643bXHjBlDcXEx+fn5V9ynAMnJyQghaN++vV19b7/9tnKP9957L82aNSMsLIxBgwbx+eefU1BQcFXXAa7q/V61ahXdu3fH398fFxcXhgwZQlVVFTk5OXblOnfurPzs6elJVFQUaWlpwIURpHfeeYc2bdpgMplwcXHhs88+U973vLw8zpw5w3333XfV9/J7Y8aMYeHChdTW1lJTU8OiRYvsEn40RaVSMWvWLJYuXcr+/fvrHU9LS+Ouu+5Co9Eo+1q3bo27u7tyr7169SI1NZXi4mLi4+O555577EYq4+PjGx2RlP6PzPUoSZIkSVKD3N3dKS4urrf/YmIEnU7X5PmOjo506dKFLl268Morr7B06VKGDRvG1q1b6dGjx1W1JSoqiqioKMaMGcPUqVOJiIjg008/Zdq0aY2e8/DDD2Mymfjkk08ICgpCo9HQtWtXqqqqmrxWXV0dw4YNY+LEifWOeXl5Adh9gb0Y4Gi1Wrp06cLmzZvRaDT07t0bb29vWrRoQWJiIvHx8fTr16/R695///2cPn2aDRs2sGXLFoYOHUqrVq3YvHmzEhitWLGCiIiIeucajcYm76mhewTYsWMHzs7OdscuZo5zcXEhOTmZ7du3s2nTJj777DMmTJjA5s2badeu3RVfq0WLFlitVrKysggMDGy03O7duxk4cCCTJk1i1qxZeHp6smvXLoYPH37Z9+xS77//PjNnzuTDDz+kbdu2uLq68uGHH7Ju3borruNKDRs2jNdee41169ZRV1dHcXExQ4cOveLze/fuTd++ffnXv/7V5Ge5MZ07d0aj0bBlyxbi4+P55z//Sa9evRg8eDCnTp1i3759zJ49+6rrvd3IgOgaEkLIp5FLkiRJfxuRkZGsWLGC2tpa1Gq1sn/Pnj2o1WqaN29+VfVdXA9zuZGdywkNDcXZ2Vmp5+Jf0C9tZ2FhIenp6fz888/cf//9AGRlZdW7tkajqbdupH379hw8eJDw8PBG/19v7N579erFihUr0Gg0TJgwAbjwpXflypXs37+fjz76qMl7MxqNPP300zz99NOMHDmSzp07k56eTsuWLdHpdJw4cYIHH3ywyTquxMWA5vTp0zz88MONllOr1XTv3p3u3bvz5ptvEh0dzbfffku7du0a7PeGDBw4kIkTJzJjxgw+++yzeseLiorw9PRk27ZtmEwmZsyYoRz74YcfGqxz165dysiHxWIhIyODMWPGALB161YeeOABnn32WaX8xVEvAG9vbwIDA/nll1+aDFAv1dDnBMDNzY1BgwaxYMEC6urqGDhwIB4eHldU50XvvfcesbGxdOjQwW5/y5YtWbhwIVVVVUpfHzhwgOLiYmJiYpR2denShdWrV5Oamkrv3r0xmUxER0fz1ltvodFo7EbTpIbJKXPX0LFjx9i1a1eTCy4lSZIk6a9i3Lhx5ObmMnLkSFJSUjh+/DjfffcdU6dOZeTIkXZf/CIjI5VF9gA9evTgs88+Izk5mVOnTrF582bGjRuHh4cHvXr1AmD16tVERkY2+SyesWPH8uabb5KUlMSpU6dISUlh+PDhWK1WHn30UQDCwsIA+PHHH8nPz6e0tBRPT0/MZjMLFizgyJEj7Ny5k6effrredLWwsDASEhI4e/asMh1s8uTJZGRkMHToUPbs2UNmZiYJCQmMHz+eEydONNlnvXv35tChQ+zfv1+5z969e7N06VJ0Oh133XVXo+e+/vrrrFq1isOHD3P06FG++eYbXFxcCA4OxsXFhcmTJzN58mQ++eQTDh8+TFpaGt9//z2vvfZak21qSPPmzXn22WcZPXo0S5Ys4dixYxw4cICvvvqKd999F4C1a9fy4YcfkpKSwunTp1mzZg1nzpwhOjq60X5vSEBAAHPnzmXBggUMGjSIzZs3c/LkSVJTU5k2bRr9+/cHLowk5efn8+WXX3LixAm+/vrres/qgQsjWBMmTGDr1q0cOnSIZ555BldXVwYPHqzUs2XLFhISEjhy5AhTpkxh9+7ddnVMmzaN+fPn8z//8z9kZGSQlpbG3LlzG50SGBYWxm+//UZaWhoFBQVUVlYqx8aMGUNcXBwbNmy4bDKFhkRHR/Pcc8/VC5ZfeuklrFYrI0aM4Ndff2Xbtm0MGzaMbt262SVJ6N27N9988w2RkZF4e3sr+77++mvuvvtuuyl3UiMaW1z0V3ndSkkVMjIyxN69e0VCQoLYsWOHsmhSkiRJun39lZMqCHFhEffDDz8s/Pz8hLOzs4iJiRGzZs0SVVVV9do0bdo0ZXvmzJmia9euwmw2C61WK4KCgsSQIUNEWlqaUubiAvlL0wz/3sqVK8UjjzwiAgIChEajEd7e3qJPnz7i559/tis3fvx4YTab7dI/b9myRcTGxgqtVisiIiLEDz/8IMLDw+3aGRcXJyIjI4WTk5Ndvx48eFD069dPeHh4CJ1OJ8LDw8Xo0aNFYWFhk/1VVVUlXFxc7BbWFxUVCbVaLe677z67sr9PqvDWW2+Jli1bCoPBoKQJ/33iigULFojWrVsLrVYrPDw8RMeOHcW8efOabNNFv0+SUVNTI959913RokUL4eTkJLy8vET37t3F8uXLhRBCJCYmil69egmTyaSk+Z45c6ZdnQ31e2OSkpJE//79hdlsFhqNRoSFhYlhw4bZpcyeMmWK8Pb2Fs7OzqJv377i22+/tfuMXOyzDRs2iMjISKHRaESHDh1ESkqKUofFYhEDBw4Urq6uwmg0inHjxokpU6aIkJAQu/YsXbpUxMbGCo1GI4xGo3jwwQdFUVGREKJ+UoXCwkLRt29f4ebmpqTdvlSbNm1EdHR0k/d/UUPJSnJycoSLi0uTabfd3d3t0m5ftGPHDgGIl19+Wdn3448/CkC8/fbbV9Smv4s/mlRBJa5iodutqH379iI5OflmNwOA+fPnk5OTQ3h4ONHR0VitVpycnGjbtm29+bmSJEnS7SEjI8MudfK1oFKprmqhuiT9XSxatIhRo0ZRU1Nzs5uiqK6uJjQ0lAkTJtySD5m9nTT1+1alUqUIIdo3dEyuIbqGBgwYwI4dOzhw4ADHjx+nefPmtGzZkr179+Lo6EibNm0wGAw3u5mSJEmSJEnSn1RXV0dBQQHz58+nrKyMkSNH3uwmSX+QDIiuocTERMrLyxkwYADHjx/n4MGDHDt2jDvuuIOYmBj27t2LVqulbdu2l83MI0mSJEmSJN26Tp8+TVhYGH5+fnz11Ve4ubnd7CZJf5AMiK4htVrNqVOnyM/Px8/Pj/79+3Pq1Cn279/P0aNHiYiIIDo6ml27dqHT6WjTpo0MjCRJkiRJkq7QiBEjGDFixM1uBnAh26Gcuvr3IAOiayg2NlZ5eFhmZibnzp3Dz8+PRx99lOPHj3Po0CGOHDlCy5YtueOOO9i9ezcGg4FWrVqh1WpvdvMlSZIkSZIk6bYjA6JrSKPR0Lp1a0JDQ8nMzCQvL4/MzExyc3Px9/fn8ccfV1I7pqenExMTg9FoZOfOnbi5uRETEyNTI0qSJEmX9Uce4ChJkiQ1TD6H6BoqKysjPT2diooK2rZtS4cOHQgNDcXBwYFjx46xceNGAJ566ilatGjBoUOHWL16NaWlpTg4OLB9+3YOHjzY4IO/JEmSJOmi6dOn3+wmSJIk/W3IgOgays7ORqVSUVlZSVpaGtXV1bRr14527doRHByMEILDhw/zyy+/oNVqefLJJwkNDSUlJYX//ve/1NbWUltby7Zt28jIyKCuru5m35IkSZIkSZIk/a3JgOgacnR0JCcnh5MnT6JWq6mqqiI9PR2VSkWnTp1o27YtAQEB1NTUkJ6ezsaNGzEajQwcOBBvb2+2b99OXFwcarWa8vJykpKSOHr0qFywJ0mSJEmSJEnXiQyIriFvb2/8/f3RarXk5ORw4sQJHB0dqaio4ODBg2g0Gjp27Ejr1q3x8/OjurqaAwcOkJCQQGBgIE8++STu7u5s3ryZTZs24eLigsViYevWrWRlZcnASJIkSZIkSZKuMRkQXUO1tbUEBgYSHByMt7c3Wq2Wc+fOkZmZiUajwWq1kpGRgbOzM506dSImJgZvb29sNhupqakkJSURFRXFY489hkaj4b///S/bt2/HaDRy5swZtm3bRn5+/s2+TUmSJEmSroFFixbh6CjzW92KRowYQZ8+fW52M6QbRAZE15DVaiUtLQ2LxUJQUBDBwcH4+fnh5OTE2bNnyc7ORqfTUVxcTHp6OkajkbvuuovIyEi8vLwoLi5mz549pKamctddd/HII49QVVXFqlWr2L9/PyaTiYyMDLZv347Var3ZtytJkiTdJNMzM2/IdXr27MmoUaPq7T958iQqlYpt27Y1eq7NZmPq1Knccccd6PV6jEYjHTp04OOPP77qdixcuJB27drh5uaGq6srUVFRjB49Wjm+dOlSVCrVVdcLF6a7L1q06A+d+2c99dRTZGdnX7f6p0+fjkqlavL1Z+79avt9586dDBgwAB8fH3Q6HeHh4QwdOpTU1NQ/3IbrZc6cOaxYsULZHjVqFD179rwmdTf2Xjz00ENXfJ5eryc0NJQnnniCuLi4a9Kua6WiogKj0YjBYOD8+fM3uzlXRAZE11BJSQm+vr6oVCp+++03ysrK8PPzIzAwED8/PxwdHcnOzubcuXO4uLhQUFDA0aNH8fPzo1OnToSGhuLs7ExeXh67du0iIyODXr160bNnT4qKili+fDlZWVkYjUZSUlLYs2cPVVVVN/u2JUmSpBvszVOnbnYTLmvs2LF8/fXXzJo1i/T0dBISEnjxxRexWCxXVc+iRYsYO3YsI0eOJDk5mZSUFN55552/RUZWvV6Pj4/Pdav/1Vdf5dy5c8qrc+fODB482G7fU089dd2uf6mFCxfSrVs3NBoN33zzDRkZGSxbtozQ0FDGjx9/Q9pwNdzd3fH09LwudV/a/+fOnWPnzp0ADBo06LLnzp07l3PnznH48GGWLFmCv78/jzzyCP/4xz+uS1v/iOXLlxMWFkaPHj1YvHjxzW7OFZEB0TV09uxZdu3aRWZmJv7+/pSWlpKeno4QgoCAAAIDAzGbzdTV1XHq1Cny8vJwcXHh9OnTnDp1isjISDp16oS/vz8qlYqsrCx2795Nfn4+/fr1o23bthw9epTly5dTXl6OwWBgx44dHDx4UGakkyRJkm4pa9as4V//+hePPvooYWFhtG7dmhEjRvDGG29cdT0PP/wwL730EhEREURERNC/f3+++uorALZs2cKwYcOA//sL+ogRIwDYuHEjPXv2xGg04u7uTo8ePdizZ49Sd2hoKLW1tYwcOVI596KUlBTuu+8+XFxcMJvNPPbYY5y6TCDarVs3Xn/9dWV72rRpqFQqNm3apOy7++67mTRpElB/ypzVamXkyJH4+vqi1WoJCgri//2//2d3jf/85z9ERkai0+m44447+Pe//01NTU2D7XFxccHX11d5aTQa9Hq9su3l5cW7775LWFgYOp2Oli1bMn/+fLs6vvjiC6KiotDpdBiNRrp3705WVlaT/f57Z8+eZezYsYwaNYply5bRp08fwsLCaN++PTNmzODHH39Uyr7++utERUXh7OxMUFAQL7zwAsXFxcrxi322adMmWrZsiU6no1OnTuzfv18pU1RUxNChQwkODkav19OiRQvef//9emuxly1bRrt27dDpdHh5edG3b1+KiooA+ylz06dP58svvyQxMdFuZG3EiBHcd9999e63d+/ePPfccw32BWD3nvj6+vLTTz8pSbYux93dHV9fX4KDg+nWrRsff/wxH3/8MXPmzCExMfGK+rGkpARXV1e+/fZbu7pPnjyJg4MDSUlJAKxdu5a2bdvi7OyMh4cHHTt2ZN++fZdt4+eff86IESMYPnw4CxYsqHfcZrPx/PPPK0HnuHHjmDRpEs2bN1fKCCGYPXs2zZo1Q6PREB4ezkcffXTZa/9RMiC6hh577DE6deqEzWZj27ZtWK1WQkJCKCgoICMjAycnJ+VDbDabqampITMzk/LyclxdXTl27Bh5eXnExsbStm1bfH19qamp4fjx4yQlJSGEYODAgYSHh5OcnMzq1auBC2uXtm7dSmZmpky8IEmSJN0S/Pz8WL9+/Z+eMuPn50dycjJHjhxp8HiXLl2YO3cu8H9/eZ8zZw4ApaWljBs3jp07d7Jjxw7uuOMOHnjgAQoLCwHYu3cvarWajz76SDkXID09nR49etC5c2eSk5OJj49HrVZz7733UlFR0Whbe/XqRXx8vLIdHx+P2WxW9pWWlrJ371569+7d4PlTpkwhNTWVtWvXcvToUZYtW0ZUVJRyfPr06cyePZuZM2eSkZHBnDlzmD9/Pm+++eaVdqed0aNHs2rVKubPn09GRgZvvPEGr732Gl9++SVwISh84YUXmDRpEocPHyYxMZFnnnnmsv3+e8uXL6eyspIpU6Y0ePzSkRi9Xs/nn39Oeno6ixYtYsuWLbz88st25evq6pgwYQLz5s1jz549mM1mHnroIWw2GwCVlZXExMSwZs0a0tPTmTp1KtOmTbObHrhw4UKGDh3Ko48+SmpqKgkJCTzwwAMNjjy++uqrDB48mM6dO9uNrI0ZM4ZNmzaReckU1mPHjrFlyxaef/75y3U/ANXV1Xz11VcMHz4cnU53Ref83pgxY/Dw8LCb4tdUP7q6ujJ48OB6wcqXX35JZGQk3bp1Iycnh4EDB/L000+TlpbGzp07+cc//nHZNW9paWns3buXwYMH079/f86dO8fWrVvtyrz22musXbuWJUuWsGvXLtzd3Zk3b55dmXnz5jF16lQmTpxIWloa//rXv5g4caLy2bzmhBA37AU8ABwGjgETGzgeDCQA+4CDwIOXq7Ndu3biVnHy5Elx8OBBcfz4cfHdd9+J6dOni+nTp4uvv/5axMfHi8WLF4tvvvlG7NixQ2zdulXExcWJZcuWiS+++EJ89tlnYtmyZWLTpk1i+fLlYsOGDeLQoUNiw4YN4osvvhAffPCBePvtt8WCBQvE+vXrxeHDh8Wnn34qpk+fLt59911x4MABsXv3brF161aRk5Nzs7tCkiRJ+l/p6enXvE4SEq55nQ3p0aOHeO655+rtz8zMFIBISkpq9Nxt27aJ4OBg4eDgIFq1aiVGjx4tVq9eLerq6q6qDefOnRN33323AERISIh48sknxfz580VpaalSZsmSJeLCV5qm1dbWCg8PD7F06VJln1qtFgsXLrQrN3z4cPHUU0/Z7auoqBB6vV6sXr260foTEhKEo6OjsFqtoqysTGg0GjF79mzRqVMnIYQQP//8s9BoNKK8vFwIIcTChQuFWq1Wzu/Xr58YPnx4g3WXlZUJvV4v4uLi7PYvXrxYuLu7X/behbB/P0+cOCFUKpXIyMiwK/Pmm2+K1q1bCyGEWLVqlXBzcxPFxcUN1nel/T527Fjh5uZ2RW38vVWrVgmNRiNqa2uFEBf6DBCbNm1Sypw/f14YDAbxxRdfNFrPyy+/LPr06aNsBwUFiRdffLHR8sOHDxf33HOPsv3cc8+JHj161CvXqlUr8frrryvbEydOFLGxsVd0b0IIsWLFCvGyBj4AACAASURBVAHUex8aAoglS5Y0eKxTp06ib9++jZ77+35MSUkRgDhy5IgQQoiamhoREBAgPvjgAyGEEKmpqQIQmZmZV3wvQlzo58cee0zZHjNmjBgyZIiyXVpaKjQaTb33qlOnTiI8PFzZDgwMFP/617/syvzjH/8QYWFhTV6/qd+3QLJoJJ64YSNEKpVKDXwC9AWigadVKlX074pNAZYLIdoCg4B5/IVkZWWRlZVFQUEBMTExDBkyhICAAE6cOMH27dtxdXXF09OTI0eOkJOTg9FoxNfXF39/f7y8vCgtLeX48eM4Ojri6OhIRkYGjo6OtGvXjhYtWuDh4YHFYuHAgQPs3LmTyMhI+vfvj1qtZvXq1ezbtw9vb2+OHDkiEy9IkiT9TUzPzES1ZYvdC6i370YlWrhSd999tzLDYfjw4eTm5vLEE0/Qr1+/q5rN4Ovry7Zt20hPT2fSpEkYDAYmTJhATEwMeXl5TZ6bmZnJsGHDaN68OW5ubri5uVFcXHzZqW979+5l9erVuLi4KC8vLy8qKio4evQogN2xvn37AtC5c2ccHR1JTEwkKSmJkJAQhg0bRmpqKiUlJcTHx3PXXXeh1+sbvO64ceP44YcfiImJYfz48cTFxSlT4tPS0rDZbDz++ON21x4zZgzFxcVXnYU2OTkZIQTt27e3q+/tt99W7vHee++lWbNmhIWFMWjQID7//HMKCgqu6jrAVb3fq1atonv37vj7++Pi4sKQIUOoqqoiJyfHrlznzp2Vnz09PYmKiiItLQ24MIL0zjvv0KZNG0wmEy4uLnz22WfK+56Xl8eZM2canO52tcaMGcPChQupra2lpqaGRYsW2SX8uJz58+fTo0cPIiMj/1Q7hBB2Uz4v14933nkn7du354svvgAgLi6OgoICZQQwNjaW+++/n5iYGAYMGMCcOXM4c+ZMk22oqKhgyZIldlMnhw8fzg8//KCMFB87doyqqiruuusuu3MvfT+tVitZWVl0797drkyPHj04efIk5eXlV9k7l3cjcz12BI4JIU4AqFSq74H+QPolZQTg9r8/uwNnb2D7/rS8vDzOnj3L+fPn8fPzw9PTk65du1JbW0tCQgIHDx5Ep9PRtm1bysvLOXz4MEajER8fH5ydnZXnDhUWFlJYWIifnx81NTUcOXIEf39/OnbsyMmTJ8nOziYvL4+ioiJ8fX3p1q0bNpuNHTt28P333xMdHU1sbCwpKSm4ubnRunVrmdZTkiTpL2p6WBjTw8Ls9qm2bEFco4xXTXF3d7dbv3HRxcQIl5vi4+joSJcuXejSpQuvvPIKS5cuZdiwYWzdupUePXpcVVuioqKIiopizJgxTJ06lYiICD799FOmTZvW6DkPP/wwJpOJTz75hKCgIDQaDV27dr1sQqK6ujqGDRvGxIkT6x3z8vICsFuzcjHA0Wq1dOnShc2bN6PRaOjduzfe3t60aNGCxMRE4uPj6devX6PXvf/++zl9+jQbNmxgy5YtDB06lFatWrF582YlMFqxYgURERH1zjUajU3eU0P3CLBjxw6cnZ3tjl38Yu3i4kJycjLbt29n06ZNfPbZZ0yYMIHNmzfTrl27K75WixYtlC+5gYGBjZbbvXs3AwcOZNKkScyaNQtPT0927drF8OHDryqJ1Pvvv8/MmTP58MMPadu2La6urnz44YesW7fuiuu4UsOGDeO1115j3bp11NXVUVxczNChQ6/o3GPHjrF58+Z6a3muVk1NDYcPH6Zjx47AlffjCy+8wOTJk5kxYwZffPEFjz32mPL5VqvVxMXFsXfvXjZt2sTKlSuZOHEiK1as4OGHH26wHcuXL6eoqIgBAwbY7a+trWXx4sX885//VPb90ayQ18uNXEMUAFwaWmb9775LTQeGqlSqLOBn4P+7MU27NoQQlJWVkZeXR3p6OidOnCA3N5fq6mr69u2r/CVi586dZGdnExQURFlZGYcOHaKmpgaTyYSfnx9+fn7odDrOnTvH2bNncXNzw2q1cvz4cUJCQmjTpg1+fn7AhVGp1NRUioqKeOihh4iNjSU9PZ3vv/+eiooKNBoN27dv58iRI3J9kSRJknRVIiMjSUlJqbeuYs+ePajVartF0Ffi4nqYy43sXM6lWVkBNBoNgF07CwsLSU9PZ+LEidx///1ER0ej0+nqXVuj0dS7v/bt23Pw4EHCw8Np3ry53eviepdL9wUE/N/XmYvriOLj47nnnnuAC4vsV65cyf79+xtdP3SR0Wjk6aefZv78+axbt47ExETS09OVBAInTpyo16bmzZujVquvqg8vBjSnT5+uV1d4eLhSTq1W0717d9566y1SUlLw8/NTvsA31O8NGThwIFqtlhkzZjR4/GIig23btmEymZgxYwadOnUiIiKCrKysBs/ZtWuX8rPFYiEjI4Po6AsTj7Zu3coDDzzAs88+S9u2bWnevLky6gXg7e1NYGAgv/zyS5PtvlRDnxMANzc3Bg0axIIFC1iwYAEDBw7Ew8Pjiur8/PPPMZlMPPbYY1fcjsbqKS4uVpIyXGk/Dho0iIqKCuWz9vuRLZVKRceOHZk8ebLyR4yFCxc22Y4RI0awf/9+u9crr7yirFdq3rw5Go1Gyax30aXvp5ubG4GBgfXWHiUmJhIWFlYvgL8WbrVhg6eBRUKI91UqVWdgiUqlihFC2KVQU6lUzwPPAwQHB9+EZjasRYsW1NbWkp2dTXl5OWfOnKGwsBB/f3+MRiOurq7K4rTk5GQSExMJCgoiJCSE3NxccnJyCAkJwcPDA4PBQHl5uTKsq9fr8ff359SpU6hUKmWqQHZ2NhaLhaNHjyojUwMHDmT79u3s2bOHgwcP0rt3b4qLi0lKSqJFixbXNcWnJEmS9Pcxbtw45s6dy8iRIxk/fjweHh7s2bOHqVOnMnLkSLsvfpGRkbz00ku89NJLwIXpLU8//TTt27fHbDZz7NgxJk+ejIeHB7169QJg9erVTJo0ic2bN9sFFZcaO3Ysvr6+9O7dm+DgYAoKCpgzZw5Wq5VHH30UgLD/HUH78ccf6dq1K3q9Hk9PT8xmMwsWLCA8PJzCwkImTJhQb7paWFgYCQkJ9O3bF41Gg8lkYvLkyXTs2JGhQ4cyfvx4zGYzJ0+eZM2aNYwfP55mzZo12me9e/fmjTfeQK1WK/fZu3dvnnjiCXQ6Xb2pQpd6/fXXadeuHS1btsTBwYFvvvkGFxcXgoODcXFxYfLkyUyePBmVSkWfPn2oqanh0KFD7Nu3j3ffffdyb6ed5s2b8+yzzzJ69Gjee+89OnfuTFlZGSkpKeTn5ysL30+cOEH37t0xm82kpKRw5swZJfBoqN9dXFzqXSsgIIC5c+cyZswYLBYLo0ePJjw8nPPnz7N27VoSEhLYunUrLVq0ID8/ny+//JJevXqxbdu2eovt4cIX9QkTJvDBBx/g6enJ66+/riQKgAvfx5YsWUJCQgIBAQF8/fXX7N692y55w7Rp0xg7diw+Pj488cQT1NXVkZCQwKBBgzCZTPWuGRYWxooVK0hLS8PHxwdXV1e0Wi1wYdrcxSlfl2Z6a0pVVZWSqe5iYHkliouLycnJobq6mlOnTrF8+XLmzZvH+PHjlSlmV9qPBoOBoUOH8sorrxAWFqZ8XuHCyOHmzZu577778PPz4+jRoxw8eLDR7HlpaWls376dmTNnEhMTY3fs+eef5/3332fr1q10796dMWPGMGXKFHx8fIiIiGDx4sVkZGRgNpuVcyZNmsQrr7zCHXfcQc+ePYmPj+fTTz/lk08+ueK+uiqNLS661i+gM7Dhku1JwKTflUkDgi7ZPgF4N1XvrZRU4bvvvhNz584Va9euFUuXLhXvv/++eO+998THH38sFi1aJDZu3CiSk5PFr7/+Kk6fPi0WL14spk+fLt566y2xcuVK8csvv4jFixeLZcuWiV27domkpCSxceNGsXr1arFw4ULx+eefi2XLlon4+HixYsUK8dNPP4l9+/aJn376ScybN0/Mnj1bzJo1SyxZskRs3rxZ7N27V3zwwQdi+vTp4vPPPxdpaWkiKSlJbN++XVnQKUmSJF1ff+WkCkIIsX//fvHwww8LPz8/4ezsLGJiYsSsWbNEVVWVfZtATJs2TdmeOXOm6Nq1qzCbzUKr1YqgoCAxZMgQkZaWppS5uEC+qYXbK1euFI888ogICAgQGo1GeHt7iz59+oiff/7Zrtz48eOF2WwWgJKYYMuWLSI2NlZotVoREREhfvjhBxEeHm7Xzri4OBEZGSmcnJzsEgQcPHhQ9OvXT3h4eAidTifCw8PF6NGjRWFhYZP9VVVVJVxcXOwW1hcVFQm1Wi3uu+8+u7K/T6rw1ltviZYtWwqDwSDc3NxE9+7d6yWuWLBggWjdurXQarXCw8NDdOzYUcybN6/JNl30+yQZNTU14t133xUtWrQQTk5OwsvLS3Tv3l0sX75cCCFEYmKi6NWrlzCZTEKr1YrmzZuLmTNn2tXZUL83JikpSfTv31+YzWah0WhEWFiYGDZsmNi3b59SZsqUKcLb21s4OzuLvn37im+//dbuM3KxzzZs2CAiIyOFRqMRHTp0ECkpKUodFotFDBw4ULi6ugqj0SjGjRsnpkyZIkJCQuzas3TpUhEbGys0Go0wGo3iwQcfFEVFRUKI+kkVCgsLRd++fYWbm5sA6iXiaNOmjYiOjm7y/i/13XffCZVKJY4ePXrF53BhaYkAhFarFcHBweLxxx+v929BiMv340X79+8XgHjvvffs9v/666+ib9++wsfHR2g0GhEcHCxeffVVUVlZ2WDbXn75ZeHv799o0pQ2bdooyRXKy8vF6NGjhaurq3B3dxdjx44V48ePFzExMUr5uro68d5774nQ0FDh6OgowsLCxIcffnjZPvqjSRVU4gZNo1KpVI7AEeAeIBvYCwwWQqRdUiYOWCaEWKRSqaKAzUCAaKKR7du3F8nJyde38Vfoww8/xGq1otfrMZlMeHl5kZOTg8ViwdHREWdnZ7y8vJQFbs7Ozjg4OLB+/XoKCwsxGAy0bt2aiooKiouL8fDwUJ5nVFVVRUlJCRaLRZle5+7uTl5eHmazGYPBwOnTp8nPz6eiogInJyf8/PwICgpS0nxWVVXRsmVLoqOjycvLw9PTk5iYmKseZpckSZKuXEZGhl3q5GthemZmvXVFknQ7WLRoEaNGjWr02Us3Q3V1NaGhoUyYMOGWfMhsU37++WcGDBjAmTNn8Pb2vmnt6N27N56enqxcufJP1dPU71uVSpUihGjf0LEbNmVOCFGjUqleAjYAauArIUSaSqV6iwsR24/AK8AClUr1Ty5EwCOaCoZuNe7u7litVmw2G2fOnKGgoIDAwEBMJhPZ2dmUlZVRVVVFUVERAQEBeHt7o9freeSRR8jNzSU+Pp4dO3bg5+dHZGQkOTk5/Prrr/j7++Pu7o5Op8NgMFBYWIjFYlGSKlwcNg0KCsLb25usrCwKCws5c+YMpaWlmEwmHnzwQX777TfS0tL47bffuPvuuxFCsG3bNsLCwm6pqYeSJElS02QwJEk3X11dHQUFBcyfP5+ysjJGjhx5s5t0xS4uy5g+fTpDhgy5ocHQoUOHSE1NpXPnzlRVVSnTG+Pi4m5YG37vho0QXS+30giREILDhw+zbNkyZZ+DgwPu7u4EBARQU1NDVlYWtbW16HQ6ZdGY0WhEo9Hg6elJcnIyBw4cQAhBZGQkvr6+5OTkUFtbS3BwME5OTlRWVlJRUaHMIXV0dCQwMBCr1YoQgqCgIAoLC8nKysJqtaJWqzGZTJhMJry9vdm+fTuFhYUYjUZ69OiBzWajqqqK1q1b4+bm1sQdSpIkSVfreowQSdLt6lYaITp58iRhYWH4+fkxd+7cP50c4UaaPn06M2bMoGPHjqxdu9Zu/c719uuvvzJq1CgyMjKoq6sjMjKS119/XVkT+Gf80REiGRBdB5WVlWzcuJGUlBRln1arxd3dHX9/fyVltlqtxmAwYDQa8ff3x9XVFZ1Oh7OzM3FxcZw7dw6dTkebNm0QQpCfn4+rqyuBgYFUVlZSXV1NSUkJxcXFVFRU4ObmpgRQF6ftZWdnk5+fT3l5OWq1moCAAPz9/ampqWH37t3YbDYiIiKIjY0lPz8fd3d3WrVqJdN0S5IkXSMyIJIkSboxZEB0CyosLGT58uVKik+VSoVer8fLywsPDw+ys7OpqKhAq9Wi1WqVKW9arVZJtb1x40ZKSkowmUy0atWK8+fPY7Va8fb2xmQyUVVVRWVlJcXFxVitVqqqqjCbzbi7u5Obm6sMgWZnZ1NYWEhdXR2enp7K84+ysrJIS0tTUiv6+PhQVFREaGiokj1GkiRJ+uNkQCRJknRjyIDoFnb06FG+++475TlAjo6O6PV6JcVodnY2Qgg0Gg0eHh4EBgbi6emJk5MTXl5eHDhwgN27dyOEICIiAn9/f2UaXWBgIHq9nurqaiorK5WkCnV1dcrwZ1lZmZKqNC8vD4vFgkqlwtvbG6PRiMlkYu/eveTn5+Pl5UWXLl2oqqqiurqaNm3a4OrqetP6TpIk6a9OBkSSJEk3hgyIbnFVVVVs3bqV7du3K/ucnZ0xGAz4+vpSUFCgZKPT6XTKQ8MMBgM6nQ5XV1fWrVtHVlYWOp2OO++8k9raWvLz8zEYDAQFBVFdXQ1ASUkJ+fn51NbWolarlTVFDg4OmEwmzp49S1FREWVlZTg5OeHv74/JZKKmpoZ9+/ZRVlZGWFgYbdu2JT8/H6PRSKtWrWQ2OkmSpD8gIyODyMjIW+7J7JIkSX8nQgh+++03GRD9FRQWFrJ69Wqys7OBC0+A1mg0eHl54e7uTnZ2NjabTQmCAgMD8fPzQ61W4+bmhsViIS4uDpvNhre3N9HR0Zw/f57S0lK8vLwwm83U1NRQW1tLUVERJSUlVFRU4OHhoawp8vT0RK1Wk5OTQ1FREXV1dXh5eWEymTAajZw8eZIjR46gVqvp2LEjRqMRq9VK8+bNCQwMvMk9KEmS9Ndy7Ngx/P39r8vT1SVJkqQLysvLOXv2LM2bN2/wuAyIbjFCCI4cOcL333+v7NNqtTg5OSkJE3Jzc5U1Rx4eHoSEhODh4YGDgwNeXl6kpKSwd+9e4MITiX19fcnNzaWqqorQ0FAMBgMVFRXU1NSQm5tLRUUF1dXV+Pj44OjoiMViwc/Pj/Pnz1NYWIjVasXBwQE/Pz88PT3R6/UcPHiQ/Px8TCYTnTt3xmaz4eDgQOvWreV/7JIkSVfIarWSm5tLQEAAer1ejhRJkiRdQ0IIbDYb2dnZ+Pj4NJoxWQZEtyibzUZCQoIS2ADKs4YCAwM5d+4cpaWlaDQaNBoNgYGBBAQE4OTkpEylW7duHWfPnsXZ2Zm2bdtSW1tLQUEBzs7OyholBwcHrFYrOTk5VFZW4ujoSEhICAUFBQgh8PDwoKCggKKiIsrLy9Hr9QQFBeHm5kZZWRmHDh3CZrMRGRlJVFQUhYWF+Pr6yikgkiRJV8hqtZKXl6dMbZYkSZKuHScnJ7y9vZt8fIwMiG5x586dY82aNUo2Oq1WixBCeWOzsrKoqqpCr9fj7u5OcHCwkjDBaDSSm5vLhg0bqKysJCgoiIiICM6fP09JSQlmsxmz2UxVVRU1NTVYLBZKSkqw2Wy4uroqD3L18PBQUntffJ7RxUx2Li4uHDlyhNOnT2MwGGjfvj16vR6bzUZ0dDQmk+lmdp8kSZIkSZIkNUkGRH8BdXV1pKamsm7dOmWfTqdDo9Hg7+9PcXExRUVFymiRj48PISEh6PV6NBoNRqORrVu3cujQITQaDTExMbi4uJCTk4ODg4PyUNeamhqqq6uV0aKamhrMZjNqtZqioiK8vLwoKSmhqKgIq9WqpAN3c3Ojrq6OgwcPUlxcTGBgIHfeeSclJSW4uroSGxsrky5IkiRJkiRJtyQZEP2FWCwWNmzYwG+//QZceHaRVqvFxcUFs9lMTk6OknTBYDAQGhqKj48PAB4eHtTV1bFmzRosFgseHh60adOGkpISrFar8mDY2tpaAIqKiigsLKSqqgoHBwcCAwPJz88HwNXVVTleXV2tjBbpdDry8vI4fvw4Qghat25NQEAA58+fp3nz5gQFBd2cjpMkSZIkSZKkRsiA6C/o+PHjrF69mrKyMuDCaJGDgwO+vr5UV1dTWFiISqXCYDBgNpsJCgrCxcUFBwcHzGYz6enpJCYmUldXR0REBAEBAeTk5FBdXY2/vz+enp5UVFQghKCwsJDS0lLKy8txc3PDy8uL3NxcnJ2dqaurw2KxUFRUhJOTk91o0dGjR8nLy8PLy4uOHTsqgVXbtm3R6XQ3uQclSZIkSZIk6QIZEP1FlZeXs3v3brZu3ars02q16HQ6/P39ycvLo6ysDJ1Oh16vJzQ0FF9fX1QqFS4uLhgMBn766SeysrJwdnZWnl1UWFiIVqslODgYlUqFSqXCarVSUFBgN41OCIHFYsHT05OysjKKioooLS3F3d2dkJAQNBoN58+f5+jRo1RWVhIREUFERARFRUUEBQURHh4uky5IkiRJkiRJN50MiP7isrOz+emnn8jNzQVAr9crzw4yGAycPXsWIQTOzs4YjUbCwsJwd3dHCIHRaCQnJ4d169ZRU1NDSEgIERERFBQUUF5ejpeXFz4+PlRVVSmjRcXFxcq0PD8/P3Jzc3F0dMTBwUFJygDg5+eH0WhECMGZM2fIzs7G2dmZDh064OjoSE1NDW3btsVgMNzM7pMkSZIkSZJuczIg+huorq5m3759xMXFKfsuJl3w9vbGarVSUlKi7AsNDSUwMBAhBC4uLri5ubF582YyMjLQarW0adMGrVZLTk4OarWa4OBgdDod1dXV1NbWkpeXh81mw2azYTQaMRgM5OTkYDAYqK6uxmq1UlxcjLOzM+Hh4Wi1WoqLizl69ChlZWWEhoYSHR1NaWkpJpOJqKgoHBwcbmIPSpIkSZIkSbcrGRD9jeTl5bF+/XoyMzOBC0FRbW0t7u7ueHp6cu7cOWprazEYDLi7u9OsWTMlpbaXlxdlZWWsXLkSm82Gr68v0dHRWCwWSktLcXNzIygoiMrKSjQaDQUFBcpokRCCwMBAzp8/T2VlJXq9nrKyMiwWCzU1NQQGBmI0GqmtreXs2bOcOXMGrVZL69at8fDwwGaz0bJlS7y8vG5yD0qSJEmSJEm3GxkQ/c3U1tZy6NAh4uLiqKqqAi5Mo1Or1Xh7e1NWVqakzHZyciIsLIyAgAAcHR3RaDR4eXmxY8cOkpOTUavVtGrVCqPRSF5eHrW1tQQEBGAwGKipqUEIQV5eHhUVFZSWluLi4oLJZOL06dNotVoAysrKKC4uRq/X06xZM3Q6HRaLhZMnT2KxWAgICCA2NpaysjKMRiMtW7aUo0WSJEmSJEnSDSMDor+pwsJCEhISSEtLA8DR0RG1Wo2zszPe3t5kZ2fbjRaFh4fj6elJTU2NMpqzatUqLBYLJpOJVq1aYbPZKCoqwtnZmaCgIIQQqNVqrFYrhYWFVFZWUllZiclkQghBUVERLi4u2Gw2LBYLlZWVBAYG4u3tTWVlJbm5uWRlZaFSqYiJicFsNlNRUSEf6CpJkiRJkiTdMDIg+hurq6sjPT2d9evXKym6nZ2dEUIoQYnFYkGn06HT6QgODiYwMFAZLfL09GTv3r3s2bMHgJYtW2I2m8nPz6e6uhofHx+8vLyoqKjAycmJnJwcSkpKKCsrQ6vVEhAQwLlz56iurkaj0VBeXo7VasXJyYnw8HAMBgOFhYVkZWVx/vx5fHx8iI2NxWaz4enpSatWreRokSRJkiRJknRdyYDoNmCxWNiyZQsHDhwAwMHBQZky5+3tTU5ODjU1Nbi6uuLh4UGzZs3w9PSkuroao9GISqVizZo1ynOFYmNjqaiooKioCK1WS2hoKLW1tTg6OlJWVkZBQQEVFRVKYKPX6zl79qySAc9isWCz2QgMDMTX11cZLcrOzkYIQcuWLfHx8aGsrIyoqCjl4bKSJEmSJEmSdK3JgOg2UVdXx2+//cb69euV1NgXR4u8vLyora3FYrGg0WjQ6/UEBwcTFBSEWq1Go9FgNBr59ddf2bJlC3V1dcTExODj40N+fj4VFRX4+vri7e1NRUUFGo2G3NxcrFYrZWVlStKFwsJCbDYbGo2GqqoqLBYLWq2WZs2aYTAYyM3NJScnh6KiIsxmM9HR0dTU1ODh4SFHiyRJkiRJkqTrQgZEtxmLxcL27du52C+Ojo5otVpUKpUyHe7iaJHRaCQ0NBSj0aisLXJwcGD16tXk5ORgNBqJjY2lqqqK8+fPo9VqCQoKwsHBAUdHR8rLy5WkCzabDTc3N9zd3Tl16hQajUZ5dlFFRQUBAQEEBARQUlJCYWEh2dnZAERERODn50dFRQVRUVGYzeab2X2SJEmSJEnS34wMiG5DdXV1HD58mA0bNlBcXAz832iRh4cHtbW1WK1WnJ2d0el0hISEEBAQgIODgzJalJaWRkJCAkIIoqOj8ff3p6CggLKyMnx8fJQHuqrVagoKCigtLaWkpOT/Z+/OYuTKszu/f29sN/Y9MjO2jNyCzI1rsaq7oR6N1dAIggzIAiRbHo88L7b8ZPjBgB/84hkPYMAGDNhjYPzgMWDYsA21elMvUrnVXaheqlhdWxbJJJPMfc+IjP3GHvdGxPUDi1ddrVKL6mZVklXnAxAo3gxkXPwBAnXwP+d3GI1G5HI5qtWqlXY3HA6t9rulpSXsdjuFQoFKpUKj0SAajbK0tMRoNCIajbK6uiq3RUIIIYQQ4pmQguhzrF6vWxHbAE6nE6fTic1mIx6PU6lUGI/HVjLd3NwcwWAQXdeJRqPY7Xa++c1vcn5+TiwWY2VlxVrMarfbmZ2dRVEUbDYbvV6PSqWCruu0Wi28Xi/xeJz9/X1rpunJbFE6nSaXy1Gr1ahWqxQKBUzTJJ/PG6alGwAAIABJREFUMzExwXA4lL1FQgghhBDimZCC6HNuNBqxsbHBD3/4Q5rNJvD4tmg0GhEMBgGs2yKfz2ftLRqNRqiqSiwWY319nR/96EdWIEIymaRWq9Hr9YjH40xNTdHr9fB4PBSLRTqdDp1OB13XSafTtNttzs/PCQQCH7ktWllZAeD09JR6vU6tViORSLC0tIRhGFYRJrdFQgghhBDiVyUFkQAe7y26ffs2a2trANaMj9PpJBwOU6/XrZucJ7dFoVDIKkwAvvGNb3B+fk48Hmd1dRXDMGg0Gtjtdubm5lAUBbvdTr/fp1QqMRgMaLfbqKrK5OQkBwcHjEYj/H4/tVqNfr9PNpsll8tRLBap1Wqcn5+jKAqLi4uEQiFM0+Tq1auEQqGLPD4hhBBCCPGCkoJIWIbDIY8ePeKv//qvrSS6QCDAYDAgEokwGo1ot9t4PB6CwSBzc3OkUil0Xcfr9RKJRHjnnXe4ffs2DoeD5eVlJicnqVardLtdJicnSSaT9Ho93G435+fntNttOp0Og8GAyclJer0epVIJv99v3RZ5vV5WV1cZjUYcHR2haRqNRoOJiQnm5+cBmJqa4tKlSyiKcpFHKIQQQgghXjBSEIm/pVQq8eabb3Lv3j0AVFW1kuP8fj+tVgu73Y7b7bbmfbxeL8Ph0Irw/trXvmYtW71y5Qrdbpd6vY7L5SKfzzMajazboid7i1qtFi6Xi2Qyyd7eHsPhEJ/PR71eR9d1qwA7OTmh0WhQqVRQFIWlpSX8fj+KonDjxg18Pt8Fn6AQQgghhHhRSEEkPpau66yvr/P666/T6XSAv7ktisfj9Ho9er0efr/fui16Eo/t9/sJhUJWvLfb7eby5ctEo1Hq9bq1lDWRSNDv93G73ZyentLtdmm32wwGA6ampuj3+xSLRQKBALquo2kafr+f1dVVdF3n4OCAdrtNo9EglUoxNzfHcDgkl8sxOzt7wScohBBCCCFeBFIQiV/q9PSU27dvs7GxAYDH4wHAbrfj8/loNpu4XC58Ph/T09NMT0/jcDisha+dTodvfOMbNJtN0uk0KysrNJtNqxUun89jGAZOp5N2u02lUmE4HNJsNnE4HKTTaXZ2dj5yWzQajVhYWLBukjRNo1qtoqoqly5dst7n6tWruN3uizw+IYQQQgjxnJOCSPy9er0ea2tr3L59m263C0AoFELXdYLBIL1ej+FwaEVpz87OWrdIkUgEv9/P97//fTY2NvB6vSwvL1vBCYZhMD09TSQSQdd1nE4nhULBaqF7clvU6XSsJLrBYECz2SQajbKyskKj0eDk5MSaR8pkMlYSXj6fJ5PJXPAJCiGEEEKI55UUROKpmKbJwcEBP/3pT9nf3wfA5/MxHo9xuVzWDY+qqgQCAebm5shmswyHQ5xOJ7FYjGKxyPe+9z06nQ65XI7Lly/TaDTQNI1gMMj8/DyDwQBVVWk2m9RqNXRdt26hJicn2djYwG63EwwGqdVqVtR3MBjk0aNH9Pt96vU6brebhYUFHA6HFc/tcDgu+BSFEEIIIcTzRgoi8Q+iaRrvv/8+7777Lv1+H7vdjt/vp9/vEwqF6Ha72O12XC4XqVSK2dlZAoEA/X6fWCyGqqp861vf4ujoiHA4zOLiIm63m2q1imEY5PN5K6ABoFwu0+v16Ha7dLtdMpmMFb8djUatnUapVIqlpSVOTk6s9LrBYMDs7CzhcBiHw8Hq6iqRSOSCT1AIIYQQQjxPpCAS/2BPlrm+9dZbFAoF4G8CFzweD4qi0O12CQQChMNhZmdnrcCFJ/Hcjx494vXXX7fmgaanp6nVarRaLWKxGDMzM3S7XbxeL9VqlU6nQ7vdRtM0vF4viUSCBw8e4Ha7cbvd1Ot1HA4HN27cwGaz8ejRI3Rdp1qtEolEmJmZwWazkU6nJZ5bCCGEEEJYpCASv7Jyuczbb7/N2toapmnidrux2+2YponH46HT6aCqKj6fj2w2y8zMDHa7nfF4TCwWw2az8Wd/9meUy2Xi8TjLy8uMx2M0TQNgYWEBu92OzWZjPB5TLBatZa69Xo9sNsv5+TnVapVYLGbNHE1PTzM7O8vu7i6aptFut63Cy+124/P5uHbtmhUQIYQQQgghPr+kIBK/lsFgwP3793nrrbeoVqvA48CFXq+H1+tlNBoxGo3wer3EYjHm5+eJx+N0u10ikQiBQIC33nqLn/3sZ6iqSj6fJ5lMUq1WabVapFIppqenabfb+Hw+qx2u3W7TarXwer34/X52d3cJBALYbDbq9To+n48bN27QbrfZ29vDMAwajQZTU1Mkk0nsdjvz8/Nks9kLPkEhhBBCCHGRpCASz8TR0RFvv/22Fc/95LZoPB6jqqq1b+jJzqJsNothGDgcDqLRKK1Wi69//eu0Wi2y2SxLS0v0ej0qlQoul4vLly8zGo1wuVwMBgPK5TKDwQBN06zdQ5ubmwwGAyYmJqwEu6WlJZLJJHfu3GEwGNBoNHC5XMzNzeF0OonH46yurkrgghBCCCHE55QUROKZaTabrK2t8d5771nLXMPhsDULZBgGNpsNr9dLOp1mbm4Ov99Pr9cjGo2iqip/+Zd/yfb2NsFgkHw+b6XJ9Xo9FhYWCIfD6LqOqqoUCgWrhU7TNKLRKACHh4dEIhEMw6DZbDI5OcnVq1c5Pj7m5OSE0WhkBTFEo1FcLhdXrlyRwAUhhBBCiM8hKYjEMzUajdjc3OT27ducnp4CfxO44HK5ADAMA7/fTzweZ2ZmhlQqRbfbxePxEA6H2d7e5rXXXmM8HpPNZllYWLCWuUYiEebn562WvEajQb1eZzAYUKvVAMhkMmxubqIoCoFAAE3TsNvtXLt2Dbvdzv379zFNk0ajgd/vJ5PJ4HK5yOVyzM3NSeCCEEIIIcTniBRE4hNRKpV4++23uXv3rtXq5nQ6rb1FTwqkcDjM9PQ0mUwGh8OBaZrEYjEAvvrVr3J+fs7ExAT5fB6Hw0G9Xmc8HpPP53E6nQDY7XbrtqjVatFqtZicnKTZbFIqlYhGo/T7fTqdDrOzs+TzeTY2Nmi1WrTbbUzTZH5+HqfTSSgU4sqVK7jd7os8PiGEEEII8SmRgkh8Ynq9Hnfu3GFtbY1KpQI8bqHrdDq4XC4URbF2FqXTaebn5wmFQrRaLSKRCH6/n9u3b/P++++jqiqzs7NMTU3RbDZpNBqk02kymQztdptgMEixWLT2FTUaDex2u7XM1e1243K50DQNn8/HSy+9hKZp7OzsAI/3KyWTSSKRCE6nk9XVVRKJxEUenxBCCCGE+BRIQSQ+UePxmL29Pd577z02NzcB8Hq9jMdjxuMxDoeD4XBIMBgkHA4zNzdHKpWi1+vh8XiIRCJUKhW+9a1vWYtZFxYWMAyD8/NzfD4fS0tLGIaBy+VC13XOz8/RdZ1Op0Oz2SSTyXB4eGgth9U0jdFoxPXr1/H5fKyvrzMajdA0DZfLxczMDA6Hg0wmw6VLl7DZbBd8ikIIIYQQ4pMiBZH4VFSrVT744APW1tbo9Xo4HA7cbje6ruPxeD6SQpfNZsnlclZrXTwex+l08s1vfpPDw0Oi0SgLCwsEAgHK5TK6rnPp0iUCgQC6ruPz+Tg+PsYwDFqtFpqm4ff7URSF4+NjgsEgpmnSbrfJZDLk83n29vYol8sAVuHl8XgIBoNcu3YNr9d7wScohBBCCCE+CVIQiU/NYDDg0aNHvP322xQKBQCCwSD9fh+73Q6Aw+HA4/GQTqeZnp4mHo/TbDYJh8MEAgE++OAD3nzzTZxOJ9ls1tpRVKlUmJiYYH5+nlarRTAYpF6vU6/XMQyDarXKaDQimUyyvb1tfbemabjdbm7cuEG/3+fRo0fYbDZqtRrhcJhkMmnFfqdSqQs7OyGEEEII8cmQgkh8qkzT5OjoiPfee48HDx5gmiaqquJ0OtF1HYfDwWg0IhAIEAqFmJ+fJ5VKMRgMrJ1FnU6Hr33ta2iaZsV32+12isUiLpeL5eVlxuMxdrsdu93O6ekpo9HImj1KJBLU63UqlQrxeJxer8dgMGBlZYV4PM6DBw/o9Xp0Oh3sdjvZbBaHw0EymWRlZcUq3oQQQgghxItPCiJxIer1Onfu3OGDDz6g1WpZEdn9ft8qip6k0OVyOTKZDKqqous6sVgMl8vF9773Pba2tohGo2SzWWKxGPV6nU6nw8LCAvF4nH6/j9frpVQqWUVOo9EAHgc87O7u4na7cTgctFotpqamWF5e5vDwkPPzc2w2G5qmkUql8Hq9hEIhrl27ht/vv+ATFEIIIYQQz4IUROLC6LrOw4cPWVtb4+joCIBQKES/37cCF5xOJ6qqWu1x8XgcTdOsFrrNzU1ee+01bDab1Wan6zrlcplIJMLCwoI1n9Tr9SiXy9Zs0ZOkuoODA3Rdt3630+nkxo0bGIZhtdBpmkYgECCRSKCqKktLS9JCJ4QQQgjxGSAFkbhwx8fHrK2tWWlvbrcbVVXpdrsfaaF7UuAkk8mPtND1+32+9rWvUa/XSSaT5HI5PB4PxWIRm83G8vIyADabDVVVOTk5Qdd1ut0ulUqFQCBgpdZFIhEMw6Df77O4uMjExAQbGxv0+316vR6maZJOp3E4HGSzWZaWlqSFTgghhBDiBSYFkXgu1Ot11tfXef/992k2m8Dj26Jut4vNZmM8HuN2u4lEIkxPTzM9PW2l0MViMVRV5a/+6q/Y2dkhGAySyWSYmJig0WjQaDSYm5tjamqKXq9npdM1m00GgwHVahXDMIjFYhweHqIoCj6fD03TmJqaYmlpidPTUwqFAjabjWazyeTkJD6fj3A4zNWrV6WFTgghhBDiBSUFkXhuPGmhu3PnDgcHB8DftNANh0Psdjsejwe3200mkyGXyxGLxWg2mwSDQYLBIJubm/zwhz/EbrczMTHB3Nwcuq5TKpWIRCJcvnzZ2nE0GAw4Pz9nNBpRrVatAujJgtdYLEa73cbhcHD9+nVGoxEPHz60iiK/3088HsftdrO4uCgtdEIIIYQQLyApiMRzxTRNDg8PuXfvHhsbGwwGAzweD06nk16vZy1JDQaDRCIR5ubmyGQydDodXC4XkUiEwWDAn//5n1Ov10mlUqRSKSKRCGdnZ5imabW52Ww2PB4Ph4eHjMdjms0mtVoNp9OJzWajWCzi8/lQFIV+v8/S0hKxWIzt7W06nY4165RKpbDZbMzMzEgLnRBCCCHEC0YKIvFcqtVq3L17lzt37lgtdNFolEajgdPpZDwe4/F4iEaj5HI5pqensdvtH2mhe/XVV9na2iISiZBMJpmamqLRaFCr1cjn80xOTn6kha7VajEYDKykulAoRKFQQFEU/H4/mqYxOTnJ4uIihUKBs7MzHA4HjUaDVCqFw+FgYmKCq1evyiJXIYQQQogXhBRE4rk1GAzY2NhgfX2d/f19ACKRCJ1Oh+FwiMPhQFVVAoGA1UIXDodpNBqEw2GCwSAPHjzgRz/6EU6nk4mJCXK5HAAnJyfE43Hy+bzVQjccDikWi4zHY2q1GtVqlUgkQqPRoNfrfWSJ7LVr1+j3++zv71tFkdfrJRqN4na7WV1dZWpq6iKPTwghhBBCPAUpiMRzbTwec3BwwJ07d9je3rYitJ1OJ51OB4fDgd1uJxAIWAVPOp2m2WxaIQxPFrm2Wi3S6TSpVIpgMMjR0REOh4OVlRUURbHCFE5OTqxo7lqthqIo2Gw2KpUKHo8H0zQxDIOlpSVCoRC7u7t0u10GgwGj0YhkMondbiefz7OwsGC1+QkhhBBCiOePFETihVAqlVhfX+fevXtWC10kEqHVamGaJoqiEAwGCYfDzMzMMD09zXg8ZjgcEo/HcTqdfPe732V/f59IJMLExATpdJpqtUq9XmdxcZF4PM5gMCAQCFAqleh0Oui6TrVapdlsEo1GKRQKAFYLXSqVIp/Pc3JyQqFQ+MiCV5vNRjKZ5Nq1a3g8nos8PiGEEEII8XeQgki8MDqdDpubm9y5c4fj42PgcVH05HbGZrPh8/mIRCJkMhlmZmbwer20Wi2i0Sg+n4/19XV+8pOf4HQ6SSQSzMzMMBqNODk5YXJyknw+T7fbxe/3MxgMKBaLmKZJo9GgVCoRCoVoNpv0ej28Xi/9fp9AIMCVK1dotVrs7u6iqqrVbuf1egkGg1y7do1YLHbBJyiEEEIIIX6RFETihTIej9nZ2eHu3bvs7Oyg67qVBNdut7HZbHi9XgKBAJOTk+RyOVKplDXjEwqFqFarfPvb36bT6ZBOp5mamiISibC/v4+qqqysrDAej3E6nbjdbk5PTxkOhzSbTSqVCgCKolCr1XC73dhsNgzDYGVlBbfbzf7+vrX4VVEUEokEdrudxcVF5ufnURTlgk9RCCGEEEI8IQWReCGdnp6ysbHB/fv3aTab2Gw2AoEArVaL8XiMy+UiHA4Ti8XI5XJks1krtjsSiWC32/n6179OsVgkHo8zMTFBMpmkXC7Tbre5fPkywWCQ4XCIz+ejXC5bLXT1ep1arUY4HKZarTIajfB6vbTbbXK5HJlMhkKhQLVaBaDVapFMJgHI5XJcuXIFp9N5kccnhBBCCCE+JAWReGE1Gg0ePHjAxsYGZ2dnwONobk3TGI1GwOPFrtFolNnZWdLpNA6Hg8FgYKXBvfHGG6ytrREMBq3iyTAMjo+PmZ6eZnp6+m+10AFomkaxWERVVXRdp9PpEAwG6Xa7BAIBVlZW0DSNk5MT7HY79XqdWCyG0+kkFotx8+ZNAoHAhZ2dEEIIIYR4TAoi8UIzDIPNzU3W19fZ3d1lNBoRCAQYjUZ0u13gcQBCIBCwCpwn+4xCoRCBQIDj42O+973vATA1NUUymSQYDLK7u0soFGJpaYnBYIDb7cbhcFjFl6ZpnJ+fo+s6Ho8HTdNwOBwoisJ4PObq1auYpsnR0ZG1+NXpdBIOh/H5fKyurpJKpS7s7IQQQgghhBRE4jNgPB5zeHjI+vo629vbtNttVFXF7XajaRoAHo+HUCjExMSEVRg1Gg3cbjehUAhd1/nqV79Ku922Zoqy2SyHh4cMh0OWl5dxu92Mx2MCgQCFQoFer8dgMKBWq1Gr1fB6vVYCntPpxDAM5ufnCYfDFAoFNE1jPB7T7XbJZDKMRiMWFxfJ5/PY7faLPEIhhBBCiM8tKYjEZ0a5XGZjY4MHDx5QLpeBxyl07XYbwzCw2+1EIhGrNW56ehpd1xmNRsRiMVRV5dVXX2V7e5toNEooFGJmZoZ2u02hUCCfzzM5OclgMMDv99Nut605oVqtxtnZGR6PB8Mw6Pf7eDweer0eyWSSbDZLs9m0Wug0TWNiYgJFUUin0xLNLYQQQghxQaQgEp8pnU6Hra0t7t27x/HxMaPRiHA4zGAwoNfrARAOhz8Sze12u2m320SjUTweDxsbG7z++us4HA4mJyfJZDK4XC729/eJx+MsLCxgGAZerxdFUawFr0/mikzTxDRN66ZqNBqhqiqrq6v0+32r5a5arRIOh602ups3bxKNRi/y+IQQQgghPnekIBKfOcPhkJ2dHR4+fMj29ja9Xg+/34/NZrNa2nw+H8FgkOnpaTKZDFNTU1QqFYLBIMFgkFKpxHe+8x10XSeVShGNRkmlUmxvb+NwOFhdXQXA4XDg9Xo5PT1lMBjQ7/cplUpomobf77cWxzqdTobDIUtLS7hcLs7Pz+n1evR6PcbjMZFIBIfDwfXr18lmsxLNLYQQQgjxKZGCSHxmHR0dsbGxwebmJo1GA5vNRjgctlLonswPPbkFmpmZodFooKoqoVAI0zT5+te/TrlcJpVKWcEMhUKBVqvF6uoqfr+f0WiE3++nXq/TaDQAOD8/p1Qq4Xa70XUdwzBwOBwYhsHs7CzRaJRms0m5XEZRFDRNY2pqitFoxKVLl1hZWZG5IiGEEEKIT4EUROIzrVqt8vDhQzY2NigUCgDEYjFarRa6rmOz2YhGo0SjUaanp5mZmWE4HDIcDolGozidTn784x9z9+5dEokEXq+X2dlZhsMhh4eHzM7OkslkrBa64XBIoVDAZrNRq9UoFAoMh0OcTifdbheXy4VhGESjUXK5HP1+n/Pzc0ajEY1Gg4mJCQCSySQ3b96UuSIhhBBCiE+YFETiM+/JXNH9+/c5OjpiOBwSCAQYDofWXFEgECAWi5HNZsnlcni9XjRNIxaL4fV62d7e5rXXXkNRFCYnJ5mYmCASibC5uUk8HiefzzMcDnG5XHg8Ho6OjoDHS1mLxSKdTgeXy0Wn07FufpxOJysrK+i6TrVaZTAY0Gg08Pl81mLZ69evW0WSEEIIIYR49qQgEp8LT+aKtra22NnZodVq4fV6cTgc1lyRx+Ox4rZ/ca4oEAjQarX4xje+Qb/fJ51O4/P5mJ2dZXNzE4DV1VWcTid2ux2v10u5XKbdbqPrOpVKhVKpZIUs6Lpu3RYtLi6iqirNZpNms0mn0/nIXNGVK1eYmZmRuSIhhBBCiE+AFETic+X4+JjNzU0ePnxIrVaz5ooajQbj8RiXy0UkEvmlc0Xf/va3KRQKJJNJVFUln89TLpepVCqsrq4SDocZDodWqEKpVLJa6E5PT7Hb7SiKwnA4BB4Xa9lsllgsZrXQmaaJpmmkUin6/T7Ly8ssLy/LXJEQQgghxDMmBZH43KlWq2xubrKxscHp6SkAwWAQwzCsFrpEImHNFc3Ozlr7iiKRCC6XizfffJP333+fSCSC3+8nl8uhKAp7e3vMz8+TTCYZjUb4fD7G4zFnZ2coikKj0eDs7IxOp4Pf76fX66EoihUPnsvlMAyDSqXCaDSiWq0SjUax2WykUimZKxJCCCGEeMZ+WUHk+LRfRohPQywW49q1a3i9XrxeL8fHxzSbTfx+P263m36/T7lcpt/vYxgGhmGQy+Vwu92USiWi0Shf/vKXmZyc5Ac/+AG9Xg+bzUYkEuHKlStsbGzQarVYWFig3W7jdrvJ5XKcnZ0RCoWs26JyuYzX68UwDACazSYPHz5keXmZRCJBq9XCbrdTqVTw+XycnZ3Rbre5desWsVjsgk9RCCGEEOKzT26IxGfak7mizc1N9vb2aDabeL1eXC6XFZ/tdruZnJwknU6TzWaJx+NUq1WCwSB+v59Go8G3vvUtBoMBmUwGVVVZWFhga2sL0zS5cuUKTqcTm82Gx+OhWq2iaRqKonB+fs7Z2RkulwubzcZgMMA0TRwOB/Pz86iqSrvdptPp0Ol00HXdKoRu3rzJ9PS0zBUJIYQQQvyapGVOfK6Nx2NOTk7Y2tr6yFxRJBKhWq0CYLfbicfjZDIZMpkM09PTVKtV3G43wWAQ0zT57ne/y9nZGel0GrvdztLSkrWL6OrVq9bnPB4P3W6XUqmE3W63orl1XUdVVXRdZzweMx6PSafTxONxBoMB9XqdwWBg7SvSdZ2VlRWWlpZkrkgIIYQQ4tcgBZEQQLlctsIWnuwFCoVC9Pt9BoMB8HiuKJlMMjU1xfz8PO12G4BIJIKqqvz0pz/lgw8+IJFIoKoquVwOh8PB9vY28/PzpFIpRqMRXq8Xm83G0dERiqLQarU4PT1F0zQCgYB1U/RkF9L09DTj8ZhKpYJhGFSrVeLxOKZpkk6neemll3C73Rd5fEIIIYQQLywpiIT4UKvVYnNzk62tLU5OTuj1evj9fsbjMd1uF3i8ryiVSpFOp5mbm8M0TbrdLrFYDLfbzaNHj3jttdfw+XxEIhHC4TDJZJL19XUSiQSXL1+20uw8Hg+np6dWmEOpVKJQKBAIBBiPx+i6DoCqqszPz6MoCs1mE13XKZVK+Hw+6/bq5ZdfJhwOX+TxCSGEEEK8kKQgEuLnDAYDa1/R3t4e7XYbj8eD0+m09hWpqkoqlSKbzZLNZgkEAtTrdaLRqDUn9Bd/8RdW25vL5eLy5cs8ePAAgKtXr2K327Hb7fh8Pmq1GpqmYZom5XKZ4+NjbDYbTqeTwWBgFVALCwu4XC76/T6tVgtN0xiPx1ZQw8svv0wmk7nI4xNCCCGEeOH8soLI9mm/jBAXTVVVlpaWuHLlCsvLy8RiMXq9Hr1ezwo0GAwGHB8fs7e3x87ODqVSiYmJCTRNo9lsEo1G+ZM/+RMikQgHBweMRiPu3bvH5cuX8fl8vPfee9aNU7vdtvYemaZJKpVibm4ORVHo9/sEg0GcTie6rvPw4UOazSaqqhKNRgmHw6iqSrVaxWazcfv2bR49esR4PL7IIxRCCCGE+MyQGyLxuXZ2dsbW1hZbW1uUy2WGwyGRSMRKfAOYmJhgenqaRCLB/Pw8jUYDu91OOBzG4XDw+uuvs7GxQSqVQlEUZmdnMU2T3d1dFhcXSSQSVtjCx80VVatVIpEIo9GIfr+PoihEIhHS6bT1OU3TqNfrJBIJDMMgn89z9epVXC7XBZ+gEEIIIcTzT/YQCfF3SKVSuN1u3G43m5ubFItF6vU6Pp8Ph8NhpcWZpkm/32c4HLKwsEC/37cKma985StEIhHefPNNQqEQ+/v7TExMcP36de7evUu73WZ2dpZ+v4/D4WB2dpZCoYCiKKiqiqqqFItFvF4vHo/HWto6HA7J5XL4fD6cTidOp5NKpYLf72dnZ4dGo8EXvvAFAoHARR+jEEIIIcQLSwoi8bkXjUa5cuUKXq+Xzc1NKw3O5/MRDAZpNpuUy2Xa7TbD4ZDRaMTMzAw+n49SqUQ8HufmzZvEYjFeffVVBoMBqqrSarW4desWd+7cod1us7S0ZLW6TU1NUavVrN/ldDo5Pj5GVVXcbjfj8Zh6vU6/32dmZgZVVQmHw7hcLs7Pz3E4HNTrdX70ox/x8ssvMzU1dcGnKIQQQgjxYvo7Z4gURRkrijJ6mj+f5gsL8Unw+XwsLS2xurrKwsIC0WiUTqfDYDCwkt16vR67u7scHBywtbVFq9Wylri2Wi0ymQx//Md/jKqqHBwcYJomd+/e5dq1a5imydraGoZhMBwO6XQ6RCIRJiZD/bWlAAAgAElEQVQmGI1G5HI5Ll26hM1mo9ls4vF48Hq99Pt967ucTqeVaGe329E0jdFoxJtvvsne3h4vevurEEIIIcRF+DtniBRF+SPgyQ8ngX8FfAt468NnXwL+APgXpmn+r5/we/6dZIZIPEvj8ZijoyO2t7c5ODigUCgAEI/HKZfL1ueeLHBNpVJkMhmq1SqqqhIMBhkOh/zgBz/g6OiIXC6HrussLi7SarU4OTmxlrgCeL1eAI6Pj7Hb7TQaDU5PT6nVakSjUXRdt1Lo0uk00WgUm81Gu92mXq/TbDaZmppiMBiwtLTEysqKLHEVQgghhPgFv3bstqIo3wG+a5rmv/2F538K/IFpmv/uM3nTX4EUROKTUCgU2NnZYXt7m2q1SrfbJRgMous6/X4feBy2kM1mSSQSLCws0Gw2rUAEu93O7du3WVtbI5lM4nA4SCaThEIh1tfXWVhYIJlMYrPZcLlcqKrK6ekp4/GYTqfD0dER5+fnBINBHA4HvV4PwzCIRqNkMhnsdju6rlOtVqlUKkQiEUzTJJfLcePGDTwezwWfoBBCCCHE8+NZhCp8BfgvP+b568D//Ku+mBDPq2QyabWtbW1tUSgUaDabeL1e/H4/7XabUqmEYRhWG9ylS5fo9/uUSiVisRhf/vKXiUajvP766/j9fux2O+12m5dffpm1tTXa7TYLCwsfuQEql8sYhsH8/Dwej4eTkxPsdjt+v98KchgOh2SzWVwuFxMTE7hcLsrlMn6/n6OjIzqdjixxFUIIIYR4Sk+7h6gC/NHHPP8joPwxz4V44YXDYWuuaGZmhnA4TLfbZTgcEgqFAKjX6+zs7HB6esqjR49QFIVAIECpVKLb7bK0tMQf/MEfMBgMKBaL6LrOgwcPuHXrFq1Wi7t37zIcDtF1nU6nQyKRIB6PAzA3N8fMzAwAjUYDt9uN1+tF0zS2t7fpdDrY7XZisRjpdJpOp0Ov16PZbPKTn/yEs7Ozizo6IYQQQogXxtO2zP1z4P8AfsjfzBB9Efht4D8xTfP//MTe8O8hLXPik2YYBnt7e+zt7XF4eGilvPl8PjRNA8ButzMzM0MmkyGbzRIKhajVaoTDYbxeL81mk1dffZV6vc78/DydTocrV65wdHREq9Xi2rVrqKqK0+m0orfPzs5wuVxUKhWOjo5oNBpEo1EURaHZbGKz2chkMoTDYWvJa6FQQNd1YrEYhmFw48YNFhYWUBTlgk9RCCGEEOLi/NozRB/+ki8A/wWw9OGjh8D/Yprm28/kLX9FUhCJT8OTsIW9vT329/cpFouMRiOi0SjVatX6XDKZZHp62gpdeBK2EAgEGI1GvPbaa+zv7zMzM4Ou68zOzgKwu7vL6uoqoVAIRVHw+XwoisLZ2RmmadJqtTg+PqZcLhMIBFAUhcFggK7rJJNJq3VO13UKhQKNRoNUKkWv17NuuSRsQQghhBCfV8+kIHpeSUEkPk2FQoG9vT12dnaoVCq0222CwSD9fh9d1wFIJBLMzMwwMTFBPp+nWq3icDgIhULY7Xbefvtt3n33XdLpNA6Hg2g0ytTUFHfu3GFubs6K1Xa5XNYNUavVAuDw8JDT01NUVcXr9aLrOt1ul2g0SjqdRlVVTNOkXC5TLBaJRCKMRiOmp6e5deuWhC0IIYQQ4nPpWYQqoCjKJPAfA3PAf2OaZkVRlN8AzkzT3H82ryrE8y2ZTKKqKi6Xi52dHc7Pz60lrk+WsT4JRjAMw4rcbrfbVKtVIpEIX/rSlwiFQvz4xz/G4/HgcrnY39/n1q1brK2t0el0mJ+fxzRNxuMxiUTCWsSaz+dxuVxWyEMoFMJms1GtVjEMg2w2i8fjIZlM4nK5OD09xev1cnp6Sq/X45VXXpGwBSGEEEKIn/NUoQqKorwEbAL/DPhPgeCHP/onwH/3ybyaEM+naDTK8vIyS0tLZLNZIpEInU4HXdeJRCLA4xCEra0tzs7OuH//Pi6XC6/XS7lcptfrsby8zO/93u9hGAbHx8fYbDbu3bvHyy+/TLvd5t69e1ZB9WSJazKZtNrsstksqqpSq9VwOp2EQiFarRa7u7t0Oh2GwyGRSISFhQUrKlzTNH70ox9J2IIQQgghxM952pS5/xH416Zp3gAGP/f8+8BvPPO3EuI55/P5WF5eZnl5mXw+z9TUFKPRyLq1Aeh2u2xtbVkJdL1ej0gkQrVapd1uk8lk+MM//EMCgQBbW1sEg0Hee+898vk8Ho+H999/H13XMQyDTqeD2+1menoawzDIZDLMzs4SCoWoVCrYbDbC4TCGYbC5uUmpVGI4HOLxeJibm8Nut6NpGqPRiDfffJPd3V1e9HZZIYQQQohn4WkLopeAj0uSKwCTz+51hHhxuFwuLl++zOXLl8nn89YC1larRTD4+BLVMAy2trbY399nf3+fer1OIpFA0zTa7TahUIjf//3fZ3Z2locPH+L1ellfXycUCjE9Pc0777xj3T51Oh0ApqensdlsxONx63ur1Sr9fp9QKISqqhwfH3N2dka/38fpdJLP5/H5fJRKJVwuF2+//Tbr6+sMh8OLPEIhhBBCiAv3tDNEPSDyMc8XgdKzex0hXiw2m425uTlUVcVut2Oz2ajVajSbTYLBIIPBgMFgwNHREb1ej9FoRK/XY2ZmhkqlwnA4JBgM8tu//dv87Gc/4+7du6TTaQ4PD4nFYly/fp07d+6wsLDA5OQkuq5js9mYmpqiXq8zGo2YnZ3FbrdTKBQwDINQKITD4aBYLGIYBqlUCq/Xy6VLlzg6OuLs7IxYLMb9+/dpt9u89NJLqKp60UcphBBCCHEhnrYg+jbwLxRF+fc//LupKMoM8D8A3/gE3kuIF0o6ncblcqGqKnt7e1aLmsfjwe/30263PxK2MBgMuHTpEpqmUavViEQifPnLXyYQCPDmm28SDAbxeDzs7+/zyiuv8O6779LtdpmZmcHhePzPNhqN4nA4qFarXLp0CYfDQalUolqtEovFCAaDVCoVBoMB2WyWYDBILpezbpC8Xi9HR0d0u11eeeUV61ZLCCGEEOLz5GkXswaBvwKuAj6gyONWuTeB3zNNs/NJvuQvI7Hb4nnSbDbZ3d1lb2+P8/NzqtUqdrsdv99PvV4HIBgMMj8/TywWY3FxkX6/T7/fJxwO4/P52N7e5rXXXsPhcDA7O0ur1eLGjRvcvXsXp9PJ6uoqNpsNVVXxeDx0u13Oz89RVZWjoyOKxSLNZpNYLAZArVaz5o/C4bCVhrezs2NFe/t8Pr7whS8wMTFxkccnhBBCCPGJeGZ7iBRF+Qpwk8ezR2umaf7w2bzir04KIvG86Xa77O7ucnBwwOnpKeVyGYBQKGQVRaqqsrCwQCKR4PLlyyiKQrPZJBKJ4PF4KBaLvPbaa7TbbVZWViiXy1y7do39/X3a7TavvPIKgJVeNxwOKRaL2O12zs/POT09pVqtEg6HcTgctNttax9RLBZDVVXG4zEPHjxgPB4TjUYxTZObN29ay2KFEEIIIT4rfu2CSFGUfw581TTNwS88dwH/oWma/9czedNfgRRE4nlkGAa7u7scHR1xdHREqVRiNBrh9/tpNpvA4/mjXC7H9PQ0s7Oz+Hw+Go2G1S7XarX46U9/ytHREUtLS9TrdRYWFuj3+xwfH3P9+nU8Hg9utxuXy4XNZqNcLqPrOs1mk4ODA8rlMl6vF5/PR6fTodfrkU6nSSaTuN1uFEVhe3ubVqtFNBplOBxy9epVFhcXsdvtF3yKQgghhBDPxrMoiEZA0jTN0i88jwEl0zQv7P+cpCASz6vxeMzBwQHHx8ccHh5SrVZpNpv4/X663S7j8RiAVCrFwsICmUyGRCJhFTHBYBDDMHjjjTfY3NxkZmaG0WhEPB4nGo1y584drl+/TjAYxOVy4XQ6rQWurVYLgO3tbcrlMoqiEA6HGQwGaJpGPB4nnU7j8/nwer3s7OxQKpWIRCKMRiPy+TzXr1/H6XRe5BEKIYQQQjwTv6wgetpQBQX4uMppGtD+AS/yu8C/BuzA/26a5n//MZ/5D4B/+eH33TVN8z962t8vxPPkSQKd2+22ihWbzUaz2cTr9TIej+l2u5ydnaHrOsPh0Eqgq1ar1m3Rb/3Wb+Hz+VhbW2NiYoJGo0G32+VLX/oS77zzDjMzM6RSKUzTtAomp9NJtVplZWXF2ktUqVRIJBLYbDaq1SqGYZDL5bDZbOTzedxuN8fHx9ZepE6nw61bt/D7/Rd9lEIIIYQQn5hfWhApirLO48LEBH6sKMrPLy2xAzkehy38vRRFsQP/BvgnwAnwrqIo3zFNc+PnPpMH/mvgN0zTrCuKIhPe4oWXSqVwOp04nU5sNhsOhwNN07DZbASDQZrNJpVKBV3XGY1GVgJdo9GgVqsRjUb54he/SCAQ4Kc//SndbpdMJsP6+jpf+tKXePfdd2m1WiwuLjIajQCs6O3z83MuX76M0+mkXq9zfn5OIpEgGo3SaDTY3Nxkbm6OUChENpvF6/WyubmJ1+ulWCxy+/Ztbt26RTQaveBTFEIIIYT4ZPx9i1m/zuNYbQX4yw//+8mf/xv4U+BPnvK7XgF2TNPcM01TB/4M+Pd+4TN/Cvwb0zTrAL/YoifEiyqRSHDp0iWWlpZIJpNEo1FrJ9GTNLhms8n6+jonJyfcv3+fcDiMy+WiXC7T7/e5cuUKv/M7v8N4PGZvb49AIMC7777LjRs30HWdO3fuYJqmtcTV5/ORyWQwDIP5+XkmJyeJRCIUi0WGwyGxWIzxeGy11T0JdXjy+9rtNpqm8cYbb3B6enrBJyiEEEII8cn4pTdEpmn+twCKohwAf/aLoQr/QGng+Of+fgJ84Rc+c+nD73uTxzdQ/9I0zf/v1/hOIZ4boVCIS5cuWZHZT9ra6vU6kUiEer1Ot9tla2sLwzAYDocsLi4SDAap1WoAzM3N4fP5eP3119nY2GBlZYW1tTWWlpYolUq8/fbb3Lp1i9FohKIouFwustkslUqFVCplte9VKhUMwyAcDtNqtdjf36ff75NMJvH7/bz00kvcvXvXuqG6ffs2N2/eZH5+/oJPUQghhBDi2fr7boieOAC++IsPFUX5x4qi/OYzfB8HkAf+HeCfAv9WUZTwx3zvf6YoynuKorz3JNJYiBeBx+Ph8uXLLCwskMvliMVieL1eNE2zFqP2+30ePnzI/v4+jx49YjAYEI1GrYIpkUjwu7/7u+RyOe7fv080GuXRo0f4/X5mZ2e5ffs2/X6fTqdjteElEgk8Hg+hUIj5+XkSiQSDwYBGo0EkEkFVVU5PTzk4OEDTNHRd58aNG4TDYarVKuPxmHfeeYd79+5ZbXlCCCGEEJ8FT1sQ/U9A5GOeBz/82dM4BbI/9/fMh89+3gnwHdM0DdM094EtHhdIH2Ga5v9mmuYt0zRvJRKJp/x6IZ4PLpeLfD7P3NwcCwsLxONxQqEQrVYLv99vxV0fHh6ytbXFzs4OmqYRi8XQNI1Wq0UwGOQrX/kKi4uLbGxs4HQ6KRaLNBoNrl27xnvvvUez2aTT6WAYBrquE4/HiUQiOBwOFhcXmZiYwGazUSwWCQaDhMNhKpUK29vbtNtter0eV69eJZlMUqvVUBSF9fV13nvvPfr9/gWfohBCCCHEs/G0BdFl4O7HPL//4c+exrtAXlGU2Sf7i4Dv/MJn/oLHt0MoihLncQvd3lP+fiFeGDabjdnZWebn57l06RKJRIJYLEa328XlcuHxeAA4OzvjwYMH7O7uUiwWmZiYoNfroWkadrudf/SP/hG3bt3i8PCQfr+Pruvs7+/zxS9+kYcPH3J2dka328UwDHq9HqFQiGQyiaIoXLlyhampKfx+P8ViEZfLRTgcpt1u8+jRIzRNQ9M0FhcXyefzNBoNTNNkd3eXn/3sZ1a0txBCCCHEi+xpC6IekPyY52lAf5pfYJrmEPjPge8DD4E/N03zgaIo/0pRlN//8GPfB6qKomwArwP/lWma1ad8RyFeKIqikMlkmJubY25ujomJCSYmJqwI7kAgAEC1WmV9fZ2DgwN2d3eZnJzEMAyrQLl16xa/+Zu/SaVS4fT0FK/Xy927d3n55ZcpFArs7Oyg6zq6rtPtdvH7/aRSKQzD4PLlyyQSCRKJBMViEYBYLIau62xsbFAul2k0GmSzWa5evUqn02E0GlEoFHjrrbeoVuWfpxBCCCFebE+7mPX/4fHOod9/kgCnKEoU+DZwYprmP/1E3/KXkMWs4rOg0Wiwv7/P4eEh5XKZSqXCeDzG5/OhaY9XfXm9XvL5PMlkkuXlZRqNBoZhEIlEcLvd7Ozs8MYbb6DrOqurqxSLRVZXV9nb20PXdW7evImiKHg8HlRVZTwec35+jmmanJ6eUqvVKJVK+Hw+PB4PmqZZu4qSySShUAjDMHj33XcBCAQCeDwebt26RSqVusjjE0IIIYT4pX7ZYtanLYiSwE+ACeDeh4+vAiXgH5umefaM3vUfTAoi8VnRarU4ODjg+PiYQqFArVaj2+0SjUatlDmv10s2myWbzbK4uGjFY8diMWux6htvvIGmady4cYNiscjCwgLVapVqtcoXv/hFRqMRXq8Xl8uFoijU63VarRatVovT01MqlYrVPqdpGu12m1QqxfT0NH6/H4/HwzvvvEO32yUYDOJwOLh58yZzc3MoinLBpyiEEEII8bf92gXRh7/EC/wz4PqHjz4A/l/TNLvP5C1/RVIQic+SwWDA3t4eR0dHnJ2d0Wg0aLfb+Hw+ut0uo9EIp9NJJpMhl8uxtLQEgKZphMNhPB4P9Xqdt956i+PjY65evUqpVCKZTFpLV1966SWcTic+nw+73Y6qqjQaDarVKoZhcHR0ZP335OQkzWaTdrtNJBJhYWGBQCCAz+fjgw8+oF6vEwqFsNlsLC8vs7y8bIVCCCGEEEI8L55JQfS8koJIfNYMh0MODg44Ojri5OSEZrNJrVbD4/EwHA7R9cdje+l0mrm5OS5fvozH46FWqxEMBnG73fT7fX72s5+xubnJ3Nwcpmni9XpJp9Osra1x9epVfD4fgUDAaqNrNps8ibF/kmzXbreZmpqi1+vRarVwuVwsLS0RCoUIBoNsbGxwdnZmLZqd///Zu9PYyPL1vu/fU3Vq38kii8WliktxazbZzd5membu9F1yowiBA8lC/EYIbAgSAltAVlt54Wy2oxeWZcBw4jgxEtlIAsNJbL9IkEgXc6V7lTt3uqeHZHNnk2zuS7HIWln7cs7JCzaPZq7mXnE03ZezPB+AaPJUNfnM/830w////3uGhrh9+zYOh+M6l1AIIYQQ4hN+VkP0Mwez/sQ3+UXgN4FB4BcMwzhQFOXXgR3DMP7w1ZQqhFBVlcHBQVRVxW63s7+/bx5ts1qtuFwuqtUqR0dH1Ot1dF1nYGCAcDhMNptF0zQ8Hg/f+MY3zICFrq4ubDYb29vbPHjwgJmZGQYGBrBYLNjtdgzDwO/3mzHc4+PjPH/+HIvFwvHxMZ2dnQQCAc7Pz1leXmZsbAxd15mcnMTj8bC+vk4wGGRra4t6vc6dO3fwer3XvZRCCCGEEH+mK6XMKYryq8D/AWwCA4Dt5UtW4LdeT2lCfH1ZLBb6+/sZGhoyB6l2dnaiaZrZ8ACk02lWVlbY2NggmUwSDoep1Wqcn59jsVh48OABb731FqlUilQqhcvlYnl5mXv37rG/v28m0NXrdarVKl6vl76+PhRFYWRkhPb2djo6Okin0xiGQSgUwjAM1tbWSKVSpNNpBgYGuHPnDqVSCU3TOD4+lgQ6IYQQQnxpXDV2+7eA3zAM4z8GWh97/oQ/uVMkhHjFotEoAwMDDA4O0tHRYaa5XTYvcJFQt7a2xubmJtvb22bjdBnLPTU1xbvvvkuz2WRzc5NwOMzS0hJTU1NUq1WWl5cxDINKpUK5XMZms9HV1YXD4SCRSNDZ2UkkEjGHtba1tWEYBuvr6xweHnJ2dkZ7eztvvfUW1WrVPHr35MkTksnkdS6fEEIIIcSf6aoN0TDw+FOelwD/qytHCPGTOjs7GRoaMmcVRSIRnE4npVLJHOBaLBZZW1vj+fPnLC8v09bWhsViMcMRJiYmePToEW63m8XFRaLRKCsrK/T19eFwOHj69CkAlUqFWq1m/lyPx0NXVxddXV20t7dTr9fJ5XKEw2FcLhfb29tsb2+TyWSw2Ww8evQIVVUpFouUSiUeP37M7u4uX/a7ikIIIYT46rrqHaJjYATY+4nn7wJbr7QiIcSfEgqFsNlsWK1WbDYbFouFfD7P+fk5fr+f8/NzarUa+/v71Ot16vW6uQOUTqdpa2tjaGgIh8PBhx9+yMzMDLdv32ZnZ4dIJILP5+P999/n4cOHnJ+fEwgEsFqthEIhLBYLuq5jt9uxWq3k83nOzs6IRqPmHaNKpcL4+DjBYJB3332X2dlZstkswWCQmZkZKpUKY2NjWCxX/R2MEEIIIcTPx1X/dfJPgH+oKMrbL7/uUxTlLwO/A/zj11KZEOITvF4viUSCeDxOT08P4XCY9vZ2M5ZbVVWq1SoHBwdsbm7y7NkzHA4Hfr+fTCZDuVymq6uLd999l/7+fmZnZ/F4PJyenlIulxkfH+eDDz6g1WqZQ18bjQbBYJBIJILL5WJwcJBgMIjX6+X4+Biv14vP56NUKrGwsEAmk6FWq/HGG28QjUYpFAo0Gg0WFhZYWFigXq9f9zIKIYQQQnzClXaIDMP4HUVRAsB7gBP4AVAHftcwjH/0GusTQnyM0+kkkUigqiqqqmKxWFBVldPTU+x2OxaLhUajweHhIa1Wi1arxcTEBO3t7WSzWXw+H8FgkHfeeQeXy8Xq6ir9/f00m02SyST37t1jdnaW0dFRrFYrHo8HXdfx+y9OxqZSKYaGhtjd3cVut5tBDhaLhXK5zLNnz7h58yaapjE9Pc3Gxgabm5v4fD7W19ep1WrcunULt9t9zSsphBBCCHHhM80hejmc9QYXO0urhmGUXldhVyVziMTXkaZpHBwccHx8zP7+Pufn52YSnN1up1K5mJcciUSIx+OMjY0RCoXIZDJ4PB7cbjeNRoOVlRVmZ2fN3abLo23z8/N0dXWZd4wcDgdut5tarcbp6SmNRoPd3V2KxSK5XA6v14uqqmbS3OjoqHnfaW9vj8XFRdxuNw6Hg+7ubm7fvk0gELjmVRRCCCHE18XnnkOkKMrvAf+hYRhFYOZjzz3Af2sYxq+9kkqFEFditVqJx+PmrtDBwQFWq5WTkxNqtZo5qyiVSpnDXMfHx+nq6iKdTqNpGl6vl1u3bmG325mZmaFarTI8PMzKygpTU1Osra1RrVYZHx9H0zQAXC4X0WiUTCZDPB7n+PgYgEKhgM1mIxgMks/nWV1dNcMZ+vr68Pl8PHnyBF3XOT4+ptFocOvWLTo7O69tDYUQQggh4Io7RIqiaEDUMIzTn3geBk4Mw7jygNdXTXaIxNfd6ekph4eH7O7ucn5+zsnJCY1GA4fDYTYlgUCA3t5exsbG6O/vJ51OY7FY8Pv9qKrK+vo6H374IYZhcOPGDU5PTxkcHCSZTFKv15menkbXdbxeL3a7HbiI+y4UCqRSKTNqW1EUgsEgmUyGVqtFNBpleHiYjo4O6vU6P/rRj2i1Wng8Htrb27l586Y590gIIYQQ4nX5c+8QKYrSBigvP0KKonx8BpEV+LeB1KsqVAjx2XV2dprJc0dHRxiGQTabpVwumztFhUIBXdfN3aKxsTEymQz5fJ5AIMDY2BiqqjI7O8vi4iLT09Ps7OzQ2dlJvV7n6dOnPHjwgEKhQDAYxGq10tbWhqqq6LqOzWZD0zQKhYKZalcsFkmlUlQqFW7evEk4HObRo0c8efKEYrGIzWZjbm6OZrPJwMCAJNAJIYQQ4lr8WTs7acB4+bH6Ka8bwH/1qosSQnw2oVAIq9VqhizYbDby+TyZTAa73U6j0aBYLLK/v0+1WqVarXLr1i0KhYIZjz0yMoLD4WBubo6ZmRmmp6fJZDL4/X76+vp4//33efPNN8nn8wSDQTRNM2O5FUXB4XCgqiqFQoFcLkcoFKJcLlMoFHj27BmTk5N0dnaasdypVAqfz8fCwgKNRoPh4WFU9do2m4UQQgjxNfVn/evjW1zsDv0R8CtA9mOvNYA9wzCOX1NtQojPwO/3k0gksFqtZmNhtVo5OzvDZrPRarWoVqvmMbharcb9+/dRVZVsNovFYjFDFObm5pidnWV8fJxisUi9XufGjRs8fvyYO3fukMvl8Pv9lMtlAoEAFouFVCpFd3c3AKqqkslkCAQCGIZBrVbj2bNnTE1N0dnZyb1791haWmJ/fx/DMFhaWjJ3khwOx3UuoxBCCCG+Zn5mQ2QYxh8DKIoyAOwbMm5eiC80t9ttNkWKonBycoLdbufk5ASHw0Gj0aDZbJJOp9F1nWazyf379wkGg2SzWQKBAOFwmLfeesuM5Y7H4wAcHBxw584d5ufnGRkZQVEUvF4v1WoVv9+P1WollUoRi8U4ODgAIJfLmQ1TrVZjbm6OyclJuru7mZqawuv1srS0hNfrZXNzk1arxc2bN/F4PNe5jEIIIYT4GrnqHKI9RVEmFUX594Eh4NcMw0gqivJLXOwSPXutVQohrszhcJBIJLDb7djtdo6OjohGoySTSRRFMY/QnZ2dYRgGjUaDe/fuEQqFyOVyeDwePB4P9+7dw+Vy8ezZMzo6Oujs7OT58+dMTU2xsrJCNBqlp6cHh8OBYRi43W6i0SjpdJpYLMbJyQlWq5VcLofD4cDj8VCpVFhcXKRcLjM4OEgikcDj8TAzM4NhGOzt7ZmzioLB4HUvpRBCCCG+Bq4au/1vAv8X8PvAtwHXy5eGgL8C/NLrKE4I8eejqir9/f1YLBasVqsZtnA5Q+gybOFydtFlUxQOh8lkMmiahs/nY2pqCofDwczMDI1Gg3g8zubmJiMjI+zs7FCtVhkZGaHZbJrNVmdnp9ji+jMAACAASURBVJlEd3mvKZfLoWkafr+fUqnE1tYWzWaT4eFhotEob731Fo8fP6bVaqFpGrquc+PGDTo7OyWBTgghhBCv1VVjnf4O8J8YhvHLXNwduvRD4MGrLkoI8flZLBbi8Tj9/f3EYjHa2tro7u7GZrNRrVax2WwAZDIZjo+PefLkCWdnZ3R0dNBoNCgUCqiqysTEBG+++SaNRoONjQ0ikQj7+/v09fWhaRpLS0tYrVYKhQL1eh2AtrY2otEonZ2d5tBXq9VKsVgkEAhgt9vZ399ncXGRk5MT2tvb+da3vmWGQSSTSWZnZ81GTgghhBDidblqQ3QT+H8/5XkWaHt15QghXiVFUYhGo8TjcWKxGKFQiN7eXrxeL81m0wxfyOVynJyc8PjxYzNuW9d18vk8hmEwPj7OG2+8gd1uZ3l5mc7OTpLJJH6/H6/Xy9OnT83jcZqmmbtB0WiUjo4OOjo6CAQCuFwustksHo8Hu93O2dkZ8/PzHB4e4na7efToEX6/n0wmQy6XY3Fxke3tbXMwrBBCCCHEq3bVjNss0APs/sTzO8DhqyxICPHqRSIR7HY7FosFh8OBxWLBbreTzWaxWq3mDKFWq8Xs7Cy1Wo2bN2+ajUkoFGJ0dBS73c78/Dxzc3NMTU2Z84T6+vr48Y9/zMOHD8lms4RCIQzDIBAImMfmbDabORD2/Pwcr9cLQKlUYm5ujlarRW9vL2+//TYLCwscHh6iaRr1ep16vc7w8LC5qyWEEEII8apctSH658DfUxTlL3Exe0hVFOUR8LvAP31dxQkhXp1QKISqqqiqaqbQ2Ww2UqkUiqJgGAblchld15mfn6dcLnP//n0KhQKZTIZQKMTQ0BAOh4P5+XkWFhYYHx+n1WqRyWQYGxvjRz/6Effv3zebqGq1itfrRVEU82cahoHFYqFYLOJyuWg2mzQaDWZnZ2m1WsRiMaanp3E4HGxtbaHrOs+fP6fVajE6Oiqx3EIIIYR4pa7aEP3nwD8D9riYS7T68s9/Dvz2a6lMCPHK+Xw+hoaGUFXVHKhqs9k4OjrCYrGg6zrVapVms4lhGNTrdd555x1zVtHlPSRVVXE6naysrJBIJHC73RweHnL79m3m5uaYmJgAIBAImE3R5dBYRVHMuUeFQgG73Y7D4aBarTI/P0+tViORSHDz5k18Ph+Li4sAbG5uUq1WJZZbCCGEEK/UVWO3m8CvKoryXwLTXNw9emYYxubrLE4I8eq53W4GBwexWCxYLBZOTk6IxWIcHh6aOzitVotUKoWmadRqNR49ekQwGDTnCoXDYe7evYvL5WJhYYHu7m4ikQjb29tMTk6ytrZGd3c3iqLgdDoBcLlcZgLdZXKcrutUKhUURTGT71ZXV6lWq4yPjxOLxbDb7czOztJsNtE0jWazycTEBKFQ6DqXUQghhBBfEVfdIQLAMIwtYOs11SKE+DlxOBzmTpGqqhwdHdHb20symaTRaJiN0eWsovfee49vfetb5qwir9eL1+s1Y7nn5uZoNBr09/ezvb1NIpFgd3eXRqPBwMAAmqahKAoOh8M8und5jM5ms1EsFmk2m7hcLsrlMjs7OzQaDSYmJsxZR0+fPiWfzwOYr0kstxBCCCE+L+WnRdoqivJ7V/0mhmH82iur6DO6d++eMTMzc10/XogvNU3TODg4IJlMcnx8TKlUIplMUq/XzSN0cBGj3d7ezjvvvIPf7yeXy+F0OvF4PDSbTTY3N/noo49wuVwkEgnS6TSRSIR0Og3A5OQkmqYRDAbNu0SlUomDgwNKpRLpdJpyuUyj0cDpdFKtVmm1WoTDYaanp2lvb6dSqfDBBx9QLpcJBAJEIhFGR0fp7u7GYrlqYKYQQgghvo4URZk1DOPep732s/4V0fETH78C/DKQePnxS8BfBMKvtFohxM+N1Wo1I7ljsRiBQMDckdF1HavVCkA2m+X09JQf/vCHnJ2d0d7eTq1W4/z8HFVVGR8f5+HDh2iaxurqKp2dnWQyGfx+P3a7nZmZGfMe0sdjuQcGBszmxufz4XK5qNfruN1urFYr2WyWp0+fkkwmcbvdfOMb3yAUCpHNZjk5OWF5eZm9vT1ardY1r6QQQgghvqx+akNkGMZfuPwAPgC+B/QahvGuYRjvAn3AHwAf/nxKFUK8Doqi0NPTYzZFbW1t9PT0EAwGPzH/p1AokE6n+eM//mO2t7fp6Oig1WqZx9jGxsZ48OABHo+HxcVFgsEg1WoVgM7OTp48eWI2Obqu02g08Pl8xGIx/H4/4XAYt9ttHptzu91mRPdHH33Ezs4OLpeLt99+m97eXtLpNKenp6ytrbG9vU2z2byW9RNCCCHEl9tV7xD9B8B3DMMoXz4wDKOsKMrfAf4QSZoT4ksvEolgs9nMmUFWqxW73c7p6an5nmKxaM4qqlar3Lp1i0wmY84eGhkZwWKxsLKywuLiIhMTE9TrdYrFIr29vXz44Yfcv3+fTCZDe3s71WoVv99PLBYjmUyiKAr5fB6r1UqpVDLrqFarLCwsUK/XGR8f5+7du7jdbjY3N82ghUajwfDwsMRyCyGEEOIzuWpD5AW6uYjb/rgo4H6lFQkhrk1bW5s5SPXjwQfJZNJ8T7Va5ezsjNXVVUqlEm+99Rb5fJ50Ok1bWxuJRAK73c7q6iqLi4sMDw/jdrtJp9MMDw/z5MkTJicnyWazBAIBKpUKHo+Hnp4eM4HusobLBDqn00mj0WBlZYV6vc7k5CTj4+PY7XZWVlbMu07NZpORkRGJ5RZCCCHElV21IfpXwD9VFOVvAE9ePnsT+LvAv34dhQkhrkcgEGBwcNBsShRFQVVVDg8PuQxhqdfrJJNJms0mlUqFb3/726iqau78XMZlOxwONjc3icVidHR0cHh4yPj4OEtLS4yOjmIYBl6vFwCn00kkEsFut7O/v28m3VWrVfM+k6ZpbGxsUK/XmZ6eZmhoCI/Hw0cffUQ6nUbTNKrVKjdu3CAYDF7nMgohhBDiS+KqDdFfBf4+F8NZbS+ftYD/Gfjrr74sIcR18nq9n2iKkskkg4OD7O/vm3d1NE3j9PQURVH4gz/4A7773e8SCATM43OdnZ04HA6cTieLi4s0Gg16e3s5PDxkaGiI3d1dOjo66OnpQdM0DMPA5XLR1taGqqrs7Oygqiq5XI5Go0GlUkFVVer1Ovv7+zQaDe7evUs0GuWdd97h6dOnHB8f02q10DSN8fFx2tvbJZZbCCGEED/TT43d/tQ3K4oHGHr55dbH7xRdF4ndFuL1aTQa7O3tkUwmSaVS1Go1Dg4OPhFgoCgKHR0dBINBvvvd7wIXAQx+vx+Hw0G5XGZ7e5vZ2VmCwSCxWIxcLkdbWxupVAqPx8PIyAiGYZipdADlcpmtrS3K5TLpdJpGo0GtVsNqtVIul7Hb7YRCIe7fv08gEKBYLJqx3B0dHWYsdyQSkVhuIYQQ4mvuZ8Vuf6aG6ItIGiIhXq9Wq8X+/j4nJyecnJxQq9U4PDw0E+QudXR04Ha7+c53voPH4yGfz+PxeHC5XDQaDTY3N5mdncXpdJJIJDg/P8ftdlOpVGg2m0xPT9NoNMxZRTabjUqlwtbWFqVSiUwmQ6VSQdM0Wq0WzWYTi8VCMBjk9u3bRCIRqtUqP/7xj8nn84TDYbq6ukgkEkSjUVT1M82hFkIIIcRXyJ93DpEQQqCqKv39/fT19dHb24vL5aK7u/tPBRecnZ2Rz+f5/ve/z+npKW1tbVQqFUqlEna7nbGxMR4+fIhhGDx//hyfz0er1UJVVXw+Hx9++KF5RE7Xder1unl07zKW2+fz4XA4sNls2Gw2dF2nUCgwOzvL7u4uXq+Xd999l+7ubs7Ozjg6OmJlZYW9vT2J5RZCCCHEp5KGSAjxZ7JYLPT29tLb20tfXx/BYJBoNPqnggsKhQK5XI7333+f3d1d2tvbaTQaFItFLBYLw8PD3L17F4/Hw9LSkhmrXalU6Ojo4MmTi8yWy1lF1WrVDHloa2szd6HcbjeqqmKxWDAMg3w+z/LyMqurqzgcDu7fv08ikSCXy5FMJtnc3GRzc5N6vX4dyyeEEEKILzA5QyKEuBJFUeju7jZ3Zy4jsh0OB6lUynxfsVhE0zQ++ugjSqUSt27dIpvNks/nCQQCjIyMYLVaWV1dZWlpiYmJCQKBALlcjoGBAWZmZpiamjLDGcrlMl6vl/7+fo6OjtB1nXw+j67rZsiCxWKhWCyytrZmJtBNTk7icrlYW1vj6OjIPGp3mUwnhBBCCAHSEAkhPqOOjg6sViuGYWCxWMxBroeHh+Z7Lu/6PH/+nFqtxhtvvMH5+Tm5XI5QKEQikUBVVZ4/f87q6ipDQ0O0t7eTTCYZGhpiYWGBiYkJstkswWCQcrmMx+Oht7cXp9OJYRjmzpLVaqVer5uR2zs7OzQaDe7du0cikcDpdDI/P2/W12w2GR4exu/3X9cSCiGEEOIL5EoNkaIoj4CaYRgfvvz6rwC/DqwA/6lhGKXXVqEQ4gvncoDr5ZG3s7Mz4vE4e3t75nvq9Tqnp6domka5XOZb3/oWpVLJ3Pnp7+/HbrfjdrtZX18nFovR1dXF8fEx8XictbU1+vv7URQFn89nDmi9bMh2dnaw2Wzk83lzZlG9XqdUKpnx4Hfv3jXvPX344YccHh6asdxDQ0O0tbVJLLcQQgjxNXfVO0T/AOgCUBRlFPgfgUXgIfD3Xk9pQogvskAgQDwep6uri0gkgtvtJpFIYLVazfc0m01OT09JJpN873vfw+Fw4PF4SKfT1Ot1uru7uXHjBhMTE+zt7XF8fEw0GiWXy9HX18fR0RHHx8dUKhXOz8/N2O1wOMzY2Bhut9tszrxeLw6HA1VVzXjwx48f02g0aGtr4xvf+AaqqrK3t8fR0RFra2ucnZ2h6/o1rqIQQgghrttVG6IEsPTy818B3jMM468BvwH8hddRmBDii+/ybk8kEqGrqwu73c7Q0BAOh8N8j67rpNNpTk9P+f3f/30MwyAUCpHNZqnVarS1tXHjxg3u3r1LKpVie3ubjo4Ozs/PaWtr4/z8nBcvXgBwfn5OvV7HMAwCgQBjY2M4nU5zAKvb7cbj8aAoCpqmcXJywkcffUSxWMTv9/PNb36T9vZ2Dg4OOD4+Zn19nZOTE1qt1nUtoRBCCCGu2VUbIh24/LXvd4A/ePn5CdD+qosSQnx5uFwuBgcHiUajRKNRHA4H8Xgcp9NpvkfTNAqFAplMhu9973uUSiWCwSD5fJ5qtYrP52N0dJS7d+9yfn7O+vo6fr+fVquF0+lE13WWlpawWq3k83mazSaNRgO/38/4+Dher/cTx/j8fj+GYaBpGqlUivn5eZLJJG63m3feeYfu7m6Ojo7Y399nY2ODo6MjieUWQgghvqau2hB9BPwXiqL8e8A3gN9/+bwfSL6GuoQQXyJ2u53+/n66u7vp6urC4/EQi8U+kebWbDYpl8vk83l+8IMfcHZ2ZgYmVCoVXC4Xw8PD3L9/H13XWV9fx+FwmI3V5awiq9VqxnLXajUCgQCjo6OEQiHC4bA5pygUCqEoCo1Gg1QqxfLyMltbW2Ys9+DgIOl0mr29PV68eMHu7q7EcgshhBBfQ1dtiP4j4Dbw3wG/bRjG1svn/y7w+HUUJoT4crHZbPT39xOLxcwZRX19fbS1tZnvuWyKstksjx8/ZmdnB7/fT61Wo1gs4nA4SCQS3L17F6fTydraGnBxX6lYLNLZ2cnTp0+BP5lVVKlU8Pl8JBIJOjo6aGtrw+VyYbVazV0jTdPI5/NsbGywurqK3W7n3r17jI+Pc35+zu7uLjs7O+zs7FCpVK5l/YQQQghxPa6UMmcYxjIw9Skv/XVAe6UVCSG+tCwWCz09PVitVjO9Tdd1bDabOavo8mhaOp1mfn6eZrPJ2NgY5+fn5qyiwcFBFEVhbW2NtbU1RkZGCIfDnJ6eEo1GmZ2dZWpqinQ6TVtbG6VSCY/HQzwex2azoes6iqKYA1+z2SyNRoN8Ps/u7i6NRoPp6Wlu3LiBw+FgaWmJvb09M6lucHAQn893besohBBCiJ+fzzWHyDCM2qsqRAjx1aAoCtFoFFVVUVUVm832p2YVXTZF2WyWpaUlSqUSd+/eNY/UXTZFVquVjY0N1tfXGRwcpKenh6OjI2KxGIuLi4yNjX1iVpHL5aK7uxtVVTk8PERVVYrFIu3t7eTzeSqVCrlcjlarRavVYmpqikQigcvlYm5ujt3dXQzDoNVqMTg4SDAYlFhuIYQQ4ivupzZEiqIsAo8Mw8gpirIEGD/tvYZhfNrukRDia6yjowNVVc1m6OTkhKGhIba3tzEMg2azicViIZvNYhgGtVqNt99+m2q1Si6XIxgM0t/fj9VqxeFwsL29TaPRoKenh5OTE7q7u9nc3CQWi5kJcwAOh4Ouri5sNht7e3tYrVaKxSLBYBCr1UqpVKJQKNBsNtF1nYmJCbq7u3E6nTx9+pTNzU2azSatVsscGCtNkRBCCPHV9bN2iP4VcHnD+F/+HGoRQnzFhEIhLBYLFsvFdcWzszMSiQTb29tomka9XjdDEjRN47333uM73/kOiqKYTVFfXx82mw2n08nq6iqtVove3l4ymQzhcJijoyPq9To9PT20Wi38fj92u53Ozk5UVTUjuwuFAj6fD1VVKRQKVCoV9vf30TSN0dFRAoEAb7/9No8fP+bFixdomoau67RaLTo7O83/BiGEEEJ8tfzUhsgwjL/1aZ8LIcRnEQgEsFgsqKqK1Wrl7OyMwcFBdnd3aTabaNrFNcR8Pk+r1eJ73/sejx49wuPxkMvlCIVCRCIR8+8vLy/TbDaJx+MUCgU8Ho85tDWRSFAoFPD7/aiqSjgcxmKxsLW1haIoFAoF3G43drud09NTarUa+/v76LrO0NAQoVCIR48eMTMzw87Ojnm0TtM0Ojs7sdls17yaQgghhHjV5FeeQojXzufzEYvFiEQihMNhnE4niUTCPOamaRqGYVAul0mn0/zgBz+gWCzi8/nI5XI0m03a29sZGRlhenqaQqHA5uYmXq8Xp9OJoigYhsHKygoWi4V8Po+madRqNcLhMKOjo/j9fgKBAIqioCgK3d3d6LpOvV435xElk0lUVeXNN99kaGiI/f19jo6OWF9f5/j4WGK5hRBCiK8gaYiEED8XbrebWCxmzipSVZW+vj4zza3VatFsNmk2m6RSKT744ANSqRR+v59isUi9Xsfr9ZpNUavV4vnz51itVtrb26nX63g8HmZmZlAUxbybVC6XCYVC5n2gQCCAzWZD0zR6e3uxWCw0Gg0ODg7Y39/n8PAQRVGYnp5mbGyMVCrFwcEBOzs7HBwcUK1Wr3klhRBCCPEqSUMkhPi5cTgc5pyinp4e3G43PT095qyiywbGMAxOTk6YnZ3l8PAQt9tNpVKhVqvhcDgYGhri1q1bOBwOVldXqdVqRCIRSqUSHR0dzM3NoWka6XQawzAolUqEQiEGBwfp7OzE5/PhdDppNpv09fXhcDhotVrs7++zs7PD1tYWuq5z69YtpqamzBlG+/v77O3tUSwWr3klhRBCCPGqfK7YbSGE+KxsNhvxeNxMoLtsWlRV5fT0FIBKpYLX6yWVSjE3N0epVGJsbIxKpYKmaXg8HoaGhrDb7SwtLbG2tsbw8DCxWIz9/X3C4TALCwvcuHGDs7Mz2tvbKZfLeL1eYrEYqqpyfHyMxWKhWq3S1dXFyckJ1WqVs7Mz897Q0NAQw8PD2Gw2FhYW2NjYQNd1s5G6PIInhBBCiC8vaYiEED93lwNcPx7Lffnn0dERAKVSCb/fTzabZW1tjXq9ztTUFNVq1QxOiMViAGxsbPDixQsMw6C3t5fDw0M6OztZW1sjkUiQzWbx+/1mPHdfXx+qqnJwcGD+rO7ubs7OzszEu8tZSbFYjIGBAex2O8+ePWNtbQ24uPcUi8UIhULSFAkhhBBfYlduiBRF+UXgN4FB4BcMwzhQFOXXgR3DMP7wdRUohPhqslgsRKNRrFbrJ6K5nU4nW1tbAJyfn+P1esnn82xtbVGv17lz5w6tVotCoUAgEGBgYABVVXG5XGxsbBCPx+nr6+Pk5IT29nZ2dnbo6elBURRarRYAdrud3t5eHA4HOzs75k5RR0cHdrudk5MTDMNgfX0dTdPo6+ujq6uLhw8fMjc3x8rKCsPDw2iahqZptLe3Syy3EEII8SV1pYZIUZRfBf4H4H8CvgNcZs9agd8CpCESQvy5XM4LUlUVm83G6ekpiUSC3d1dWq0WpVIJt9tNoVBA0zQajQb37t3DYrF8YlaRqqrY7XY2NzdpNBrE43HS6TQ+n49kMkmlUqG3txfDMPD5fFitViKRCACHh4fAxVE9n8+H3W7n4OAAXdfZ3NzEMAw6OjoIh8O8/fbbfPjhh6yvr9NoNMzo8HA4jKrKprsQQgjxZXPV/3v/FvAbhmH8i5e7QpeeAH/71ZclhPg6aWtrM3eJFEUxB7hubW3RbDapVCo4HA5KpZI5THV6ehqbzWY2Rd3d3WZjtbq6ah5pq9Vq1Ot1arUaW1tbDA8Pc35+jt/vR9d1enp6sNls7O3toSgKlUoFu91uDpAtlUo8f/4cXdcxDINQKMTDhw959uwZ29vbNBoNMyGvs7MTh8Nx3csphBBCiM/gqg3RMPD4U56XAP+rK0cI8XUVDAaxWq1YrVYURSGVSpFIJNjb26NSqVCv17FaraiqyuHhIa1Wi9u3b5uzikKhEB0dHeZO0/LyMltbW/T399PW1kY6ncZut7O2tsaNGzfI5XIEAgEqlQqdnZ0A5g5VrVZD13XGxsbY2NigXC6bO0KtVou2tjbu379vHtOr1+vouo6u63R2duJyua55NYUQQghxVVdtiI6BEWDvJ56/C2y90oqEEF9blwNcL0MKzs7OiMViHB0dUSwW0TSNarWK2+3m4OAATdOYmJigs7PTbHBCoZDZFK2urrK5uUkikSAajXJ0dITP52N+fp5bt26RzWZpa2ujUqkQiUTMv3d8fEytVqNcLjM2NsaLFy8oFotsb2+bR+Ta29s/Ef19uYPUbDaJRqN4PJ5rXk0hhBBCXMVVbwH/E+AfKory9suv+xRF+cvA7wD/+LVUJoT4WnK73fT399PV1UVXV5c5qygUCgEXA1wrlQpWq5WjoyMWFhY4PDzE5XKZA1x9Ph8DAwNMTk6iqirPnz+nVqvR39/P+fk5oVCIZ8+eoes66XSaVqtFuVymra2N3t5eYrEYXq8Xh8NBsVhkdHSUQCBAsVhkd3eXg4MD8vk8+Xye4eFhJicnOT8/Z2Njg6OjI/b39zk/P7/mlRRCCCHEVVxph8gwjN9RFCUAvAc4gR8AdeB3DcP4R6+xPiHE19DlANfL43PZbBbDMHA4HJycnNBqtSgWi3i9XpLJJI1Gg3q9Tn9/P+VyGU3TzMZKVVVWVlbMZLiBgQEODw9pb29naWmJsbEx0um02XD5fD5UVcVqtXJ8fIyiKOTzefr7+9nf3yeXy3F4eEi9XmdkZARd1xkaGsLlcpkJdLqu02q1zEZOYrmFEEKIL64rRyIZhvE3FUX5beAGFztLq4ZhlF5bZUKIrzWbzWYOUbVYLGY8t6IoJJNJ4GJ+UCAQIJvNsrq6SqPRYGRkxBzg6vV6icfjWCwWNjc32dzcpNlsms1NIBBgbW2NgYEBAPz+iyuRDoeD3t5eFEXh6OgIi8VCsVikr68Pm81GKpVC13UajQYTExPouk5XVxdvvvkmz549Y3FxkfHxcXPAq8RyCyGEEF9cnykj1jCMCjCjKIoLeFtRlE3DMH7yXpEQQrwSFouF7u5uc3DrZXPkcDjY3d0FoFAoEAwGzTS4RqPB2NgY9XqdVqtFMBg0Gyubzcbu7i6aptHT08PZ2Rl+v5/9/X26u7uBi4GrHo8Hu91OPB43d4p0XadYLNLV1YXL5TK/z8LCAjdv3kTXdTOBbm5ujtXVVUZHR82whfb2donlFkIIIb6ArjqH6J8BTw3D+O8VRbEDHwI3gYaiKL9sGMbvv8YahRBfYxaLhUgkgsVi4fj4GKvVimEYjI6Osr6+DkA+n8fv99NsNtnY2KDVajE6OgrwiVlFiqLgcDh48eIFzWaTeDxOPp+n1WpxenpKpVKhr68PTdPMo3P9/f1YrVYzga5cLuNyuUgkErx48YJ8Ps/CwgKTk5MYhkEgEOCNN95gdnaWtbU1qtUqjUYDXddpa2uTWG4hhBDiC+aqZzh+gYuZQwD/DhAAuoD/+uWHEEK8Vh0dHfT19dHe3k40GsVutzM+Po7dbgfg/PwcTdPQdZ2NjQ1WV1ep1+vARVNkGAZ9fX0MDg4yNjZGKpVic3MTt9tNIBAAMGcVNZtNzs/PzQCHvr4+otGoOetI13Xsdju3bt0CLnap5ubmyGQyFAoFms0mDx8+ZGhoiJ2dHfb399na2uLs7IxqtXo9CyiEEEKIT3XVhigEnL78/N8C/qVhGKfAv+DiTpEQQrx2lylwwWDQbIqGh4fNuT+lUolms4nVamV7e5vl5WXy+TyKophpctFolKGhITMZbmdnB6vVSmdnJ41GA4vFwvr6OpqmUSgUzKjv3t5eotEoAwMD2Gw2dF2nWq2aSXalUonFxUWOj49pNBrk83mmp6cZHx/n+PiYra0tdnZ2SCaTlMvla15JIYQQQly6akN0AtxUFMXKxW7R918+9wLN11GYEEJ8mmAwSDwep62tja6uLlRVJR6P4/P5AKhWq5TLZex2O4eHhzx//pzT01NUVSWXy9FsNmlvb2dgYICpqSmazSYvXrxA13UGBwepVCrYbDaWlpZoNpucnZ3RbDapVCpEo1EikQhDQ0PmnaRCocDExAQ+n49KpcL6+jovXrzAMAxOT0+ZnJxkenqa8/Nz1tfXOT4+5vDwkEKhcM0rKYQQQgi4ekP0e8D/DiwDGvCHL5+/ATx/DXUJIcRP5fP56OvrkaTUDgAAIABJREFUIxwOm7OKent7CYfDwMWsonw+b84qWl1dZW9vD4vFQi6Xo16vEwgEGBgYYGJiAovFwsbGBvl8nsHBQWq1Gm63m8XFRTRNI5PJUK/XKZVKhMNhwuEwQ0NDWK1WHA4H+XyeGzduEAgEKJfL7OzssLy8jMvl4ujoiHg8zt27d2k2mywtLZFMJjk6OjLjxIUQQghxfa46h+hvK4qyAsSA/9MwjMbLl1rA331dxQkhxE/jdrvp6+sz46wLhQKGYWCz2Ugmk+aRN7/fz9nZGY1GA0VR6Orq4vz8HK/Xi8fjob+/H5vNxvPnz1ldXWV4eJihoSH29/fx+/2sr68zNDRELpczZwr5fD6sViuqqrK3t4emaZyenjIyMsLu7i6np6ccHR1Rr9d54403SKfTRKNRbDYb8/PzLC4uMjU1haZpEssthBBCXDPly/7byXv37hkzMzPXXYYQ4pq0Wi2Oj485OTkhn8+buzl7e38yEeByvpDL5WJkZMSM8na5XHg8HhqNBsfHx2xvb3N4eEg8HicWi3F8fEyz2aTRaNDV1UUoFMLv92O323E6nWiaZv7sQqFArVYjFAqRTqfZ3d3FZrPR1tbGw4cPqdVqtLW1US6XWVxcJJPJcPPmTTo6OohGo7S1tWGz2a5rGYUQQoivNEVRZg3DuPdpr115KIaiKCrwgItdIvvHXzMM43/5XBUKIcSfk6qq9Pb2moNbbTYb2WyWgYEBdnZ2gIsEumAwSKVSYXl5GUVR6OjoAEDXdbxeL319fVitVqxWKwcHB7RaLfr6+sxY7lQqRavVwjAMPB4PcDE8Nh6Pm5+fnp6Sz+cJBAJmLPjp6Snvv/8+Dx48oFAo4PF4uHfvHouLiywvL5NIJMzvGwqFJJZbCCGE+Dm76hyiMeD/BgYAhYt7RCoXgQp1QBoiIcS1uRzgqqqqOasIYHh4mM3NTQCzUVEUhfn5eUZGRujt7TUHp17eS7JarTidTnOe0eVw1mw2Sz6fp1KpEI/HabVaBAIBDMOgv7/fbMYODw9pNBrY7XZu377N/Pw8mUyGJ0+eMD09bcaE379/n6WlJTY3N6nVajSbTXO462VqnhBCCCFev6seWv8HwCwX84cqwDhwD5gHfuX1lCaEEFenKAqRSIRYLEYwGKSrqwuXy8WNGzc+cc+o1Wpht9tZX19nd3fXjOrO5/MYhkF3dzcDAwPcuHGDTCbDixcvUFWVrq4ums0mmqaxs7ODpmnkcjlarRb1et1MvkskEmiaZj5/8OABDoeDbDbLzMwMx8fHqKpKOp3mzp073Lx5k8PDQ168eMHOzg4nJycUi8VrXk0hhBDi6+OqDdF94L8xDKMM6IBqGMYc8FvA339dxQkhxGfV3t5OX18fgUCArq4urFYrY2NjuN1u4OL43GWK3IsXL1hfXzdnFGUyGTRNIxKJ0N/fz8TEhJkaZxgGQ0ND1Ot1DMNgZWUFXdfJZrM0Gg1qtZoZ/z0+Pm6mxxWLRe7cuYPH46FQKLCwsMD6+jrt7e0cHh4yMjLCrVu3OD8/5/nz5xwdHZFMJs0GTQghhBCv11UbIoWLnSGAM6Dn5eeHQOJVFyWEEJ9HKBQiHo8TCoWIRqM4nU7i8TjBYBC4GOBaLBbNWOwXL16QTqcxDIN0Om0mv8XjcSYnJwHY3Nwkl8sxNDREs9k0ZxW1Wi2y2Sz1ep1yuUx3dzd+v5+bN29itVrNobC3bt0iGAxSq9XY3NxkZmaGzs5Ojo+PGRwc5NatW1SrVZaWlkin05ycnEgstxBCCPFzcNWGaBm49fLzp8B/pijKI+BvAS9eR2FCCPF5+Hw+YrGYOTfI7XYTjUbp6uoCoFKpkM1mcTqdnJ6esra2xsnJCbqumzHdgUCAWCzG2NgYNpuNra0tcrkciUQCRVFwuVysra3RaDTMpqhardLR0YHf72dkZASn04nFYiGVSjExMUEkEqFarbK7u8v7779PNBrl4OCAzs5OHjx4gM1mY2ZmhrOzM1KpFGdnZ7RarWteTSGEEOKr60qx24qi/ALgMQzjXyuKMgj8P8AokAb+kmEYP3ytVf4MErsthPhZ6vU6R0dHnJ2dcX5+TiaToVQqcXR0BIDVasXv96PrOna7nampKQKBAA6Hg0AggNPppFarcXR0xObmJul0moGBAbq7uzk+PqZWq6HrOtFoFL/fTzAYxOFwYLPZaDQaZgR3sVhE13XC4TAnJyfs7Oxgs9kIh8N885vfJJ/P4/V6aTQazM/Pk8vlmJiYoKuri0gkIrHcQgghxOfwuWO3DcP43sc+3wbGFUVpA3KGnOcQQnyBORwOYrGYmTx3GbBwGcutaZqZQNdqtZibm+PWrVv4fD7gYs6R1+slFouhqio7Ozvm3+vp6SGbzVIoFEgmkzSbTQzDwO/34/F4sNlsRKNRdF0nnU5zdnZGOp0mHA6jqiqbm5ucnJzw/e9/n3feeYd6vQ7AvXv3WF5eZmVlhVqthqZpGIZBMBjE6XRez0IKIYQQX1FXjd3u4iJI4fDymWEYWUVRehVFaRqGkXptFQohxOekqip9fX2oqsrJyQl2u51UKsXQ0BBbW1sYhmE2RRaLhYWFBSYmJsz7O5cR2z09PVgsFlRVZXt7m1qtxsDAADabzbzzU6vVsFgs6LqO2+1GVVVisRhw0Zzt7e1RKpXw+XxMTU2xuLjI2dkZP/zhD3nw4AF+v59iscjt27dxOp3mz6nX6/T29hIKhcw5SEIIIYT4/K56h+h/A37xU57/AvC/vrpyhBDi9bicVdTb24vH46Grqwu3283Y2Jj5nkKhgK7rWK1WFhYWODk5IZ/PU6/XyWazWCwWent7SSQSjI2NcXZ2xubmJna7nVgsRqvVolarsbOzQ61Wo1AooGkazWaT/v5+AoEAIyMj5vssFgtvvPEGdrudXC7HBx98wPHxMR0dHeTzeSYnJxkZGeH4+JiNjQ329/c5PT2lUChc40oKIYQQXy1XbYjuAf/fpzz/0cvXhBDiC+/js4r8fj+RSASn08n4+Lh5FK1QKJix3BsbGxwcHJiBCZlMBkVR6OzsZHBwkBs3blCpVNjc3ETTNAYHB2k2mzSbTZ4/f46maWQyGVqtFo1Gg1gshsvlYnJy0nxfsVjkwYMHeDweisUiz549Y2lpie7ubpLJJKOjo9y8eZNCocDq6irJZJJUKiUJdEIIIcQrctWGSAUcn/Lc+VOeCyHEF1Y4HDZnFUUiERwOB/F4HL/fD1zEcp+fn+N2u9nb2+PFixfkcjnq9TonJycYhkF7ezv9/f2MjIxgGAYvXrygVCoxPDxs3lNaXV017w/VajUajQZ9fX04nU7u3LmDrusYhkEmk2F6eppwOEylUuH58+f8+Mc/JpFIcHR0RDweZ3p6mmazycLCAqlUitPTU87OztB1/TqXUgghhPjSu2pD9CHwVz/l+W8CH726coQQ4ucjFAoRi8UIBoNEIhF8Ph/RaJT29nYAqtUqhUIBl8vF6ekp6+vrnJ+fU61WOT09RdM0gsEg/f39jI6OmiEJ2WyWeDyOzWbDYrGwurpqHrmr1+vUajVzZ2pqagqbzWY2TePj43R1dZnH7t577z0GBwc5OzvD7/dz9+5d7HY7c3NzpFIp0uk06XSaZrN5zasphBBCfHldKVQB+JvAHymKMgX80ctn3wamgX/jdRQmhBCvm9/vR1VVVFVFURRUVcVqtaKqKqlUimq1isViwe12UywWmZ+f59atW2iaBlw0VZfzjqxWKzs7O6ytrTE0NERvby/JZNKcORSJRMykOMMwCAQC2Gw2RkdHOTg4IJfLkUqlSCQSOJ1Odnd32d7epl6v8+1vf5t8Po/VauXOnTssLy8zNzfHjRs3zGS7y7hvIYQQQnw2V43dfqIoykPgbwB/8eXjZ8BfMwxj4XUVJ4QQr5vb7aavrw+LxYKiKNhsNprNJi6Xi93dXcrlMo1GA6/Xi6ZpzM3NMTk5ia7rKIqC1+v9RCy33W5nd3fXnE2UzWbJZDKcnp7SaDQACAQCADidTlRVxTAMM6kuk8kQiUTMoa//P3v3GhtZnt73/XvqnFP3+5V1YRXJItnN7p7ZmzSaVVZe20FiBYIdQIadi5PYDpLYgRPYQJIXNhBISaDEBoLYSWC/iBXLDpwgQBLDlhBAXl3Wu1rsZrWjnemZne5mk81rFVn3+73OqX9edPNoerSr7ZnmTPfMPB9gsGSxWPzPeTN49v88v6darfK1r32Nr3zlK7hcLieB7v79+9y7d4/xeIxlWc6Nld/vf5GPUwghhPjEedYbIp4UPv/OR3gWIYR4Ia52FZmmycXFBfl8nlqt5sRyL5dLRqMRfr8f0zS5e/cut27dwrIsAKcYWV9fxzRN57ZoNptRKBScWaRer8discDlcjn7jQzDYG1tDaUUPp+P4+NjBoMBwWCQL37xi0573Ne//nV+8id/klQqRaPR4M6dO04s93w+x7Zt55+rHUpCCCGE+PGedYZICCE+1QzDIJ/Ps76+TjgcJpfLEQgE2N3dBWC5XNLv91kul7jdbn7wgx/QarVot9uMRiOazSaGYZDNZtnd3WV7e5t6vc7R0REAW1tbrFYrJpMJx8fHzOdzer0ey+USTdPI5/OEw2Fu3rzp/C3btvnyl7+M2+2m0+nwrW99i4ODA9bX1+l0Ok/Ff9+/f5+LiwtarRbdblcS6IQQQohnJAWREEI84XK5yGazTlGUTqfx+Xzs7e1hmibwOJZ7Mpng8/k4PDykUqnQ6/WYTCbU63UMwyCdTlMul7l9+zbT6ZSjoyMsy6JcLqNpmhPLvVgs6HQ6TKdTlFLkcjn8fj+f+9znUEoxn88Zj8f81E/9FOFwmPF4zJtvvskbb7zB1tYW7XabQqHAnTt3mE6n3L171ymK2u22JNAJIYQQz0AKIiGEeA9N00gmkxSLxadiube3t51WtOFwyGg0IhAIcHFxwfHxMePxmPF4zMXFBfA42rtUKrG7u4tt2zx48IDBYMDm5qZTXO3v7zObzeh2u8xmMyzLYm1tDa/Xyxe+8AV0XWc2m9FqtXjllVdIp9MsFgveffddvvGNb7C7u8tgMCAej3P79m0Avv/971OtVmk2mzSbTaetTwghhBA/nBREQgjxQ7w3ljubzRIIBMhms6RSKeDxrqJ+v49pmnQ6He7du8disWA8HlOr1bAsi3A4zPr6Ojs7O3i9Xh4+fEiz2WR9fZ1gMAjAo0ePmE6ntFot5vM5i8WCRCKBx+Phzp07BAIBLMui1+uxt7dHsVjEsiwODg74tV/7NXK5HJZlOe8PhUK8+eabTlHUbreZz+cv8lEKIYQQL7VnDlW4omlaBmgqpaQXQwjxqRYOh9F1nWq1CoBpmk489+XlJZPJBF3XnVjuu3fvcvv2bWcuKBKJPBXtfXZ2xqNHj5ybIMMwaLVaTiw3QDQaZbVaEYlEmM1m7OzscHZ2RqvVol6vUyqV8Pl87O/vU61W+fVf/3V+5md+BqUUw+GQV155hf39fd555x0nge7q8ySBTgghhPiDnqkg0jTNBH6Jx8tZfcAucKRp2t8CTpVSf++jO6IQQrw4gUDASaBTSmEYBi6XC8MwOD8/ZzgcYlmWc5Nz9+5d9vb2nFAD27YJh8MUi0Xcbjcej4ezszOWyyWFQgG3283FxQXNZpPFYoGmafj9fgKBAD6fD03TKBaLeDwezs/PabVaxONx7ty5w7vvvusk0L3++utkMhlqtRp7e3vOLqPJZOLEcl/dWgkhhBDi9z1ry9wvAH+Sx7Hb7+29+F3gL1zzmYQQ4qXi9XopFApks1lCoZDTQre1tQXAdDplMBhgWRaapnHv3j36/T7NZpPBYECn08Hn85HL5djY2GB9fZ2LiwtOTk7weDxsbGxg2za9Xo+zszOm0yn9fp/FYoHH4yGRSJDJZNjd3WWxWNDr9fD5fHzpS1/CMAza7Ta/8zu/w9nZGcVikfF4zNbWFtvb2zSbTd59912q1SrtdptOpyMJdEIIIcR7PGtB9G8Bf1kp9c+A97bK/YDHt0VCCPGpZpom+XyefD5PIBCgUCgQDAadWO7FYkG/33fmeQ4ODmi1WvT7fbrdrpNAl81mKZfL7O7u0ul0ODw8BKBcLmMYBtPplIODAxaLBd1ul/l8jq7rJBIJIpEIt2/fxrZt+v0+q9WK1157jWAwyGAw4Lvf/S5vv/025XKZ6XRKLpdjb2+P0WjE3bt3ncWvzWZTEuiEEEKIJ561IMoBpz/kdYMPMYckhBCfRLquk81mnWJobW0Nv9/P7du38Xq9KKXodruMRiOnxe309JTJZOLcGGmaRiqVYmNjw7nxuXfvHuPxmFKphMfjwbIs9vf3mc/ndDod5vM5mqaRSCQIBoO8+uqruFwuRqMR4/GYz3/+88RiMWazGW+++Sbf+MY3nPCFeDzO3t4eLpeLt956i8vLS+csy+XyRT9SIYQQ4oV71oLoXeCP/JDX/yzwe9d3HCGEeLlpmkY6nXZ2FWWzWaftLRqNAjAYDJjNZng8HhqNBoeHh0ynU+emyLIsotEopVKJ7e1tTNPk4ODA2SsUCoVYrVYcHBwwnU5pt9ssFgvgcfqd1+vl1VdfxefzMZlMGI1G3L5920mce/jwIb/5m79JKpXCNE0CgQA3btzA5/Px1ltvcXR0RKfTod1uM5vNXuTjFEIIIV64Z73d+a+Af6xp2jqgA39G07SbwL8N/Nyz/jFN034W+B+ffMYvK6X+5o94358G/m/gJ5VSbzzr5wshxMclHo87aXO6rtNqtVBK4fV6qdVq9Ho9gsEgfr+f0WjEo0eP2NjYcPYCxWIxwuEwpVIJXdepVCrOAtdMJuPEeR8fH5PNZrFtm3g8jsfjcZa07u3tcXR0RLvdxrZttre38fl8HB0dcXJywmw246tf/Sput5tut8vu7i4nJyfcu3eP6XTK1tYWSinC4TCBQOAFP1EhhBDixXimgkgp9Wuapv1Z4G/weIboF4DvA39SKfWbz/IZmqbpwN8F/hWgAnxP07RfVUrde9/7QsBfBb77zP8WQgjxAlxFal9cXGBZlrNw1TRNzs/PGY1G6LqOz+djPB6zv7/Pzs6OszD1Kpa7VCphGAZut5uzszMsyyKbzToJdLVajeVyicvlcoqsq6Joa2sLr9dLtVrFtm3n9x4+fEitVuM3fuM3+Omf/mnW1taoVquUy2Xcbjenp6fM53OWyyWLxcI5jxBCCPFZ88zzP0qpfw788+f4W68Bh0qpIwBN0/5P4F8H7r3vff8N8LeA/+I5/pYQQnws/H4/hUIB0zRpNBqYpsnl5SWbm5scHx/T7/dZLpf4fD5s2+bBgweUSiU0TWO1WmHbNtFo1InWviqmFosFxWKRjY0NKpUK7XabyWRCqVRiuVwSDofx+/24XC7y+Txer5fDw0NarRaJRILPf/7z3L17l06nwze/+U0+97nPsbOzQ7VapVAoOPHfk8mEW7dusVqtnJkjTdNe9GMVQgghPjbPOkN0HfLA+Xu+rzx5zaFp2heBdaXU//sxnksIIZ6L1+sll8uRzWbx+/3k83mCwaATyz2ZTJx9RZqmcXJyQqvVYjgc0mq1aLfbGIbB2toam5ublMtl2u02BwcHKKUolUqYpsliseDo6MiJ3l4sFni9XoLBIKlUir29PSzLotFo4HK5+OIXv0g4HGYwGPC9732Pt956y9l9dBXsMJ/Peeedd54KW7hq6xNCCCE+C56pINI0bahp2uBH/XMdB9E0zQX8D8B/9gzv/Y80TXtD07Q3ms3mdfx5IYR4LqZpksvlyOVyBINBcrmcE2ZwVcx0u10WiwWGYVCtVqlWq8xmM1qtlpNAl0wmKRaLTgLdgwcPmE6nFItFvF4vs9mM/f19JpMJrVaL2WyGaZoEg0Hi8TivvPIKuq7TbrdRSvHKK684CXR3797l29/+NolEAr/fTzKZdOK+33zzTU5PT+n1erRaLebz+Y//lxZCCCE+BbRnWdCnadqff99LJvAF4E8Dv6SU+p+f4TO+DPyiUupPPPn+rwMopf67J99HgEfA6MmvrAEd4E/9YcEKP/ETP6HeeENyF4QQLwelFO12m8vLS6bTKc1mk9FoRLVaZTgcAjghBtPplGQyST6fxzAM4vE4yWQSXdcZDodUKhUnHGF7e5tIJEKr1aLT6eByuVhfX8fv95NIJNB1HaUU8/mc6XTKw4cPGQ6HBINBwuEwR0dHVKtVAAqFAl/96ldZLpf0+30mkwmVSoVOp8ONGzecxLxIJILf73+Rj1MIIYS4Fpqm/Z5S6id+2M+eNVThH/2ID/4+8C8DP7YgAr4H7GiatglUgX+Txyl1V3+jDyTf89n/AvjPJWVOCPFJcnXLYxgG9XodwClW2u02rVaLweDxxbrf76fX67Farcjlck67WiqVIhgMUiqVcLlcXF5ecnBwwMbGBolEAo/Hw+XlJefn56RSKQBCoRB+vx+fz4emady4cYPT01OazSa2bbOxsYHb7ebk5IRKpcLXvvY1vvKVr5BMJmk2mxSLRUzTdG6ftre3sW0by7IIh8Mv7HkKIYQQH7XnXar6deDvPMsblVKWpmn/CY+DGXTgHyil3tU07b8G3lBK/epznkUIIV4a0WgUXdeBx0WS2+1GKYXH46FarTIYDNA0DY/Hw3A45OjoiEKh4IQtJBIJAoGAs6zVNE2Oj4+Zz+dks1nW19e5uLig1Wo5C1ZXqxWBQAC/349Sio2NDWdB7Gq1olAo4PP5ePToEc1mk9/6rd/iy1/+MmtrazSbTXK5nJNsN5vNuHHjBpZlsVwuJWxBCCHEp9Yztcz9yF/WtL8B/IdKqc3rO9IHIy1zQoiX2XQ65fLykk6nw2QyoVarMZlMOD09BR7fEgWDQQBcLpezmNXn85FKpQiFQiwWC1qtFpVKhfPzc+LxOKVSidVq5RQvVzdKbrebcDiM2+1mPB6zXC6p1+ucnJzgcrlIJpNMp1Pu37/PbDbD7/fzyiuvcPPmTQaDAb1ej263y8XFBaZpcvv2bdbW1ggEAk5rnhBCCPFJ84e1zD3rDNE7wHvfqAEZIA78x0qpv38dB/0wpCASQrzsroqSRqPBbDajVqsxnU45PDwEwOPxEAgEMIzHl/apVIpUKoXH4yGRSBCLxVBK0Ww2ubi44OzsDK/XS7lcxuVyUavVGAwGeL1etre30XWdWCyG2+1mOp1iWRadTof9/X00TSOVSrFcLjk8PKTb7eJ2u9nZ2eFLX/oSk8mEXq9Hp9OhXq9j2zY3b96kUCgQCASIx+O43e4X+TiFEEKID+w6CqJfeN9LK6AJ/Aul1IPnP+KHJwWREOKTwLZt6vU6l5eXLJdLarUao9GIs7Mzp+UtHo/j8XhYLBZks1ni8Tgul4tMJkMsFkPXdef25uTkBKUU5XIZv99Pp9Oh1Wqh6zpbW1uYpkkymcTtdjObzVitVvT7fR4+fMh0OiWVSmEYBg8fPqTZbGIYBsVikddff53VakWv16PdbjuhENvb207YwtW8khBCCPFJ8VyhCpqmGTwORPiuUqp93YcTQojPAl3XyWazTthCLpej0Wig6zqXl5cMh0M6nY6TQHfVCpdKpajVas4C16t2OF3XOT8/Z39/n3K5TDwed5bCXs0jrVYrp8iyLItYLMatW7c4Pj6m0WgQDofZ29tz5pqOjo4YjUZ85StfIZFI4HK5cLlcGIbB/v4+o9GI3d1dlssltm0TCoVe9GMVQgghntuPLYiehCH8E+AmIAWREEJ8SJqmkU6ncbvd1Go1J2wBHrfNvTeBzjRNut0utm2TyWRoNBosl0vS6TQ+n49SqYRhGNRqNQ4PDymVSsTjcYrFIpVKhbOzM9LpNACRSASfzwdAIBBgd3eX09NTLi4uWCwWTvjCyckJjUaD3/7t3+a1115zzmoYBrquO0XarVu3nLCFWCwmYQtCCCE+0Z41Ze4usA2cfHRHEUKIz4ZoNIphGFxcXACPix9N0/B6vVQqFQaDgdOWNh6PqVQqZDIZXC4X8/mctbU1vF4v6+vrmKb5VAJdLpejWCxycXFBo9FgOp3icrlYLBZEIhE8Hg9KKTY3NzFNk0qlQqvVIpfL4fV6OTo6otfr8e1vf5vbt29TLpedv22aJo1Gg7fffpubN2+ilMKyLOLxuDP/JIQQQnzSPOsM0b8G/E3gF4DfA8bv/blSqvORnO4ZyAyREOKT6ipgodVqsVgsqFarzlwRgM/nIxgMopRyWu5CoRBut5tCoYDf72e1WtFqtZywhXA4zObm4+DPq7AFv9/P1tYWLpeLRCKBYRgMh0MMw+Dy8pKTkxNs2yadTjObzTg4OGA4HOLxeNjd3eX27dvYtk2j0aDdbjs3V3t7e6yvr+Pz+SRsQQghxEvtOkIVVu/59v1pc0op9cJyWKUgEkJ8ki2XSxqNBo1Gg/l8TrVaZTKZcHR0BDxus7ua54HHCXRXNz2ZTIZIJILL5aLT6XB5ecnp6Skul4tyuYzH46Hb7dJqtTBNk42NDSdsQdd1ptOp0753cnLCZDIhmUyiaRqHh4e0220Mw6BQKPDaa69hGAatVotarUa/32c8HrO9vU2pVHLmmyRsQQghxMvouUIVnvhj13geIYQQT5imSTabRdd16vU6+XyeRqPB9vY21WqV6XRKq9UikUjgdru5vLxEKUUwGHQS6xKJBNFoFNM0MQyD8/Nz7t+/z/b2NtFoFLfbTaVS4dGjR6yvr7NarUgmk3i9XubzOel0GtM0OT09pdFoEI/HuXXrFo8ePXJukCaTCa+//rrze+fn505K3XA4dMIWlsslkUjkRT9WIYQQ4pk9a0F0DJyr910naY8nadev/VRCCPEZchWtfZUSp+u6037WarWcCOxIJIJhGDQaDRaLBclkkmazyWw2I5vNOstZDcOgWq3y6NEjisUisViMra0tqtUqp6enZDIZ4HHYgt/vx7ZtwuHGIN0hAAAgAElEQVQw5XLZuTGyLMu5ZTo/P6fRaPDNb36TL3zhC2QyGXZ2dpzbqKtZpVu3bj01VyRhC0IIIT4JPkhBlAUa73s9/uRnsrpcCCGew1Vr3FVRpJTCNE0n9rrVatHv9wmFQk4rnGVZpFIpVqsVy+XSCVlYX193EuiOjo7I5/Osra2Rz+ep1WpcXl4ym82csIVoNArgLHZ1u91Uq1Xm8zmlUgld16lWq/R6Pb73ve9x8+ZNyuUyGxsbuFwudF2n3+9z9+5dbt26RTqdxrIsZ15JCCGEeJk963+pNJ6eHboSBGbXdxwhhPhsC4fDGIaBYRgopfB4POi67uwKGg6HWJZFOBxmNBoxn8/JZrOsViuOj48pFAp4vV4KhQKGYThJctPplI2NDXK5HN1ul06nw2w2Y3t7m2az6bTCTadTyuWyE7NdqVRYX1/H7/dzcnLCYDDg3r17jEYj7ty5w8bGBl6vF4DhcMjdu3fZ3d2lVCoBj2+hrn4uhBBCvIz+0FAFTdP+pydf/hXgV4DJe36sA68BC6XUv/SRnfDHkFAFIcSn0WKxoFarOfuHKpXKUwl0brfbmdXRdZ1MJoPP58PtdrO2tkYsFmO1WtHv952wBcMw2N7exjRN+v0+jUYDwzCcsIVUKoXL5WI8HuP3+6lUKlQqFYbDIYVCgfl8zqNHj+h2u2iaxtraGq+99hrBYJB2u83JyQnT6ZTxeEypVGJ7e5tIJEIoFCIQCLzIxymEEOIz7kOnzGma9vUnX34V+A6weM+PFzzeS/TfK6UOrueoH5wUREKITyvbtqnX69TrdWazmdM2V6lUmM/nAE4qnFKKtbU1AoEAbrebWCzG2toaq9WK+XzuFDfT6ZTt7W38fj+TyYRarcZqtaJYLBIMBp0Qhul0itfrpdlscnZ2RqvVIplM4vF4OD4+ptlsYts2yWSSL3zhC6RSKSzL4sGDB0wmE3q9HqlUips3bxKPxwkEAkSjUZkrEkII8UJcR+z2rwB/VSk1uO7DPS8piIQQn2ZKKVqtllMUNZtNGo0G3W6Xfr8P/P6iV4B4PE44HMbtdhMKhSgUCrhcLizL4vz8nFqtRrfbZWNjg3A4jGVZTlpdMpkkkUgQCoUIBoPOnNFoNHIS6AKBAIlEgpOTE+r1OvP5nGg0yq1bt8jn83g8Hvb39+n3+/T7fTweD6+++irJZBKfz0cikUDXZexUCCHEx+u5C6KXmRREQojPgsFgwMXFBf1+n+FwSK1Wc9LnAEKhEF6vF8uyiEQiJJNJ3G43Xq/XCT9QSnFxcUGj0eDi4oK1tTVyuRzL5dJJs4vFYk4oQzwex7IsLMsC4Pj4mIuLC2c30fn5OZVKhclkgt/vZ2dnh52dHbxeLycnJ06hZVkWt27dIpfLyRJXIYQQL8R17CESQgjxAoXDYXRdxzRNAHw+H9VqFY/Hw8XFBcPhkOVySTQaZTQasVgsyOVy2LbNwcEB6+vrBAIBcrmcUyidnp4ym80oFoukUilM06TT6XBwcMDm5iatVsspXiaTCbu7u+i6TrPZ5OTkhI2NDSfiezgcsr+/z2Aw4NVXX6VUKhGJRNjf30fXdd59910mkwmbm5vOv48scRVCCPEykBsiIYT4BLkKW6jVati2zfn5OYPBgGq1CoBhGE6ggmmapNNpvF4vHo+HdDpNIpFgtVoxHA65uLjg/Pwcl8vF1tYWpmkym82oVCq4XC5KpRJer5dUKoWmac5NULVapVKpMBgMKBaLTKdTjo+P6fV6rFYrUqkUn//850mlUiyXS9566y1s22YwGJDL5ZyFsaFQSJa4CiGE+FhIy5wQQnyK2LbtJNDN53MajQadTofLy0sWi8fZN8lkEpfLhW3brK2tEQwG0TSNaDRKsVjEtm0WiwXVapVarcZgMGBra4tAIIBt21QqFRaLBWtra8TjcSKRCD6fj8lkgtfrpdPpcHZ2RrPZJB6P4/P5ODo6otvtslwuiUQi7O3tkcvl8Pv9vPXWW4zHYyaTCcFgkJs3b5JMJgkEAsRiMVwu1wt+qkIIIT7NpCASQohPmfeGLUwmEzqdDo1Gg1arxXA4BB63pXm9Xmzbdooa0zTx+Xxsbm6yWq2emitqNpsUCgXnFqnZbNLr9UgkEk6sdywWYzKZoOs6s9mM09NT6vU6Ho+HbDbL8fExtVqN2WxGMBhka2uLcrlMOBzmwYMHtFot5vM5mqZx+/Zt0uk0fr/fSbcTQgghPgrXNkOkaVoOKAJP/VdLKfXND388IYQQH5SmaaRSKWeGCMDr9eJyuXC73bTbbQaDAavVCr/fT6vVwrIskskkg8GAhw8fOi1xhULBWf56fn7OaDSiVCqRTCYxTZNms8lkMqFcLtNoNEgmkywWCwzDYHd3F7fbzcXFBWdnZ2xtbTnfj8dj9vf3GY/H3Lp1ixs3bjhzRavVirt377K1tcXm5iZKKUKhkMwVCSGE+Ng9a+x2Dvg/gD8CKEB78r8AKKVeWIaq3BAJIT7rptMpl5eXzm6gi4sL2u02tVoNAI/HQzQaxbIsPB4PmUwG0zSdJa7xeJzFYsFwOKRer3N2dobb7WZra+upz9d1nXK5jGmaJJNJZ8dRIBDg+PjY2ZNUKpXodDpUKhV6vZ5TvN25c4d0Os1iseDtt99muVwymUzIZrPs7OwQi8Xw+/0yVySEEOLa/WE3RM/atP13ABu4BUyAnwH+DHAf+NnrOKQQQogPx+fzUSgUyOfzeL1e8vk86XSaQqGAYRjM53Pq9Tq6rrNcLqlWq8xmM+bzOWdnZ1QqFbxeL+FwmHw+z9bWFkopHj586BQ86+vr6LrOgwcP6PV6tFotVqsVgUCA4XDI5uYmhUKBWCzGyckJfr+f7e1tJ72u2Wzy5ptvcnJygqZpfPnLX8bv9+P3+2k0Grz11lvU63UGgwHtdpvVavWiH6sQQojPiGe9IaoDP6eUekPTtAHwE0qph5qm/RzwXyqlXv+oD/qjyA2REEI8Zts2zWbTmeG5mjFqt9tMp1Pg8eJW0zSxLItUKkUwGMTlcjnzPpZlYds2l5eX1Ot1Op0OpVKJaDTKcrmk3W7T7XZJp9NkMhn8fj+hUIjxeIzX66Xf71OpVKjX64RCIZLJJIeHh7TbbZbLJT6fj1KpRLlcJh6P884779BoNFitVhiGwY0bN1hbW8Pr9RKLxWSuSAghxLW4jhkiH9B68nUHSAMPgXvAq899QiGEEM9N13UymQxut5t6vY7L5cLn86HrOv1+n16vR6fTIRwO4/P5aDQaWJZFPB6n3++zv79PuVx2Fq8ahoHH4+Hk5IS1tTVSqRSJRAK3202j0WA6nbK5uclyuSSRSDCdTgkEAs5cUbPZpFqtsrOz4/zOZDLh9PSUyWTC3t4et2/fJh6Pc//+fQDu3r3LeDxmY2MDQOaKhBBCfOSetWXuAXDzyddvAX9Z07QS8FeA6kdxMCGEEB+cpmnE43GKxSKxWIxQKMTOzg7JZJJYLAbAYDCg3+/j8XicWSOlFMvlkgcPHjAajTBNk0wmQy6XY3Nzk2azyfHxMS6Xi3A4zPr6OtPplPv377NYLKjX685tjmVZ3Lx5k2w2i2EYHB0dUSgUWF9fJxQKObuO3njjDY6Pj0kmk/zUT/0Umqbh9Xo5PDzknXfeodPp0O/36ff7fNITUYUQQry8nrVl7s8BplLqH2qa9kXg14EEMAf+vFLq//poj/mjScucEEL8cIvFgsvLSydh7uzsjG636xRAV2EHtm1jmiZra2t4PB6UUiQSCQqFAovFgslkQqPRoFqtYts2m5ubmKaJbdtO7HepVCIUChGNRtF13bkturi4oFar0e12yefzzGYzTk5OGA6HKKUIh8OUSiU2NjYIh8N85zvfYbFYOLNLe3t7JJNJp4VO119Yho8QQohPsGvfQ6Rpmp/HN0ZnSqnWj3v/R0kKIiGE+NEsy6Jerz+1xLXZbNJqtZjNZgAkEgkMw8C2bZLJJOFwGNu2CYfDbG9vs1gsWC6XzjLYbrfLxsYGkUgE27Zpt9u0221SqRS5XA6Px0MwGGQymeD3++l2u5yfn9PpdAgEAsTjcQ4PD+n1eliWhdvtJp/Ps7OzQyqV4t69e1Srj5sPdF1nZ2fH+dx4PC5zRUIIIT4wWcwqhBCfYUop2u029Xqd6XRKt9t1ornfu8Q1GAwyn89JJBJO9LVpms5uIdu2qdVqtFotLi8vyWQyZLNZLMtiMBjQbDYJBAJsbm5iGAaxWIzxeOz87uHhIa1WC13XWV9f5+joyFnU6na7icfj3Lhxg2w2S7PZ5J133sHj8TCdTtnY2GBrawu/3084HJa5IiGEEB+IFERCCCEYDAZcXl7S6/VYLpccHx/T7/dpt9vA4/juSCTCfD4nHA6TyWSc372K1LZtm06nQ6fT4ezsDK/X6wQgWJZFrVZjsVg4wQqJRIL5fM5qtcLr9XJ0dES73WY0GrG1tUW1WnXCFjRNIxKJUC6XKRaLKKX43d/9XeDxLqR0Os3u7i6RSIRAIEAkEkHTtI/9OQohhPjkkYJICCEEALPZzLnlsSyLSqVCs9mk0WgAj0MZkskktm3jdrvJZrO43W5Wq9UfmCu6SpFbrVZsbW3hcrmcFrper+e01YXDYQzDYDKZEAqFnCKo0+mQzWaZz+ecnp4yHA7RNI1AIEChUKBcLpNIJPjOd77DYDDAtm18Ph83btwglUrh9/uJxWIYxrMGpgohhPiskoJICCGE42quqNlsOktbr26OruaKkskkLpcLpRTpdBq/389qtXL2Fdm2zWKxoNlsOvuKyuUy4XCY2WzGaDSiXq87c0Ver5dAIMB4PCYQCDAYDDg+PqbX6zm3PVffr1YrJ0J8d3eXXC7HgwcPODs7c860s7NDNpt1ftfr9b7gpyqEEOJlJgWREEKIp1zNFdVqNSaTibNQtd1uMx6Pgcc7gEKhEPP5nFQqRSgUAsDlcrG5uYnP52O5XNJsNp3PSiaT5PN55vM5i8WCarWK1+tla2sLwzCIRqNMJhO8Xi+2bXN8fEytVnNuo46Pj+l0Os5cUSgUYnNzk83NTfr9Pm+++SYej4fJZEKhUGBra4twOEwoFCIYDL7IRyqEEOIl9twFkaZpbwG/DPzvSqnuNZ/vuUhBJIQQH95gMKBWq9HpdFitVhweHtLtdun1egB4vV7C4TCLxYJIJEIymcQwDFarFdlslnQ6zXK5pNPp0Ov1OD8/x+v1UiwWWa1WrFYrarUay+WSjY0Np81tsVg4e4eOj49ptVqMRiOKxSL1et35HXg827S+vk65XMbn8/Gtb32L5XKJZVkkEglu3LhBNBrF5/MRi8VwuZ51xZ4QQojPiusoiH4J+HeBFPBPgV9WSv3WtZ7yQ5KCSAghns9sNqNerztzRefn5zQaDVqtlrOvKJPJYFkWhmGQyWSc5LhYLEapVGK5XDKZTOh0OtRqNebzOcViEa/Xy3K5dMIbstksyWSSYDCIaZosFgv8fj+NRoOLiwu63S6pVMrZmzQcDtF1HbfbTTKZ5MaNG6ytrfHGG2/Q6XRQSqHrurMI1uPxEIvFJJpbCCHEU66lZU57HOXzs8BfBP4UcAn8CvAPlVJn13TWD0wKIiGEeH7v31fU6/U4OTmh1+sxn8+B399XtFqtSKVShMNhlsslXq+XcrkMwHw+p9Vq0Wq1aLfb5PN5EomEE8RQq9WcNjjDMAgEAsxmM/x+P+PxmKOjIwaDgRPDffW9bdvouk4wGGRnZ4fNzU3Oz8/Z39/H7XazXC7Z3NykUCgQCoUkmlsIIcRTPorFrHHgLwG/ABjAbwF/Wyn1689z0A9DCiIhhLge791XNB6PGY1GTlF0ta/oqtiYz+dEo1FisZjzu8VikUgkgmVZNBoNer0eFxcXRKNRstksSiksy6JarWLbNnt7e86c0Gw2wzRNXC4XR0dHNBoNlFKsr69zcnJCt9t13uP1ellfX2dnZwfbtvnud7+LrussFguSySQ7OztEo1H8fj/RaFSiuYUQQlxvQaRp2uvAvw/8G0Cbx7dEWeDf43Er3V97vuN+MFIQCSHE9RoOh07L3Gq14ujoiGazSb/fB8AwDFKpFMvlEr/fTyqVwjRNlssliUSC9fV1FosF/X6fwWDA2dkZmqZRKpUwDAOlFI1Gg263S7lcJhKJEIlEnpoZqlQqVCoVptMpuVyObrfrLJYFcLvdTgpdKpXiO9/5DsPhEKUUfr+f7e1t1tbW8Hg8xONxieYWQojPuOuYIUrzuOD5i0AZ+FXg7yulfuM97/ky8BtKqY815kcKIiGEuH7z+ZxGo0Gz2cS2bc7Pz7m8vHTCFwBSqZQzw3NVfNi2jdfrZXt7G6UU4/GYdrtNs9lkMBhQKpUIBoMsl0vG4zG1Wo1EIkGxWMTtduN2u525om63y9nZGf1+n0gkgq7rzlyRy+VC0zRisRjlcplSqcT+/j6VSsUJVdjc3KRYLOLz+aSFTgghPuOuoyBaAIfA/wr8I6VU64e8Jwz8M6XUH3vO834gUhAJIcRHw7ZtarUa7Xab6XRKr9fj7OyMbrfr3NRcFRqWZbG2tobP53Na1Eql0lPR3L1ej8vLS9LpNJlMhuVy6RRbhmGwu7uLaZoEg0Gm0yl+v5/FYuFEcV/tJnr06BHD4RDLsnC5XHi9XkqlEru7uwyHQ958801cLheWZZHJZNje3nZa6MLhsLTQCSHEZ9B1FEQ/o5T6nWs/2TWQgkgIIT46Sil6vZ4zEzSfzzk8PHxqrsjv9xOJRJ6aK7paoJpMJslms9i27dwSVSoV/H4/uVwOAE3TqNVqDIdDdnZ2nMJluVximiaGYXB2dkatVmOxWJDJZGg0GrTbbZbLJZqm4Xa7SSQS7O3tEQqF+O53v8tsNsO2bSKRCOVymWQyidfrlRY6IYT4DLqOgui3gZ9XSvXe93oY+KdKqT9+LSf9EKQgEkKIj954PKZer9PpdLBtm5OTEy4vL525IoB0Oo1SyonIdrvdWJZFKBRiY2MDgH6/T7/fp16vM5/P2djYcFLiJpMJ1WqVTCZDPp/H5/M5Nz2BQIBWq8XJyQmj0YhEIsF0OqXRaDAej3G5XLhcLqLRKFtbW5RKJd5++22azSYulwtd19na2iKXyzkFnNfrfUFPUwghxMftOgoiG8gqpRrvez0NVJVS5rWc9EOQgkgIIT4ey+WSer3utNB1Oh2Oj4/p9/tOIEI0GsXtdrNarchkMk4LnaZpbG5u4vF4mM/nNJtNut0urVaLXC5HPB5nPp+jlOL09BS3282tW7fQNA2fz8discDr9TKbzTg6OqLf7+PxeAgEApyfnzMej1FK4XK58Hg8FAoFbt68SbPZ5N1338U0TWzbJp/Ps7GxQSgUIhAISAudEEJ8RnzogkjTtC8++fIN4F8FOu/5sQ78CeA/UEptXM9RPzgpiIQQ4uPz3mju4XDIeDx2iqLRaARAMBgkGo0ynU6JRqNEo1EMw8C2bdLpNOl02plPGgwGXFxcEAwGnQWvVyl0w+GQvb09PB4PoVCIxWKBYRgYhsHx8TGXl5fouk4qleLy8pJer8disUDTNAzDIJlMcvv2bTweD9///veZTqfOMtmtrS0ymQymaUoLnRBCfAY8T0G0Aq7e8MP+L7Qp8J8qpf7Bc5/yQ5KCSAghPn6j0ci5LbJtm8PDQ1qtFoPBAACXy0UqlcKyLPx+v9NCdxXVXSqVcLlcTkDD+fk5q9WKfD7vtNrNZjOq1Sq5XI5sNovX60Up5cwMNZtNzs7OmM/nxGIxhsMhrVaL+XzupNCFQiGnhe7u3bu0221WqxWmaVIulykUCvh8PmmhE0KIT7nnKYhKPC6EjoDXgOZ7frwAGkop+xrP+oFJQSSEEC/GVetbs9lkuVxSrVapVCp0u12u/tsSi8Vwu90opZxo7ven0I3HY1qtFr1ej06nQy6XIxKJODdCh4eH+Hw+9vb20DQN0zRRSuHxeBiPx5ydndHpdAgEApimycXFBaPRCF3Xgcc7iwqFAnt7ezQaDfb399E0DaUUuVyOjY0NIpEIfr+fUCgkLXRCCPEpdK2LWV82UhAJIcSLs1qtqNfrNJtNxuMx4/GYR48e0e/3nWjuq9S4q3a1q8JluVyytrZGOp3Gsizq9Tqj0YhKpUIkEiGfz2NZFsBTLXRer9eJ+r7afXR2dka9XkfXdSKRCPV6ncFgwGq1QtM0XC4X8XicO3fu4HK5uHv3rpNCl0gk2NjYYG1tTVrohBDiU+pDFUSapv088GtKqeWTr38kpdQ/ef5jfjhSEAkhxIv33mhu27bZ39+n0+k40dy6rhOPx1mtVgQCAZLJJLquo5TC5/NRLBbRNI1Op8N0OuX09BRd18nn85im+Qda6NbW1vB6vaxWK9xuN7quc3l5SaVScaK2B4MBrVbLuWm6Cly4aqH7wQ9+4KTmeTweisUixWLRuSmSRa5CCPHp8WELohWwppRqPPn6R1FKKf0azvmhSEEkhBAvh9ls5swVLRYLzs7OqFQqTlEEj1PorgqZTCaD2+12AheKxSKBQIDxeEy73abT6dDr9cjn84TDYWazGaZp8vDhQ/x+P3t7e+i6jmEYTgvdZDLh+PiY0WiE3+93dhyNRiNM03QKqGw2y61bt6jVahwfH7NarVBKkc/nKRQKxGIxJ55bWuiEEOKTT1rmhBBCfCwsy3LmiiaTCaPRiIODA/r9PvP5HPj9FrrVauUUHm63m/l8TjqdJpVKoZTi8vKS6XRKpVIhGo2Sy+VYLpe4XC7q9Tr9fp+9vT0CgYAT9X01X3R+fk6z2cQ0Tfx+v5OKd/Uey7KIRCK8+uqrmKb5VAtdLBZjc3OTdDoti1yFEOJTQgoiIYQQHxullLN8tdvtYlkWBwcHdLtd57bINE1isRi2bRMMBonH4+i6zmq1wuv1UiwWMU2TdrvNZDKhUqmgadpTLXSLxYLT01Oy2Sz5fN5pizPNx6vxWq0W5+fnKKUIBoMMBgM6nQ7L5RLDMJyAhlKpxObmJg8ePKDb7TKfz/F4PJRKJYrFIj6fj3A4LC10QgjxCfY8M0TPRGaIhBBCvN90OqXRaDgpdGdnZ1Sr1R/aQqeUIp1O43a7nRa1fD5PKBRiNBrR6XQYDAa0221yuRzRaJTZbIbb7ebRo0fous7Nmzdxu924XC4Mw0DXdWazGY8ePWI8HhMMBrFtm2azyXA4xOPxoJRC13USiQSvvPIK7Xab4+NjbNvGtm1yuRzFYpF4PI7H4yEWi0kLnRBCfAI9zwzRs5AZIiGEED/UVXpcq9ViOp0yGo14+PAhg8HAaaG72gO0Wq2IRqMEAgEMw2C5XBKLxVhbW8PlcnFxccFkMqFarRIOhykUCs5tz9Xs0o0bNwiHw84NkNvtxrZtKpUK9Xod0zTx+Xy02236/T5KKWfvUTAY5MaNGwSDQe7fv894PMayLKLRKKVSiWw26xRFbrf7BT9ZIYQQH4S0zAkhhHhhrlroGo0GnU4HpZTTnnZ1W2QYBtFoFHg8Y5RKpYDHC15dLhf5fJ5gMEiz2WQ6nVKtVgGcFrrlcgnAwcEBqVSKjY0NXC4X8Ljgsm2bwWDAyckJSikCgQD9fp9er8disXBui67+1u7uLo8ePaLVarFcLtF1nVKp5AQ8BINBgsHgx/0ohRBCfEhSEAkhhHjh3ptCZ1kWp6ennJ2dMRqNnPdczeqsVivS6TSGYeDxeFgul2QyGeLxOJPJhHa7zXA4pN1uO69Pp1PcbjdnZ2csFgtu3brlRHKbponL5WI+n3N0dMR4PCYQCGDbNp1Ox1nkahgGlmURi8W4ffs2o9GIs7MzZ6dSOp1mfX2dVCqF2+12Zp+EEEK83GQPkRBCiJfC1QxPvV53Wuj29/cZDAYsFgsA3G43sVgMpRSRSMRJkbNtG5/PRzabxe12c3l5yXg85uLigkAgQC6XQymFpmkMBgMqlQrlcpl0Oo3L5ULTNKe4qtfrXFxcOEEJg8GAwWCAbdt4vV6WyyVut5tyuUwmk+HBgwdMp1Pm8zl+v5+NjQ1yuZzT7uf1el/kYxVCCPFjyB4iIYQQL5V+v0+z2aTVarFarTg4OKDVajm3RS6Xi1gshq7reDweEokEgBOvncvliEQitNttRqMRrVaLyWTC+vo6Pp+P+XyO2+3mwYMHBAIBbty4gaZpuFwufD4fq9WK4XDo7CAKBoP0+30nHvwq6GG1WpFKpbh16xbVapVWq8VsNnMS70qlkrPEVXYWCSHEy0ta5oQQQrx05vM59XqdZrOJbdtcXFxwdHT0VApdIBAgGAw6LXSmaWKaJovFgng8Tjqddm6dBoMBzWaTRCJBJpNhOp3i8/moVqv0+33u3LmD1+t1Uujcbjez2Yzz83M6nQ6hUIjFYkGv12M2m7FarfD5fEynUwKBADdv3kTTNE5OTrAsi9lsRjwep1Qqkclk8Hg8RKNRCVwQQoiXkBREQgghXkqr1cpZ5DocDpnNZty7d49+v+8EJei6TjweRylFOBwmEok4i1JdLhfZbJZQKMTl5SXD4ZBarYbb7aZYLDp/w7ZtDg4OyOfzFAoF4PEupKs0u06nw+npKT6fD4/HQ7fbZTQaYVkWHo+HxWKBruusr69TKpWcKO/xeIzf76dQKFAoFJywBQlcEEKIl8u1FESapn0R+GvArScv3Qf+tlLq+9dyyg9JCiIhhPjkG41Gzm2RUoqDgwMajQbj8dh5TyQSwePxODNGLpcLj8eDbdvE43EymQy9Xo9+v0+n02EymZBOp4nFYkwmE/x+Pw8fPgTg9u3b6LruzBVpmsZkMuHo6IjFYoHf72c6nTIYDBiNRvj9flwuF4vFgmg0yo0bNxgMBjQaDabTKUopUqkU+XyetbU154wSuCCEEC+H5y6INE37c8D/Bvw28J0nL78O/HHgLyil/vE1nfUDk4JICCE+Ha7CDhqNBsvlkkajwcHBwVMtdKZpEovFgFX2FUsAACAASURBVN9f6ur1etE0DV3XyeVyGIbBxcUF0+mUer1OOBwmk8lgWRamadLv9zk/P2d7e5tkMslqtcLtduPxeJjP51xeXlKv1wmFQiyXS/r9PsPh0Jk/Wi6XmKZJqVQiGo1yenrKcrlkNBo5+5FyuRx+v59wOIzP53tRj1QIIcQT11EQnQD/i1Lqv33f638d+EtKqY1rOOeHIgWREEJ8eiil6HQ6tFotOp0Oq9WKt99+29kXBI9b6KLRKJqm4fP5SCaTwO8HLiQSCZLJJK1Wi/F4TL1ex7ZtstksXq8Xy7Lwer28++67+P1+9vb2sCwLwzAIBoMsFguGwyGHh4d4PB4Mw2A4HDIej1ksFs5eI8uyiMfj7O3tUalUnBY6gEKhQD6fJx6PO0l0ErgghBAvznUURGPgc0qpw/e9vg28rZTyX8tJPwQpiIQQ4tNnOp1Sq9WcFrpHjx5xeXn51M6iYDCI3+/HMAxisRimaTqBBh6Ph7W1NWzbpt1u0+v16HQ6JBIJUqkUs9kMv9/PxcUFrVaL27dv4/f7UUo58z/z+ZyTkxNGoxGRSITBYMB4PGYymaDrOj6fj/F4jMfjoVwuO1Hg8/mc6XRKLBYjn8+Tz+edwAWPx/NCnqcQQnzW/WEFkfGMn/F14I8Ch+97/Y8C3/jQJxNCCCF+CJ/P50Ro1+t1Njc3yWQyTuCCbduMRiOn8Gg2m4TDYQKBgDMbdHJyQiqVYn19HV3X8Xq9XF5eMp1OWVtbY7lckkgkSKfT3Lt3j3Q6zebmJsPhEI/Hg9frZWNjw2mxCwQCTsrddDplPB47LXQPHjwgk8mwtbVFpVLBMAy63S7j8ZjZbEY+n0cphd/vJxQKyW2REEK8RH7cYtYrWeAXgf8H+P+evPY68PPALyql/t5HeMY/lNwQCSHEp9tVeEGz2UTTNO7fv8//z96dxVia5vld/777ds571tgjMiuzqma6Z3rGssaWGfsCg0HYSIzAMkI2tpAXGYEskLjjzlhCIPkGZCSEZIOwPOALI0sGhBCDMEIIWVh0V/V0VddkTWVm7HG2OPt595eLqOfpiOqq6lqiKrMy/x+pVZknI068dW4qf/1/nt9/OByy2Wz01zSbTX2fqN1uY5omvu9TVRW+73NwcMBisWA+n+vCha2tLbrdri5cePr0Kev1mh/84Af6+J26R5RlGR999BFFURBFEdfX1yRJwnq9xvd9bNvWNd9vv/02aZrqr0mShO3tbQ4PD9nZ2dGFC47jvMBPVQghXi9fZzHrFyGLWYUQQnyj8jzn8vKSwWBAURScn5/z9OnTO4ULpmnS6/WwLIs4jvE8T98BUnuMGo0G5+fnrFYrBoMBjUaDvb09qqrCsiySJOGjjz7iwYMH7OzsUJYlURRh2zZJkjAajTg7O6PVarFer1mv16xWK+q6ptlsstlsME2Tra0t9vb2uLi4oCgKptMpURTp2m+p5xZCiG+X7CESQgjxnacKF4bDIePxmKqq+N3f/V2m0yl5nqP+e9bpdLBtmyiKaLVa1HWtp0VRFLG/v89kMtEtdFmWsbe3RxRFZFlGo9Hgpz/9KWVZ8oMf/ADDMDAMg2azSZIkZFnGhx9+qCu7Z7MZm82GzWajA85msyGOY9566y296HU+n5PnOXt7e+zv7+t67na7rfcqCSGE+GZIIBJCCPHKuF24UFUVx8fHHB8f39lZ5Ps+cRxjGAa9Xg/btvE8D9M09STJ9329EHY4HNJqtdjZ2SHPczzPYz6f8/z5c9588036/T55nuv7P2macn5+zmQyodPp6FC0Xq8BiOOYxWKBYRjs7+/TarUYj8cURcFkMtH13IeHh4RhSKvVIgxfWD+REEK88u5rMWsH+FPAA8C9/Wd1Xf+Nr/uQX5UEIiGEeP2UZcloNGIwGLBYLNhsNrz//vtMp1PKstRfp+7qRFGkw4yaFoVhyMHBAcPhkPV6zWAwANCTm6IoaDabvPPOO7iuy6/+6q/qXUZRFLHZbFgulzx//pwgCKjrWhc+JElCFEX6181mk4cPHzKbzSiKgvl8ro/xPXjwgH6/r5voZJmrEELcv/uo3f5ngP8ZSIEt4IybooUUeFbX9a/f3+N+ORKIhBDi9bVYLBgMBoxGIwA++OADLi8v7xQuhGFIFEV3Chccx8GyLOq6Zm9vD8uy9O6j+XyudxltNhuiKGIwGHB5ecmbb75Jt9vVYaksS/I81xOqdrutyxRWq5U+uqcWu6qFrbPZjKqqmE6ntNtt9vf3OTg40C10Mi0SQoj7dR+B6P8Cfgj8+8Ac+APACvjvgb9T1/Vv39/jfjkSiIQQ4vWW5zmDwYCrqyvSNGU2m/HTn/6U+XzO7f/GdTodXNel1Wrp43O+7wM3e4v29/cZDoe6cMFxHHZ2drBtm7IsCcOQH//4x3qZa5qmBEGg9xEtl0uOj4/1ZGg+n7PZbHQxQ1mWbDYb2u02BwcHzOdzACaTCYZhsLOzw+HhIVtbW/rIn0yLhBDiftxHIJoBf7iu698zDGMK/GZd1+8bhvGHgf+uruu37/eRvzgJREIIIeq6Zj6fc3V1xXg8pq5r3n//fQaDAVmW6a9rNBo6xLRaLUzTxLZt3US3v7+vJzfj8ZjlcqmnRero28XFBRcXF3z/+9/Xy1zjONb13CcnJ6zXa1qtFqPRiLIs9TLXKIqYz+fYts3Ozo4OU2VZcn19TavV0k10vu/TarUIguAFfrJCCPFquI/FrNmtX18BD4H3gSWw//UeTwghhPh6DMPQxQRBEDAajfi1X/s1rq6uePLkiT6ytlwuWS6XdDod0jSl1Wrh+z5lWRIEARcXF/i+z+7uLpZlEYahvmO0t7eng87+/j4//OEPaTQafO9732M6neqjeQ8fPmSxWPD8+XM6nY4ue8iyjNlsRqPRoCxLTk5O6HQ6bG9vs1wu2d7eZjKZ8OGHHzKfzzk8PKSua5IkkWmREEJ8g77ohOh/Bf5uXde/bRjGfwX8BvC3gD8PNOq6/s1v9jE/m0yIhBBC3FbXNdPplKurKyaTCUVR6GWuqnDBMAw9LVKTmLIsaTQaGIZBWZbs7e3pooThcKgXrKr67VarxfPnz7m+vuZ73/seQRBQVRWtVoskSSiKgmfPnpHnOXEcMxwOyfOczWaD53lEUcRkMsF1XXZ3d/WuI1Uv3mw2OTg44OjoiCAIiONY7hYJIcRXdB9H5v4Q0Kzr+v8wDGML+LvAHwN+D/iLdV3/+D4f+MuQQCSEEOLTpGmq7xapxa5qmatt2xRFAdzcLfI8jziOcV0X0zQJw5CyLHFdl/39fQaDAev1msvLS8IwZG9vT/+cIAh45513aDab/PIv/zKbzYZms4nruqxWK2azGRcXF7RaLRaLhT4ip4JSlmWsVitarRb9fp80TbFtm9FohGVZ9Pt9jo6O2N7e1s8p0yIhhPhyZA+REEKI19LtZa6TyYQsy/jpT3+qdwIpURQRBAGNRoMoivTSVdd1ybKM3d1dAGazGdfX16xWK7a2tmg2m6RpSqfT4fnz54zHY95++219t0hNi8qy5NmzZ5Rlied5eplsmqa4rqunRbZts7W1pQObYRiMRiPa7Ta7u7scHR1JE50QQnwF9xaIDMN4E/j+x799r67rj+7h+b4WCURCCCF+kTRNuby8ZDAYUJYlZ2dnPHv2jOVyiWVZ+ihdu93Wwej2tKiuayzL4uDggNFoxHK55PLykmazyfb2NlVVYZomURTxox/9iCAI+N73vkeapjSbTRzHYb1eM51OGQwGhGHIer3W06KiKOh0OqzXa31nqNVq6b1Hk8kEgK2trTtNdK1WS6ZFQgjxBdzHkbke8HeA3wIq9TLwPwF/qa7r8T0965cmgUgIIcQXUVUV4/FY7xvK81zfLQJ0RXcYhvp+URRFAPi+TxRFrNdr+v0+pmkyn8+ZTqd6WtRoNMjznFarxfn5ORcXF7z99ts0Gg3quqbdbrNer8myjNPTU4qi0DuOVHmC4zg0m01dxb21tYXjOBRFgW3bDAYD4jhmd3eXw8NDoigijmP9nEIIIT7dfQSifwi8DfzbwD/5+OU/AvyXwId1Xf/pe3rWL00CkRBCiC8jSRI9LaqqirOzM54+faoXqd6+W+T7Ps1mE9u2sSxLN8QBHBwccH19zWKx4Orqikajwfb2tv45URTxzjvv4Ps+v/Irv6Jrux3HYbFYsFgsuLy8JI5jVqsV6/WaoijI85xOp8NmsyFJEqIo0mUPvu/roohut8vR0RE7Ozt6WmTbX7Q8VgghXi/3EYjWwJ+o6/r/+cTrvwn8Tl3XL+z/mpJAJIQQ4suqqorJZMLV1RWz2YzNZsMHH3ygdxjBzcTI9319r6jZbFJVFZ7n0Wg0WK1WdLtdHMdhPp/ru0X9fl8ff2u1WgwGA05OTnj8+DGtVgu4OZqXJAmbzYbLy0uSJKHRaOhpVZIkWJZFp9Ph+vqasixpt9t4ngeAaZoMh0MajQY7Ozs8ePCAZrNJo9Gg0Wi8mA9VCCFeYvcRiJ4D/0pd1+9+4vU/APyPdV0/uJcn/QokEAkhhPiq1N2iq6srqqri/Pycp0+f/tzdojiOaTQaeloE0Gw2ASiKgr29PVarFfP5nNFohOd5+midaZq0221++MMfUtc1v/qrv0pRFDQaDT0tWq/XnJ+fE4YhWZaxXC4BWK/XdLtdyrJksVjoiZVpmgRBwGw201+zt7fH4eEhnufRbrdxXffFfKhCCPESuo9A9JeBfxP4C3Vdn3382gHw3wJ/v67rv32Pz/ulSCASQgjxddR1zXg81tOiJEl0E50qS7g9GVLBqCxLHMeh1Wqx2Wz03aPZbMZkMmG5XNLv92m1WmRZRqPRYLFY8OGHH3J4eMjOzg5lWdLtdkmShCzLODs707Xdw+EQwzBIkgTDMOh2u8xmM71ENggCTNPE8zwGgwGWZbGzs8Mbb7xBq9XSz2kYxov+iIUQ4oX7SoHIMIwfA7f/8BHgA2cf//4ASICndV3/+v097pcjgUgIIcR9uD0tyrKM4XDIRx99xHK5vHO3SC1IbbVamKYJ3NwX8jyPzWbD9vY2eZ7rha62bbO7u4tlWVRVRb/f50c/+hFZlvH9739fh5ooivTxvfPzc3zfpygKZrMZpmmSJAmdTkcvi3UchyiKsG0bz/NIkoT5fE6v12NnZ4eDgwOCIKDVauH7/ov8aIUQ4oX7vED0ebcv/8E39DxCCCHES8fzPB48eEAcx1xdXWGaJs1mk48++oirqysALMtisViw2WxI05Q4jmk2m6zXa9I0pdVqMZlMME2Tra0toihiNBpxfHxMu92m0+kwGo146623yPOcd999l52dHQ4PDxmNRvR6PXzfx3VdRqMR6/Wavb09hsMhnucxm810+9x8Pmc2m+F5HkVR4LouBwcHDIdDvS/p4cOHFEVBGIay0FUIIT6DLGYVQgghPiHLMt1El2UZg8GA3//939d3i6qqoq5rGo2GnhapYKKWvC6XS7rdLqZpslqtuLi40GFG3RXa2dnhJz/5CbPZTC90tW2bRqPBcrkkSRLOzs6wbRvDMLi+vsYwDLIs01Op0Wikw5tqwsuyjNlsRhiGbG1t8fDhQxqNhp5uCSHE6+Y+F7P+88CvcHOU7id1Xf/je3nCr0ECkRBCiG9CXdfM53Ourq4YDAbkec6zZ884PT2lqips26aqblbzqUlRq9WiLEsMwyCOYwDKsqTT6ZAkCbPZjPF4TLPZpN/vU9c1juPgeR7vvvsuvu/z1ltv6Va5sixZLpfMZjOm0ylhGLJYLEjTVIeybrfLarVisVjou0We5xEEAdfX12RZRq/XY39/n93dXT0tchznRX68QgjxrbqPUoUD4B8CvwGcf/zyPvBPgX+truvzz/reb5oEIiGEEN+kPM8ZDocMBgOWyyXX19d8+OGHzOdzfYeoqiqCICCOY4Ig0PuKXNcljmOWyyVRFBGGIev1mqurK4qioN/v02g0SJKEXq/HxcUFx8fHPHjwgE6noyc+tyu667rGsiym06mePqn2OVW64HkenucRhiGO4zAcDnEch+3tbR4+fKgruqV0QQjxuriPQPQ/cBOA/lxd108/fu0x8PeA87qu/8w9Pu+XIoFICCHEt2G1WuljdEmS8Pz5c87Pz8nz/E4wiuOYVqtFFEX69UajgW3bbDYbXYwwn88ZDAaEYUi328W2bUzTpNVq8cMf/pCqqvilX/olLMsiDENc12U6nbJcLhmPxwRBwHq9Zr1eAzfBTe05ms1mWJaF7/s4jqOXv65WK+I4Zmdnh6OjIz0tktIFIcSr7j4C0Rz443Vd/3+feP0PAf97Xdete3nSr0ACkRBCiG9LWZZ3FrrO53M+/PBDJpMJgN5dZNs2nU6HMAxpNpsURYFt27TbbdI0pa5r2u02m82G8Xisl7y2223yPNdToQ8++IBOp8PR0RFws/soTVM2mw2TyYTNZoPv+8xmM/I8pygKDMOg3+8zm81I0xTbtnFdV985Ul/b7XZ5+PAh29vberolpQtCiFfVV22Z+6RPS07f7UYGIYQQ4kuwLIutrS2azSaDwYDLy0t83+fy8pKTkxM2m40OFcPhkCiKdBudek3tKxqPx0RRxN7eHsvlktFoxHQ6ZXd3l81mQ1VV/NE/+kd5//33effdd3n8+DEAjuPQ6XT0xOnq6oooinQdt2maXF1d0Ww2ieOY6+trVqsVeZ7jOA7tdpu6rvW0aTQa8eDBA5Ik0UfphBDidfJFJ0T/ENgC/mxd1ycfv/YA+G1gWNf1n/5Gn/JzyIRICCHEi6BCxeXlJZPJhPV6rSu667q+s7uo3W7Tbrd12KiqSh9vy7KMZrOp3+/6+ppGo8HW1tad+0DvvPMOpmny9ttv62N0AIvFgul0ynw+16ULeZ4DUBSFLnRQDXmu6+J5nr7blKapDmaHh4d6d5HneS/gUxVCiG/GfRyZOwL+EfAD7pYq/Bj4rbquT+/pWb80CURCCCFepDzPubq64urqitVqxXg81gtdLcuirmuqqsL3feI41lXdeZ7juq4+OleWJa1Wi6IoGA6HpGlKt9ul0WhQFAWtVovpdMpHH31Er9fj4OAAwzBoNptsNhv9s9M0xfd9ptOpfj7Lsuj3+4zHY7Isw7ZtXdjQaDQYjUbkeU6/3+fhw4f0+32iKJJjdEKIV8Z9BKIQyIE/Dnzv45ffr+v6d+7rIb8qCURCCCFeBmrX0HA41KULZ2dnFEWBaZqYpklRFDQaDdrttm6AUw11URTpxjjf91kulwyHQ0zTpN/v47oudV2zvb3Nu+++y2Kx4PHjx3r/kO/7LBYLlsslk8kE13XJ85zlckld1+R5ThzHeJ7HZDLR1eGfPEan2uiOjo5otVo6xAkhxHfZ1wpEhmFYQAL8gbqu3/sGnu9rkUAkhBDiZVFVFePxmMFgwPX1tS5duL6+BsB1XbIsA6DX6xHHMVEUUVWVnvZYlsVmsyEMQ72MdTqdEscx3W5Xv4/aXWRZFm+++SaO4+D7PkVRsFwu9f9c12W1WpEkiX7ObrfLer1muVxiGIbehdTv95nP5yRJQhiG7Ozs8ODBgzvLZ4UQ4rvoPiZEHwJ/pq7rH933w31dEoiEEEK8bLIs08fo1us15+fnnJycsF6vsSwL27b10bYoiuh0OgRBoIsPWq0WSZJQ1zVRFFEUBVdXV/pYWxRF5HlOr9fTR/Q6nQ4HBwdYlkUURbqSezKZ6ON58/kcwzBI0xTHceh2u1xfX5OmqZ5iqZB2fX2tj+o9fPiQnZ0dOUYnhPjOuo9A9G8Bfxb483Vdj+75+b4WCURCCCFeRmrX0OXlpa7WPj4+5uzsjLqucRwH0zRJ01Qfo2s0GjiOQ5qmurJb7RlqNpssFgsmkwmmadLr9XBdF4CdnR3effddptMpDx8+1HuNHMdhsViwWq2YTCY4jkNZliwWC/2z4zjGdV291FUVQmxtbQHo5rper8ejR49otVq6jU6WugohvivuIxD9GHgEOMApsLr953Vd//o9POdXIoFICCHEy6wsS0ajEYPBQLfB/f7v/z7X19eYponneWw2G+BuG11VVdR1TavVwjRN1us1nufhuq4+RtdsNul2u9R1TRAEuK7Lu+++i2maPHr0SDfUlWWpj9AtFgt8379zjK6ua3q9HmmaslgsKIpCH8Hb2tpitVqx2WywbZvd3V0ePXqkl7oGQfAiP14hhPhC7iMQ/XU+Z+dQXdf/0Vd+uq9JApEQQojvgizLuLi4YDAYsFwuubq6unOMznEckiTRR+bUYtc0TbEsi1arRVmWbDYboijCMAzG4zHr9VrfRyqKgna7zWw248mTJzSbTY6OjnS4UYFnsViQJAmu67JYLICftdF1u10WiwWbzYa6rnUoU+9bVRWO4/DgwQOOjo7wPI92u43jOC/4ExZCiM/2tQPRPT7InwT+c8AC/nZd1//pJ/78PwD+ClAAQ+Av1XX9/PPeUwKREEKI74q6rnUYGgwGrNdrTk5OOD091UFDHWULgoBer0cQBLosQYUltbg1DEOyLGM0ujnN3ul08H0fgN3dXZ48ecLFxQX7+/v0+30cx8FxHFarFYvFQh+Hq+ua1erm8EeWZfq43ng8pigKyrLEtm16vR6e57FcLimKgjiOefz4MZ1Oh0ajoadZQgjxsvnKgejjuu2/Cfyr3ByX+x3g3/sq94g+bqv7PeBf5ObY3f/LzaLX9259zT8H/JO6rteGYfw7wB+v6/rf+Lz3lUAkhBDiu6YsS8bjMVdXV1xfX7NYLHj69Cnj8RgAz/N0EInjmE6nQxRF+ntVffZisdBLXpfLJdfX1/i+f6eNrtVq8e6777JarXj77beJokiXIqzXaxaLBfP5HMdxyLKMzWaDYRhUVUWn06EsS1arFWma6orw7e1t8jxntVrp+0VvvPEGcRzTarWkplsI8dL5OoHobwL/LvDb3FRv/1ngH9d1/a9/hYf4TeCv13X9L338+/8QoK7r/+Qzvv4PAv9FXdd/7PPeVwKREEKI7yrVRnd5eclyuWQ0GvH8+XMdNNT9Itu29U6gIAio61rXdJumyWq10tXZ4/GYJEmIooh2uw1AFEWUZcn777+PZVk8fvxY3y9KkoTlcslqtWK9XuP7PvP5nLquKcsSy7KI41gvf1U7jZrNJr1ejyzLSJIEy7LY2trizTff1G10cr9ICPGy+LxAZP+C7/3TwF+u6/rvf/xGfw/4vw3DsOq6Lr/kcxwAJ7d+fwr8kc/5+r8M/C9f8mcIIYQQ3xmu63J0dES32+Xy8hLf92m1Wpyfn3N2dqbDkOu6jMdjlsslrVaLVquF67q6OS6OY6qqYj6fE8cx7XabwWDAarWi1+sBNzuSfuM3foPBYMB7771Ho9Hg4cOHuK5Lt9slCII7pQtqH1JRFIzHYxzHYW9vj9lspncYrddrHdTW6zWDwYDxeMyDBw84PDzU+4vkfpEQ4mX2iyZEGfCoruuzW69tgF+q6/rkM7/x09/rzwB/sq7rv/Lx7/8C8Efquv5rn/K1fx74a8A/W9d1+il//leBvwrw4MGD33j+/HOvGQkhhBAvvbquub6+5uLigvF4zGKx4Pnz5wyHQ+AmPKkdQkEQ6GN0vu+TJAm+7xPHMWma6sWqRVEwnU6p65p2u43ruliWxe7uLr/3e7/H+fk5u7u77O/vY5omlmXpaZFa2lpVFev1GsMw9GTI8zym0yl5npNlGa7r0m63CYKANE31PSS1v6jRaMj+IiHEC/V1jsyVwG5d18Nbry2AX6/r+umXfIgvdGTOMIx/Afhb3IShwS96XzkyJ4QQ4lVSliXD4ZDLy0smkwnX19ecnZ3dqenOsoyyLGk0GnS7XaIo0mUMURQRRRFJkuh9RmmaMp1OdXBR5Qrdbpd33nmH+XzOo0eP6HQ6d0KQCkaO45DnuW6eq6qKdruNYRjM53OSJKGqKnzfp9/v6+CW5zlxHPPmm2/Sbrf1DiPZXySE+LZ9nUBUAf8bcHtK86eA/xNYqxfquv6tL/AQNjelCn8COOOmVOHP1XX9k1tf8weBf8DNJOnJL3pPkEAkhBDi1ZRlGefn5wwGA+bzOaPRiOPjY72zKIoifdcojmO63S6e5+n9RY1GQx+DK8uSMAyZTqe6trvT6ej3Afjd3/1d6rrm8ePHunghz3MdjNTPyvOcsiwpyxLDMGi1WhRFwXq9JssyPR3q9/sAJElCXdd0u10ePnyog5H6uUII8W34OoHov/kiP6Cu67/4BR/kXwb+M25qt//ruq7/Y8Mw/gbwT+u6/keGYfwO8GvAxcffcvyLwpYEIiGEEK+y1WrFxcUFV1dXLJdLLi8vef78uS5WCIKA9Xqtixc6nQ6e55HnOaZp0mg0cF1XV2yHYchoNCLPc9rtNmEYAjdLYdfrNe+//z6O4/Dmm28SBAGGYbBer/W9IVW0kCQJeZ7rOvBOp8N6vWaz2egJllocWxQFWZbpYPT222/TbDaleEEI8a15afYQfRMkEAkhhHjV1XXNdDrV+4tmsxnn5+dcXl4C3Nlf5LounU6HdrutpzyWZdFsNrEsi8VioRfBXl9fU5Yl7XYb3/cxTZOtrS3Ozs549uwZzWaTR48eYVkWhmGQZZkuXiiKAsuydB13lmX6HtNyudQV3rcXu+Z5Tp7nGIbBzs4Ob731FkEQ6BpxIYT4pkggEkIIIV4BZVkyGo108cJ0OtW/hpv9RXVdk2UZQRDo+0WO4+gyhiiKqKqKxWKB4zhYlsVkMgGg2+3iOA62bbOzs6OLF3Z2djg4OADQwWg+n7NcLqmqSr9WVZUuXgiCgMVioY/SWZaldxQVRaED1eHhIYeHh7p4QRrphBDfBAlEQgghxCskz3M9LZpMJkwmE05PT1ksFgD4vq8DShRFOhjBTf2267rEcUySJKzX6zuNdK7r6mmS7/v0ej3ee+89RqMRu7u7HB0d6aWxSZKwE41CgQAAIABJREFUWCxI01RPo/I81/eY4jjGMAwWi4U+Ymfbtq75Vl/rOA77+/scHBwQx7E00gkh7p0EIiGEEOIVlKYpFxcXXF5eMp/PGQwGnJ+f6+KFRqPBcrnUv+71eoRhqCc6YRjSaDRYr9ekaaqD1Gw2IwxDwjDUU6UgCO400m1tbVGWJXme3wlGqqVOlS8AxHEMwHK5vBOM+v2+DkaqKvzhw4dsbW3pfUvSSCeEuA8SiIQQQohX2Gq14vLyksvLS2azGYPBgJOTE32cTRUvmKZJq9Wi2+3iui51XVMUha7qXi6XpGmqg9RmsyEIAprNJo7j0Gg0qOuan/zkJyRJwqNHj+j3+3rSs9ls9PdZlkVd1zqcGYZBHMeUZclqtdL7ihzHYWtrC8uyqKqKsizxfZ9Hjx7R7XZpt9tS1S2E+NokEAkhhBCvuLquWSwWupFuNptxcXHBxcVNcatpmriuS5Ik+j6PquouioKqqmg0GkRRpJeuBkHAarUiyzLiOMZ1XX3kLcsy3n33XQDeeustfTepqipms5m+OwTo11XzXbfbJUkSNpsNm81GT6e2t7f1zqM0TYnjmDfeeINer6d3GAkhxFchgUgIIYR4TVRVpcsWRqMR19fXXFxcMBjc7Dp3XRfTNEmSRNdlqzKDoigwDIMoivTeoqIo9D6jLMtot9vYtq3b7ObzOU+ePMEwDF3VrY7Sqf1FRVFgmiZlWepKbnVXKU1TkiRhtVqR57leNmua5p2SBhWM2u227DASQnxpEoiEEEKI10xVVYzHYy4vL7m6utK13aPRCLgJRoZhkKYpjuPQ6/V0mUGWZZimSRRFNBoNJpMJWZbRbDaZz+cURUGr1cK2bWzbZnd3l4uLC549e4bjOLzxxhv4vq8nT7PZjM1mo3cYqQlQVVX6jlKapmw2G9brNWVZEgQBvV4P0zSBm/tSqgZcTYwkGAkhvigJREIIIcRrqixLhsOhDkbqKN10OgVuqroNwyBJEl10EMcxtm3rkoRGo4Hv+ywWC32UTlVuR1GE67q4rsvOzo7eYeQ4Dr/8y7+MaZq6lW65XN6ZGKmFrWVZEoYhzWZT32Nar9fUdY3neXQ6HRzHoa5rPTFS95fiONbLZYUQ4rNIIBJCCCFec0VR6Kru4XCop0fz+RyAIAgA2Gw2uK5Lr9ej2Wzqe0eqFMFxHN0op8oayrKk0WjcCUbHx8ccHx/j+z5vvfWWbrZTS2bV0lbDMHTQUQUPvu/rO0br9VpPknq9HrZt64DVbDZ5/PixnhipfwchhPgkCURCCCGEAG52GA0GAx2MhsMhV1dXeodRo9HQR9o8z6PX69FoNHAchyRJME1TT5BUMArDUAejZrOJbdsEQUC/3+ejjz7i7OyMIAh48803sSxLT4bU95dleScY3Z483Q5Gt4/S2bZNVVUURUGj0eDx48f0+30JRkKITyWBSAghhBB3ZFnGxcUFw+GQwWDAeDxmMBjovUXNZlMHI9d12draIggCXNclTVPquqbdbuM4DtPpVO81Wq1WwE2wUsFoa2uLDz/8kPPzc3zf5/Hjx3eCkWqyU8EIIEkS6romiiIcx7lzx6goCsIwpNvtYts2cBP0oii6E4zkKJ0QQpFAJIQQQohPlWUZ5+fnOhSpqZEKRrdb41zXpd/vE4YhjuPoWu04jvE8j+vra7Is00fpAKIowrZtwjBka2uLJ0+ecH5+ThAEPH78GNu2yfOcLMt0k526Y2Sapj5ap4JRlmWs12vW6zV5nhOGIZ1OR7fnpWmqg5GULwghFAlEQgghhPhcaZrqeu7hcMhoNGI4HOqJTxAEVFVFlmU6GPm+j+u6uk3u04KRWsyqQpSaGD158oSLiwt9x8g0TR2GVqsVSZLoxbKmabJarTAMgzAM9ZRKTYyyLCOKItrtti6JyLIMz/N4/PgxW1tbdDodCUZCvMYkEAkhhBDiC8myjLOzs587SqcmPmEYUpalruve2tq6M70py1IvcVV3hHzf1zXbKtCoRazPnj3j5OQE13V58803dbtdXdfM53M9ITJNE8MwdPucumOU5zmbzUbvMXJdl263q8OPmjY9evSI3d1dWfAqxGtKApEQQgghvhQVjFQBw2QyuTMx8n2fuq7v7DFS5QtFUVAUBc1mU9d1r9drXNelqipdp+04Dr7vs7u7y8nJCc+ePcN1XR4+fIjneWRZRlVVLJdLHYTUXqI8zynLEs/zCMNQT4xUMPJ9nziOaTQaemJkWRYPHjxgb2+Pbrer/0wI8eqTQCSEEEKIr+R2MBoOhzoYqTtGvu/rPUaGYdDv93UFt7p71Gw2CcOQ5XLJYrHAtm1due37PpZl4Xkee3t7nJ+f8/z5cwAePXp0Z7q0XC7vTIxM0yRJEoqiwPd9wjCkKAp9x0iFoHa7TRRFd47w7e3tcXh4qOvFVdASQryaJBAJIYQQ4mvJsozLy0sGgwHn5+fMZrM7rXTqjpFa5trtdmm1WvqOkZraNBoN0jRlsVhgGAaWZenQZJomnuexvb3NaDTio48+oqoqjo6OiOOYzWaDYRjM53N9x0jVb5dlqe8NqerwJEl0g53aoxTHsd5zVNc1vV6PN954Qy95tSzrBX/SQohvggQiIYQQQtyLoih0MDo9PWU6nTIej/WCV9d1AXQIUcHIsizquqYsS0zTpNVqkec5i8VCT4vgZuLkOA62bbO3t8d8PueDDz6gKAr29vZot9ukaaqLFlQNt2VZWJZFmqb6LpGqDlflCyqsNZtN3T6XZRlZltHv9zk8PGR7e1svoBVCvDokEAkhhBDiXhVFwdXVFVdXV5yfnzOfzxkMBsxmMwBs28Z1XdbrtQ5A6k5RWZaUZamPs6lgpF5TC1gNwyCKIjqdDmVZ8v7777Ner9nf36fX65GmKYCeBKkCBdu2dT13EAR3gpFa9KqCURiGOpypXUYPHz7UBQye573Ij1kIcU8kEAkhhBDiG1GWJcPhUAej6XTKYDBgOp0C6PtBqqUujmMdRNQdIBWMAGazGXme6/f3PA/btnVJgu/7vPfee8xmM/r9Pru7u+R5Tl3XbDYblsslVVXdOfq2Xq+xLOtOwcJ6vSZJErIso9Fo0Gg0aLVa+j6U4zg8evSInZ0dOp0OQRB8i5+qEOK+SSASQgghxDeqqiqur6+5vLzk+PhYT4yur69Rf9e4XWoQBAG9Xo8gCLAsS98zUsfrZrOZXvyqjsOpYNRoNOj3+7z33nuMRiPCMOTw8BDDMCiKQi95VRMjwzB00FGV3epnqma6JEkIw5Bms6knWWr30cOHD9nf36fT6UgznRDfURKIhBBCCPGtqOuaxWLB6ekpJycnLBYLHYyKogBupj5VVZHnObZts7W1pSdGVVVRFAVBEBAEAUmS6OIG1Sznuq7eZbS/v8+TJ0+4vLzEtm0ODw+xLIuqqqiqivl8ru8c2bat7x6pnUjqZ6Rpynq9ZrPZYFmWLmCIokgHo62tLQ4ODtjZ2aHZbEoBgxDfIRKIhBBCCPGtWy6XnJ+fc3p6ymg04vr6mslkoic/qjxB3enpdDq0Wi3dHFcUBa7r0mg0KIpCH8ODnx3FM02TKIrY3d3l9PSU09NTyrLk4OAA3/cpioKqqvQRuaqq8DxPH53Lsgzf9/XXqmCUpillWdJsNvUxv7IsdVh74403dMmDFDAI8fKTQCSEEEKIFyZNUy4uLjg/P+fq6koHI7Xk1XVdHVDquqbZbNLpdAjDkLqudYBqNBpYlsV0OtWvqUkR3Eyeer0eRVHw5MkTVqsVvV6PXq+nq7k3mw2bzYaiKHSgyvOcNE1xXZcwDPXS19uLXlX5gjrSp1r0VAFDr9cjDMMX8wELIX4hCURCCCGEeOFuN9OdnJwwm82YTCa6mc40TXzf1810QRDQarX08lY1NWo0GjiOw3K51ItZbdvWBQyu6+o7Su+99x7T6ZQgCNjb28M0TX3PSFV2q/1H6oid4zj6CJ+q8Vb3jNQdpmazSRRFepK0s7PD4eEhW1tbxHEs94yEeMlIIBJCCCHES6OqKiaTCRcXF5ycnOgChvl8TlmWwM20Rx1RM02TbrdLo9HAdV29ANbzPKIoutMu5ziODlOWZREEATs7Ozx58oThcIhpmuzv7+M4jl7mutlsSNNUFzcYhsFms6GqKoIgIIoifc9otVrpYgh1z6jZbOqjeZ7n8fDhQw4PD2WfkRAvEQlEQgghhHjpqAKGy8tLnj9/ro/STSYTXb1tWRau6+oQ0mw2abfbBEGgQ0hd14RhiG3bzOdzkiTBMAx9nE7tM+r3+0wmE46Pj8myjG63SxzHAOR5rkNPWZa4rquPxiVJ8nOLXtM0JUkSkiSh0WgQxzHdbhe4mYQZhsHR0RF7e3tsbW1JbbcQL5gEIiGEEEK81LIs4+zsjIuLC87Ozlgul4zHY33P6PbCVQDf9+l0OjrwqFa5IAjwPI/lcqnvCqnSBNVQ12g0iKKIDz74gNlsRhiG9Pt9bNsmz3M9NVJH8SzLwjAMlsulPk6n7jylaaoDkm3bRFFEq9UijmPW6zV1XRPHsa7ujuMY0zRf5EctxGtJApEQQgghvhPKsmQ0GnF+fs7x8THL5ZLhcKjvGcHPH6frdDo0m00cx9HH6VRBgmqnU8tafd/X058gCNja2uLDDz9kPB4DsL29jeu6wM2kRzXOWZalj7+pe0tRFOF5HlmWkee5ru1WwazVatHpdHShg6oFPzo6otPp4Hnet/8BC/GakkAkhBBCiO8UdZzu4uKC58+fM5lMGI/HzOdzPSUyDAPP80jTlLqu8X2fbrdLGIa6gEG97nkei8WCzWZDWZa6mEEVObRaLfI85+nTpyRJouu2Hcdhs9noo3LqKJ5pmnpC5DgOURRR17X+WlXz7fs+zWaTbrerw1NVVfT7fQ4ODtjf35dlr0J8CyQQCSGEEOI7K8syzs/Pubi44PT0lMVicae2W4WUNE2BmwmSaoFTO43yPNfBJU1TlsslWZbpY27qOF0YhsRxzNOnT7m+vsYwDHq9HkEQ6Dru9XqtJz62bQM3U6OyLAnDEM/zdINdkiR6sWsURTSbTXq9HnmeU1UVtm3z4MEDDg4O6Ha7ejolhLhfEoiEEEII8Z2n2ulOTk50O91kMmG5XOoSBtM0dbU23Owuarfbd47ZAToczWYzXdgQhqGe/oRhSLPZZLlccnx8TFEUNJtNGo0Gtm2TpqkuXDAMQ1eDqztFqvq7qiqSJNH3kvI8x/M8Go0G3W6XIAhIkgSAVqvF0dERBwcHNJtNmRoJcY8kEAkhhBDilbJerzk7O9OTIzU1UuHidgmDaZpYlqXb6VTldlmWOvwkScJ6vSbPcz01Ug13URQRBAHPnj1jsVgA0Ov1cF1XV3enaXpnH5J6xrquCYJAN+WpNjt1/E7tNer3+7oYQlWDP3jwgF6vJ3eNhLgHEoiEEEII8UqqqorhcMjFxQVPnz5lsVgwGo1YLpeov+OoQKSmSEEQ6Ds9gL6T5DgOruuyXq9Zr9cAuqFOFTLEccxyueT09JQ0TfWSVnXXqCgK0jTFNE0cx7lT3a0a6gAdvtI01aUNYRiyvb2tyyDyPCeOYw4ODjg8PKTVaklDnRBfkQQiIYQQQrzy1NTo7OyMy8tLrq+vmc1m+m7RJ4ORZVl0Op2fmxoZhkEQBPq+0GazwbIsfVxOlTQEQaCb8Mqy1O8FkKapnhA5joPneboBrygK/f3qPtJms2Gz2VDXNZ7nEccxvV5P/7tVVcXOzg6Hh4fs7u7KXiMhviQJREIIIYR4bXza1Gg8HrNcLqmqSn+d4zi6ic51Xfr9vr5DpEoPVD13kiQsFgtdqa2mRkEQEIYhaZpydnZGlmW4rkscx/rIXlmWJEmip0bq+JwqdVA7ktbrNVVV6QmVbdsEQUC73abValGWJXVd36nvVvuThBCfTwKREEIIIV5Lm82Gs7MzTk9Puby8ZDabcX19radGgK7uhpspUhzHhGF4p1muqip838e2bZbLJev1GsMwaDQaeJ6ng02z2eTi4oLJZKLrvdUiV1XEoO4aqSmPmhJ5nofruvrYXVVVLJdLiqLQR+q2trb09KosS5rNJoeHhxweHtJut6WIQYjPIIFICCGEEK+1uq4Zj8dcXl7y9OlTJpMJ0+mU1Wqlj9DBzTE6dWxOHanzfR/HcfS+I7W7qKoq5vM5eZ7rI3VqaqTC08nJiW6xazQaOsyovUaq/CEIAl26ADeNd6ZpkqapnjCpmnHf94miiK2tLUzT1GUM/X6fo6Mj9vf39V0lIcQNCURCCCGEEB/L85zLy0td371are7sNYKfr++2LIt+v4/v+xiGoSdHqlUuz3MWi4W+M6R2IKlwlKYp5+fn+phcs9nUu5NU4FGtdrZtkyQJRVFgmiae5+E4ji6K2Gw2uk3P9306nQ5xHOtwZJomOzs7HB0dsbu7K7uNhEACkRBCCCHEp1oul5ydnfHs2TMGgwHz+Zz5fK6b5wBs29bBCG6mN61WC9d1qaqKuq4pikKHpTRNdbjyPI8wDHEcRwelyWSij9TZtq2Pum02Gz2Fchznzt2isiz1e9R1TZIk1HXNer3WzxqGIZ1Oh1arpZ/J8zz29vY4Ojpie3sby7K+3Q9YiJeEBCIhhBBCiM9R1zWTyYSzszOeP3+uQ8tqtaIsS/11hmHoOm/LsojjWLfO5XlOXdf6PpBpmqxWK30/KQxDfN8nCAJ9tO7s7EyXKQRBoJe5qn1FlmVhmiZRFJHnOVmW6RIIx3HuLIedTqf6uYIgoNfrEQQBhmFQFAVhGOr7Rr1eTyq8xWtFApEQQgghxBdUFAXD4ZDT01OePn2qp0ar1epOS526bwQ3R+xarZau8FZTm7Is8X2fuq5ZrVb6GJxa1hqGoT4qd3Z2xmaz0WUJvu/r+0Z5nmMYht5lpPYYAbrxLkkS3Y43n88xDAPTNGk2m/R6vTvH/RqNBoeHhxwcHNDtdqWMQbzyJBAJIYQQQnwFqk77+PiYy8tL5vM50+lUFyUAOniocGQYBt1uV0+C1OSoKAqCIKCuaxaLxZ07SGp6ZFkWdV1zdnamj+mpxa9qWWuapriui2VZeJ53576RZVm6AKIoCoqiYLlcYlkWhmEQxzGdTgfP8zAMg6qq7jTVtVqtF/I5C/FNk0AkhBBCCPE1rVYrfd/o6urqU+8bqWNoapKkJkdRFAHoXUJlWerGObUf6XY4Ukfiqqri/Pxcf5+6j1SWJVmW6e9T36uO+Nm2rY/bqV1IRVGw2Wz0fqVWq0W73cbzPH0MUIWj/f19Op3Ot/wJC/HNkUAkhBBCCHGPZrMZZ2dnPH36lPF4zGw2Y7FY3KnwNgxDT2EAHUJu3+upqoqyLImiiKIoWCwWAHqvkTpap5a8DgYDvRep2WzqY3sqHKniBRWO1M4jVcagwlFZlnfCUbPZpNPp6N1ItydHBwcHtNvtb/9DFuIeSSASQgghhPgG1HXN9fW1LmMYj8dMp1N9JE4xTZO6rvUkxrZtvQAW0OFIlR+UZclqtdJ7j1R9t2qey/Oc0Wikv6/RaOjCB1W8oKZGruvqyZFlWfr4nFr+qn4W3IS2KIr0kb+6rnU4Ojg4YH9/n36//+1/0EJ8TRKIhBBCCCG+YSocHR8f8/TpU66vr5nNZqzX6zu13Z90u61O3UVSwUaFEhWOAIIgIIoiPQlar9e6xjvPc+I4BtBtdepn+L6vw1FRFFiWhW3bGIaha7zLsmS9Xuvw1mw2abfbNBoN/WxBEOgq762tLSlkEN8JEoiEEEIIIb5FVVXpcKRqvD8rHN2u8latcOoekQoqaqeQYRh6QathGDpMBUGAaZokScL19bUuVAiCANu2dcBS32PbNmEY3mm+U5Ojoij0dGuxWOhdS41Gg3a7rcOYqhff3t7m8PCQvb092XMkXloSiIQQQgghXhA1OTo9PeXZs2f6WN0ndxzBTSC6Xe3dbDYJggDP8+7c/3EcB8uy9NJWwzCwbVvXdatpzmQyIUkSqqrC8zx9l0gdtVOtdFEUsVwudVhToUlNndSUSoUj3/f1sTpVD+44Dt1uVzfWeZ73rX7OQnweCURCCCGEEC+J6XSq2+pGoxGz2YzlcnmnkAF+PhyFYaiXt94uZKjrWh+dU9MeQN9RsiyLqqoYjUb63pBa3qoKGm430wVBoJfAqudQ76leUz9Ltdy122092aqqCtM06XQ67O3tcXBwIHXe4oWTQCSEEEII8RJaLpd39hxNp1OWy+WdKu9PoyYz6o6RKlJQd3yyLNMTJVXKEMexXu66WCyYzWb6z13XBdATIPjZ3aYsy0jTVBdDqL1L6hmTJNHH8cqyJI5jWq2WvnekSh+2trY4OjpiZ2dH7h2Jb50EIiGEEEKIl1yaplxcXPDs2TNOT091aEnT9HO/T90HUotgkyTRd4HULiI1GQJwXZc4jnEcB9u2WS6XzGYzHYZM08S2bYA75QvqDpO613R7cqTuHdV1zWaz0ZMn3/f19Mj3fYqiwHVdOp0OR0dH7O/v4/v+N/vBCoEEIiGEEEKI75SyLLm6uuL4+JjT01Mmkwnz+VzvDvo86lidmhSpyZG6R5QkCUVR6GruRqOB7/vYtk1RFFxfX5NlGUVR6L1Gqn5b7TqyLItGo6Hb79QxudvPX1UVaZqS5zlVVWEYBnEcE8cxjUZDh6o4jtna2uLw8FBa68Q3RgKREEIIIcR31Cd3HQ0GAxaLxZ0ShM9ye3oEP7sDpO4MqZKGPM/10blWq6XvE83nc71T6fbiVxWOVDud2qekplmqtlstji3LkqIoSNNUF0l4nker1dLTIxXY2u22Xggr0yNxXyQQCSGEEEK8ItI05fz8nJOTE05OTnRj3Waz+YXfqxrrgiDQx+jUvSB1B0i1yjmOo+8pua5LmqbM53OyLNPfp5rkVDgyDENPm7Is00FLMQxDh6ksy0iSRL8ehqE+XqemRM1mk36/z+HhIdvb21LrLb4yCURCCCGEEK+gqqoYj8ecnJxwfHzMeDzW+44+Wen9SZZl4XkeYRjiOA7r9VoHFlWGoJrkVPhpNBr6LtFisdB7jNTEyfO8n5seqSmPmjKpX1uWpY/zFUWhj+kBurkuDEN9vM6yLFqtFnt7e+zt7dHpdOR4nfjCJBAJIYQQQrwGNpsNFxcXnJ2dcXJywmQyYbFY/MLWOkBPhMIw1Pd+VIAxTVNPjlTQ8n2fOI51eFLTozzP9V4kVfmtfm/bNr7v35lOqb+LqjB2OyCpn+84jm6vU4FMHe/b39/n4OCAKIq+oU9VvAokEAkhhBBCvGZuL4Q9Pj5mMBgwm80+dSHsp3FdVx+XU+UM6n1VkYL6tZoOBUGA4zhsNhtdH64WxzqOo0OPbduYponjOPo4nnomVbbwyYB0+3idCmMqkBmGQRRFtNttXe0t94/EbRKIhBBCCCFec3meMxgMePbsGefn54zHYxaLBZvNhl/090FVuOC6rp7wqFAEPwtJarms4ziEYahDyXK51KEnyzJ9XE9NoWzb1u11lmXdKYtQu5IAffdI/RN+dv8oiiLiOMa2bR2QVL339va2vu8kXk8SiIQQQgghxB1JkuhyhrOzM0ajEev1+hfuPQL0riI1EbrdLmcYhj42p47Zua5LGIaEYUhVVaxWK708Vu06siwLwzD016tgo8KQ2nOkjuCZpqlLINQ/lUajQRAENJtNPZlqNpu0Wi0ePHggAek1JIFICCGEEEJ8prquWa1WnJ+f8/z5cy4uLphMJqzX6ztB47OogOR5nj5ip6ZHt5vsbk+Q1H0lgPV6zWaz0ZMn9X7q+zzP0yUNKgipv8OqI3lqGa0qgrj93CqMqQmSCnOdTof9/X12d3fxfV9KGl5hEoiEEEIIIcQXVtc1s9mM09NTTk5OGA6HTCYT3Sr3i6gSBVXBrUoa4GcB6favVRudOmKXJAlpmup7Q3DTPKfe23VdLMvSUyQ1OVJBSd0rUkf0bh/ng5tApu4cqaN6KjDt7u6yu7tLHMcSkF4hEoiEEEIIIcRXVtc18/lcB6TBYKAb7FTQ+UVs28Z1XRzH0RXct6c8pmmSpqk+DheGoZ4MJUmi9xap71E7idT9JjU9Mk3zTvHD7QnS7WB0+2igZVlEUaSXxKqFts1mk263y+HhoV5YK76bJBAJIYQQQoh7U9c1i8WCi4sLTk9Puby8ZDgcfuEJEqCb59RUSJUkqACkJktwE1hc18XzPF26kKapru++TQUkFV4cx9HvryY+txfJqoW2n3zuKIr0HiR1HLDZbBLHMfv7+2xtbckxu+8QCURCCCGEEOIblSQJV1dX+g7SaDRisVh8oZIGQE9x1D4hFZAsy2Kz2ejpT1EU1HWtj9ipyU+WZXfqu29TgcpxHF3SAOijfGradPs1NV1SVA15s9nUbXue5xHHMd1ul4ODA5kivcQkEAkhhBBCiG9VnueMRiNOTk64uLhgOBxyfX39hWq+b1N13+qYnboblOc5tm3re0PqHpIqY4CbRbWfVQqhCiAAfUyvKIo7Nd9qF5KaLn3yvYIguNNmp37farXY29uj3+/TaDRkivQSkEAkhBBCCCFeKHXMTjXZXV1dfel7SEoYhvrOkQpDqjzh9h0iNckxTZOqqvRRu8+bIt2uAAd0sYN6XxWc1KTq9rOrfUrNZpMgCPQUK4oiWq0W+/v/f3v3Hl3XWZ95/PtIliVbkqX4kqnjxJeEXJzAJIt4kqYkRF3AIlnQspoxLRQYTEMzdJo1pJS2pMMiMqt0AU0vXNKhGUoFHQbaoZkSBlrWkMRcShJwk4HmMoSU+B5L1sWSZRvFlt75Y+99snW8z1VH5xz5PJ+1zrLO3u9+39/Z+/Wxfn7f/e7zWL16NStWrHCSVGdOiMzMzMys6aRHkYaHhzl8+DCTk5McP368onqSh7Mmy20nyUvyPKT077vJ6nfJSNPp06dz0/PyJQkOkEuUkmOSepOpfskzl/LvRero6KCjo4Ox1cumAAAZDElEQVRVq1blptl1dXXR399Pb28v5513Hv39/b4faZEVS4g8ydHMzMzMGqKjo4P169ezfv16IBpFOnHiRG6xhpGREY4cOcL09PS8JbjzJc9RSksnSTMzM7nnF50+fZrp6el5ZZNFGJLE6dSpU7lRoPwEJxlJmp2dzSVMycNl29racg+CTe5Bmpub48SJE5w4cSJXR7Li3ooVK3IPke3q6qKvr4+enh42bNhAb28v3d3dTpLqwCNEZmZmZta00lPt9u3bx8jICKOjo0xPT2dOfStl5cqVuYQnSZKydHR0sGzZsly55P6iLMmKecnDY5OV8JLpdMloUnq58fxpgkmitXLlSrq7u1m+fDnd3d309PTQ29vL+vXrOeecc+ju7p63MISVxyNEZmZmZrYkSWLVqlWsWrWKyy67DIiWzZ6amuL555/PPTj2yJEjZd2PlB6pSRKcrq6u3GhQ+nlF+YsoJEt6px8CmyQ4WdPuOjs7c0t8L1++nLa2Nk6dOpW7RykZWUruhTp58iQnT55kbGws1x6QW/575cqVuVd/fz+rV69m3bp1dHd309nZWf1JbnFOiMzMzMxsSWlra6O/v5/+/n62bt0KREnSsWPHGB4eZv/+/YyOjjI8PMyxY8dKPhspPR0vmT2VjPakl9+em5vLnLrX2dmZW647fc9Sesnx5OfkwbRtbW10dXXlpt7Nzc2xfPny3LFJzHNzc0xPT8+b5ieJrq4uenp66OrqYsWKFbmFG3p6ejj33HPp7+9n5cqV85YUt2xOiMzMzMxsyWtra6Ovr4++vj4uueQS4MV7ksbGxti7dy+jo6McOXKEycnJeSNFWZJnEeVLEpr0vnTikyQ0knJT59LSo07p45IFG5KlwIFc4rRs2TIkMTMzk7unKBlNytfd3Z1bCryrq4ve3l76+vpYtWoV5557bu6Bs7436UVOiMzMzMzsrJQ86LW7u5uNGzfmtp86dYqjR49y6NAhDh06xMjISG4J8FL31xd6rlGytHcia8W5YpJRqPwkJ1mgIVlCPFkYIkmSknaSn48fP87x48cZHR3N1dHe3p5Lkjo7O+np6aG7u5v+/n76+vpYs2ZNLoFqxUTJCZGZmZmZtZSOjg7WrVvHunXruPLKK4EXR5PGx8fZt29fbspdOaNJQMXPUipXkvDkJ1fJYg/JvUnJc5GSqX7Je4iSrfxpd4nk/qRkxbuenh76+vro7e3N3Z90tq9254TIzMzMzFpeejTpggsuyG1P7k0aGxtj//79jI2N5abdZU1Zq6ese5qS+5g6OjrmrWwH5FbNS8tfEjzR2dmZW/Guu7s7N/Wuu7ubc845J3e/UvKcpqXMCZGZmZmZWQHpe5MuvPDC3PZksYOsRKmcEaXFNDs7m7lE+OzsbG6RhfT+ZPQnPV1wZmaGmZkZJiYmzqgnmX6XJEzJqNKqVatYvXp1bkreUlke3AmRmZmZmVmF2tracsuBb9myJbc9WT57YmKCQ4cOMTw8zNjYWNn3KC2mZMQoazswb4W8Ygot6CApN/Vu3bp1bN++feFB14ETIjMzMzOzGpGUe1bQhg0b5u2bnZ3l6NGjjI6OcvDgQcbHxxkdHWVycjJzOe96K5YM5S8aUej4ZAreyMiIEyIzMzMzM3tRe3s7a9asYc2aNVx66aXz9s3MzDA1NcXIyAgHDx5kYmKCI0eOMDU1VXBlu3qqdNGIpTJdDpwQmZmZmZk1XGdnZ27luyuuuGLevhdeeIGpqSnGxsZyI0tJstQMI0tZFmvVvcXghMjMzMzMrIktX76ctWvXsnbt2jNGlubm5jh+/DiTk5McOHCA0dFRJiYmGBsbY3p6OvOeIZvPCZGZmZmZ2RLV1tZGb28vvb29nH/++Wfsn52dZXJykqNHjzI8PMzo6Cijo6McPXqU6enpJTWSs1icEJmZmZmZnaXa29tZvXo1q1evnrdseCJ5ztL09DSHDx9mZGSE8fFxxsfHmZqaOuO5RWcjJ0RmZmZmZi0q/Zyl/FXxEsk9TFNTUzz//POMjY0xMTHB+Pj4WTHK5ITIzMzMzMwKSt/DlDXKBC9OzTtx4gSHDx9menq6zlFWzwmRmZmZmZktSHpqXta9TM1s6SwQbmZmZmZmVmNOiMzMzMzMrGU5ITIzMzMzs5blhMjMzMzMzFqWE6Kz2ODgYFPXmV9XOXVX0361MSfHLaTN9LGDg4O5F8DmzZszjym3zXRdheopFV9+XIvRZ4q1XSyWYsenyywk5oGBgaL7yzm/5fTjSq9tOQrVs9jXsJL669GfSrVT6hovdhz1OgdmZlY9hRAaHcOCbNu2LezevbvRYTQlSdT6+tayzvy6yqm7mvarjTk5biFtpo+VlNufVW9+2XLORVJXVtvlxJcfV1Z9tVbqc5eKo9R5XEgs5ewv1W9LHVOrv0OF6lmMv/fV1r/YsZTTTr1iKNRWPds3M7PCJP1zCGFb1j6PEJmZmZmZWctyQmRmZmZmZi3LCZGZmZmZmbUsJ0RmFRh87rlGh1CVRsVdr3YLtZO1vZyYBp977oxyjTiHSZvptiuNo9jnqMdnyvoMtSqf9dnS165UHYWOL3RssW35+wYef7ziuooZePzxio/d/PDDZZXL6u/lWqrfidBcsTdTLGatqK4JkaSbJP1I0rOS3pexv1PS38T7H5W0uZ7xmZWyc+/eRodQlUbFXa92C7WTtb2cmHbu3XtGuUacw6TNdNuVxlHsc9TjM2V9hlqVz/ps6WtXqo5Cxxc6tti2/H3fnJysuK5ivjk5WfGxe2dmyiqX1d/LtVS/E6G5Ym+mWMxaUd0SIkntwD3AzcDlwJslXZ5X7FZgIoTwEuBPgY/UKz4zMzMzM2s99RwhugZ4NoTwkxDCC8AXgTfklXkD8Nn45y8Br1L+msBmZmZmZmY1Us+EaAOwP/X+QLwts0wI4TQwCaypS3RmZmZmZtZy6vZgVknbgZtCCO+M378NuDaEcHuqzBNxmQPx+3+Ny4zm1XUbcBvAxo0br97rubeZ/GDW6o8B0I4dsGNHyXJ3bdrE4JYtmW025MGsFcZdqwezDj73XHnz4IeGCENDubcVP5i1zM9XD3dt2sTOCy+syYNZyz5/BeIY3LJlQXXk11VIsb5Zafs39vXNuzem1SXnfuDxxys+L33t7UzOztasXDqeRLnXt1QfaoRmir2ZYjFrJcUezEoIoS4v4Drg66n3dwJ35pX5OnBd/PMyYJQ4aSv0uvrqq4Nliy5v89aZX1c5dVfTfrUxJ8elj+ehh6o/FnKvrLjyy5bTRla5zG15cReKq9Z9Jut8lfrcpeLIOo+Frktm+6lthdrhoYeiV8a1L9VvS12TSs5xrs10zAXiKBhP/rXPqKsSFcWfujZl/92poHz+uchdt1QdRftSxrkp1n6xbVn9JdlWbl3FVHPdKilXTV+opI1m1EyxN1MsZmcrYHcokE/Uc8rc94GLJW2RtBx4E3B/Xpn7gbfHP28HHow/gJmZmZmZWc0tq1dDIYTTkm4nGgVqBz4TQnhS0geJMrb7gb8E/lrSs8A4UdJkZmZmZma2KOqWEAGEEL4GfC1v2wdSP/8UeGM9YzIzMzMzs9ZV14TIbKm7a9OmRodQlUbFXa92C7WTtb2cmJIyOys8rtaSNtNtVxpHfvmF1FWNrM9Qq/LFPlvyfieFVXpuim3Lb+vGvj4G+vvZWUFdxdzY11fxsZs6O8sqt5B+sFS/E6G5Ym+mWMxaUd1WmVss27ZtC7t37250GE3Jq8xVf0z6uIW02ZBV5io8j7VaZa5cpT53qThKnceFxFLO/lL9ttpV5moV+2L8va+2/sWOpZx26hVDobbq2b6ZmRVWbJW5ei6qYGZmZmZm1lScEJmZmZmZWctyQmRmZmZmZi2rfXBwsNExLMi99947eNtttzU6jKY1MDDQ1HXm11VO3dW0X23MyXELaTN97MDAQO41NDTEHXfcUTDOcs9FVrlKz2M6rsXoM8XaLhZLsePTZaqNedeuXezYsaOiWLO2ldOPK7225ShUz2Jfw0rqr0d/KtZOOdd4seOo1zkwM7PCdu7c+fzg4OC9Wfu8qIKZmZmZmZ3VvKiCmZmZmZlZBidEZmZmZmbWspwQmZmZmZlZy3JCZGZmZmZmLcsJkZmZmZmZtSwnRGZmZmZm1rKcEJmZmZmZWctyQmRmZmZmZi3LCZGZmZmZmbUsJ0RmZmZmZtayFEJodAwLIukIsLfBYfQBk2dh+7Wot9o6Kj2u3PLllCtVZi0wWmZcS0kj+3Ez9+GF1FPJcbUu24r92N/Fta/D38X15+/i2tfjflxfzfpdvCmEsC7ziBCCXwt8Afeeje3Xot5q66j0uHLLl1OuVBlgdyOv92K9GtmPm7kPL6SeSo6rddlW7Mf+Lq59Hf4urv/L38W1r8f9uL6vpfhd7ClztfGVs7T9WtRbbR2VHldu+XLKNfp6NkojP3cz9+GF1FPJcbUu24r9uNGfuZn7sb+Llw5/F9e+Hvfj+mr0Z664/SU/Zc6s3iTtDiFsa3QcZgvhfmxLnfuwnQ3cj5uDR4jMKndvowMwqwH3Y1vq3IftbOB+3AQ8QmRmZmZmZi3LI0RmZmZmZtaynBCZmZmZmVnLckJkZmZmZmYtywmR2QJJ2irpU5K+JOk3Gh2PWbUkdUvaLen1jY7FrFKSBiR9O/4+Hmh0PGbVkNQm6UOSPiHp7Y2Op1U4ITLLIOkzkkYkPZG3/SZJP5L0rKT3AYQQng4hvAv4ZeAVjYjXLEsl/Tj2e8Df1jdKs8Iq7MMBmAa6gAP1jtWskAr78RuA84FTuB/XjRMis2xDwE3pDZLagXuAm4HLgTdLujze94vAV4Gv1TdMs6KGKLMfS3oN8BQwUu8gzYoYovzv4m+HEG4mSux31jlOs2KGKL8fXwp8N4TwHsCzTurECZFZhhDCt4DxvM3XAM+GEH4SQngB+CLR/+QQQrg//of4LfWN1KywCvvxAPCzwK8Cvy7J/z5Yw1XSh0MIc/H+CaCzjmGaFVXhd/EBoj4MMFu/KFvbskYHYLaEbAD2p94fAK6N56rfQvQPsEeIrNll9uMQwu0AknYAo6lfLs2aTaHv4luA1wL9wCcbEZhZBTL7MfAx4BOSbgC+1YjAWpETIrMFCiHsAnY1OAyzmgghDDU6BrNqhBDuA+5rdBxmCxFCOAHc2ug4Wo2nRJiV7yBwQer9+fE2s6XE/diWOvdhOxu4HzcRJ0Rm5fs+cLGkLZKWA28C7m9wTGaVcj+2pc592M4G7sdNxAmRWQZJXwAeBi6VdEDSrSGE08DtwNeBp4G/DSE82cg4zYpxP7alzn3Yzgbux81PIYRGx2BmZmZmZtYQHiEyMzMzM7OW5YTIzMzMzMxalhMiMzMzMzNrWU6IzMzMzMysZTkhMjMzMzOzluWEyMzMzMzMWpYTIjMzQ9JmSUHStkbHUg+SdkiarkE9A/F5W1uLuMzMrP6cEJmZVUjSOkl/LmmPpBlJw5IekPSaVJk9kt5bRd27JH2ythGXZT+wHvi/DWh7SShwTb9LdN7GGhDSolmMfujk0cya1bJGB2BmtgT9HbASuBV4FjgXuBFY08igFiKEMAscbnQcS00I4QWW8HmTtDz+DGZmLcsjRGZmFZDUD9wAvC+E8EAIYW8I4fshhLtDCF+My+wCNgF/FP+PeIi3r5H0BUkHJJ2U9KSkd6TqHiJKrH4zOU7S5njf5ZK+KumYpJG4np8pEudNcdll8fuXxPV9KlXmDyR9I/553pQ5SR2SPi7pUDwKtl/Sh1PHLpf0kfiznJD0fUmvLXHudkn6lKSPSZqIX38kqS1V5hxJn433nZT0DUlXpPbvkDQt6RckPSPpp5IeknRhqsygpCfy2i46RU7SRZK+LOmwpOOSHpP0+nTsZF/TM0Y9JN0i6V9S5+2/SFJq/x5J75f0F5Km4nP4OyXO3aCkJyS9U9K++Nz8ff5oi6R3SHoqPi/PSPqtvPMbJP2mpPskHQf+MKOtIarsh5Jepmi0dCq+Tj+Q9PPx8Q/FxY7EdQ4V+8xmZvXihMjMrDLT8esXJXUVKHMLcAD4INF0qvXx9i7gMeD1wBXAx4C/kPSqeP+7gYeBv0odt1/SeuBbwBPANcCrgR7gy+lfdvN8J24vuSdoABiN/yS1bVeB4/8z8EvAm4CLgV8BfpTa/1dEvzT/KvBS4LPAVyRdWaC+xFuI/u25DviPwG3AHan9Q8C1wBuIPusJ4B8lrUiV6QTuAt4R19MO3JdOOqrQA/wD8BrgSqJRwPskXRbvL3RN55F0NfA/gfuAlwHvA+4Ebs8r+lvAvwAvBz4CfFTSdSVi3Ay8lejcvJrounwm1favEyU4HwC2Ar8N/B7wn/LquQv4WhzfPRntLKQf/g/g+Xj/VcAg8FOiKZn/Pi5zRVznu0t8XjOz+ggh+OWXX375VcGL6Be7caJf9B4G7gauzSuzB3hvGXV9Efh06v0u4JN5ZT4IPJC37RwgANcUqfsR4M745/9O9IvwSaJfRlcCM8D18f7NcX3b4vcfBx4AlFHvRcAcsDFv+98Df14knl3AM+k6gfcDB+KfL45jeGVqfx8wCbwzfr8jLvOKVJlNwCzw6vj9IPBEXts7gOlC74ucv/cXu6ZESWUA1sbvPw88mFdmMPmMqXq+kFfmx+m2MmIZjD/jxtS26+O2L47f7wPelnfcHcBTqfcB+EQZ/bKqfghMAW8vUOe8c+WXX3751SwvjxCZmVUohPB3wHnALxCNKvwc8Iik3y92nKT2ePrUDyWNxVO4bgE2lmjyauCV8RSk6fi4/fG+iyTdkN4n6S3xvl28OCJ0Yxzro/G2nwNOA98r0OYQ0f/wPyPpHkmvS40CvBwQ8FReTK8jSpaKeSSEEFLvHwY2SFpFNKoxF28DIIQwSTSScnnqmLl03CGEvcChvDIVkdQt6aPxdLOJ+PNso/S1ybcV+Ke8bd/hxc+Y+GFemUNE96IVczCEsC/1/lGic7FV0jrgAqIRx/Q1+TBnXpPdZXyOLEX7YfznnwCflvRg3Ncvy6zJzKyJeFEFM7MqhBB+Cvyf+PVBSZ8GBiXdHQrfpP5eomlM7yb6JX+aaIpTqV+E24CvxsfnGyZKbK7K2wZRQnS7pK3AKuCf420/D4wADxeKNYTwWHzfx2uBVxFNifuBopX02oj+p//fAafyDj1Z4rNUK5R4nzZHlLCldZSo/27gJqJz/GOiqXqfA5ZXEGMp6Zjzz1tgYdPYk2PfRbTyXTHHF9BGsX5ICGFQ0ueBm4n6zl2S3hVC+EzGMWZmTcEJkZlZbTxF9J3aBbwQv9rzylwPfCWE8NcA8T0vlwBHU2WyjnsM+GVgbwgh/xfpxLMZ275DdL/N7wLfCSHMxosD/DeiX2D/sdgHCiEcA74EfCm+Af4R4CXA40QJx8+EEB4qXEOmayUpNUr0s8ChEMKUpKd58f6ibwHEoyovI7qfJdFGdI/Kd+MyG4lG7J6O9x8B/k1eO+mEMcv1wOfi0T/i+8MuIpril8i6NvmeBl6RUfeB+HwuxAZJF4QQklGZa4jOxdMhhGFJh4CLQgifW2A7UH0/JITwY6Kk8uOS/ivwTqJ7nZLku9Q5NDOrK0+ZMzOrgKKV4h6U9FZJ/1bSFklvJEo6HgghTMVF9wA3SNqQWgnsGeBVkq6PpxJ9EtiS18Qe4BpFq76tjaep3UN0L83fSLpW0oWSXi3pXkm9hWINIUwTjQq9lRdX+HoEOJ8oEdlV5HO+R9KbJW2V9BKixROmiH6xf4boXpkhSdvjeLZJeq+kW0qcwvOAP5N0qaTtwO8AfxrH+2Pgy0TTvm6Q9DKie5+miG7WT5yO67hO0lVEo1dPAt+I9+8CVgO/r2j1uFuB7SXiegb4JUkvT7Wbv2jGHs68pvn+GLhR0apwl8TTF38b+GiJ9stxEvispKviBRg+BXw1Pm8Q3SP2u4pWlrtU0ksl/QdJd1bR1h4q7IeSVsTTKwfi464lSgafiuvcSzQS9jpFz/Lqqf5UmJnVjhMiM7PKTBMlFe8Gvkn0i/gfEv3C/iupch8guqfjX4lGLAD+gOjel38gGgE5TpRYpN1N9D/pT8XHbQwhHCIadZgjGtV5kuiX05n4VcwuopGrXZCb6vdofFyh+4cAjhElK98jGhm4Crg5hHAi3v8OolGbjwL/D/jfwCuJfukt5vNEIwSPEo1U/SVxQpSq93vA/fGfK4GbQgjpqXgzwIeIprQ9SvRv2S3JaFAI4WngN4hWsPsh0cpxZywvnec9RNMIv010fR6Jf07LuqbzhBAeA95ItPDGE0T38HyYKPldqD1Ei3B8BXgQ+AnR+Ura/jTwa8DbgB/E8d8GPFdFW9X0w1miRRaGiFYk/F9E94O9J47vIFHS9iGiEcpGPIDYzOwMmn9vq5mZ2eKIp+s9EULIX4K6kjp2EK1+1lKjC5IGge0hhJc2OhYzs7ONR4jMzMzMzKxlOSEyMzMzM7OW5SlzZmZmZmbWsjxCZGZmZmZmLcsJkZmZmZmZtSwnRGZmZmZm1rKcEJmZmZmZWctyQmRmZmZmZi3LCZGZmZmZmbWs/w8DILkyCp3d+AAAAABJRU5ErkJggg==\n",
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA0QAAAIeCAYAAACbe88LAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADh0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uMy4yLjAsIGh0dHA6Ly9tYXRwbG90bGliLm9yZy8GearUAAAgAElEQVR4nOzdeXxU1fk/8M+dO3NnX7OwhSWCEBDRCqggi6AotIqlSlUggguNYCv1pUVEEPDrt6jYWq0LiBoUtCoK2r6UqhBWBSFQaiUpiywJIftk9n3m+f3B754vQxZAQ0B93q/XvMzc5dxz78SQJ885z5GICIwxxhhjjDH2U6Q51x1gjDHGGGOMsXOFAyLGGGOMMcbYTxYHRIwxxhhjjLGfLA6IGGOMMcYYYz9ZHBAxxhhjjDHGfrI4IGKMMcYYY4z9ZGnPdQe+r8zMTOrWrdu57gZjjDHGGGPsPLVz5846Ispqat8PPiDq1q0biouLz3U3GGOMMcYYY+cpSZKONLePh8wxxhhjjDHGfrI4IGKMMcYYY4z9ZHFAxBhjjDHGGPvJ4oCIMcYYY4wx9pPFARFjjDHGGGPsJ+sHX2WOMcYYO9/5fD7U1NQgHo+f664wxtiPjk6nQ3Z2Nmw223c6nwMixhhj7Czy+Xyorq5Gp06dYDQaIUnSue4SY4z9aBARwuEwKioqAOA7BUU8ZI4xxhg7i2pqatCpUyeYTKZWC4bmz5/fKu0wxtgPnSRJMJlM6NSpE2pqar5TGxwQMcYYY2dRPB6H0Whs1TYXLFjQqu0xxtgPndFo/M7DkjkgYowxxs4yHibHGGNn1/f5OcsBEWOMMcYYY+wniwMixhhjjLFzYNmyZdBqub7V+WjKlCm49tprz3U3WBvhgIgxxhhjTbr66qtxzz33NNp++PBhSJKELVu2NHtuOBzG3LlzceGFF8JoNMLlcmHgwIF4/vnnz7gfhYWF6N+/P2w2G6xWK3r37o2pU6eK/StWrPjOw2W0Wi2WLVv2nc79vm699VZRGetsmD9/PiRJavH1fe79TJ/71q1bMW7cOLRr1w4GgwHdu3fHpEmTsGvXru/ch7Plueeew8qVK8X7e+65B1dffXWrtH311VdDkiS89NJLadu3bNkCSZJw+PDhVrkOO30cEDHGGGOs1U2bNg1vvvkmFi1ahJKSEqxfvx733XcfPB7PGbWzbNkyTJs2DXfeeSeKi4uxc+dOPPnkk0gmk2ep523HaDSiXbt2Z639hx56CJWVleI1aNAgTJgwIW3brbfeetauf6LCwkIMHToUiqLgrbfeQmlpKd59911069YNM2bMaJM+nAm73Q6n03nW2jcYDFiwYAH8fv9ZuwY7A0T0g37179+fGGOMsfNVSUlJq7d5/J/vs2/48OF09913N9p+6NAhAkCbN29u9ly73U5//etfv3cfbrrpJrr55pub3b9+/XoCkPaaPHkyERF99tlnNHz4cHI6nWSz2WjYsGH01VdfiXO7du3a6FxVcXExjRo1isxmM2VmZtK4cePo8OHDLfZ1yJAhNHv2bPH+scceIwD0+eefi22DBw+mWbNmERFRYWEhybIs9nm9XpoyZQq1a9eOFEWhnJwceuCBB9Ku8fzzz1OvXr1Ir9dTjx496IknnqB4PN5iv1Qnf56xWIzmzZtH3bp1I71eT3369KHFixennbN06VLKy8sjvV5PTqeThg4dSuXl5S0+95NVVFSQXq+ngoKCJve73W7x9ezZsykvL4+MRiPl5ORQQUEBeTwesV99Zp9//jn16dOH9Ho9XX755fSvf/0rrb2JEydS586dyWAwUM+ePemZZ56hVCqVdt133nmHLrvsMtLr9eRyuWj06NGiL5MnT6ZrrrmGiIjmzZvX6F4LCwtp8uTJNGrUqEb3M2LECLrrrruavFei45+D2r8Tv182b95MAOjQoUNi29atW2no0KFkMBjI4XDQ7bffTtXV1UREFAqFSFEU+uyzz8Txw4YNI0VRKBgMEhFRMBgknU5H//znP5vtz49JSz9vARRTM/EEZ4gYY4wx1uo6dOiAf/7zn3C73d+7neLiYuzbt6/J/YMHD8YLL7wAACLr8dxzzwEAAoEApk+fjq1bt+LLL7/EhRdeiNGjR6O+vh4AsGPHDsiyjL/85S/iXAAoKSnB8OHDMWjQIBQXF6OoqAiyLGPUqFGIRCLN9nXEiBEoKioS74uKipCVlSW2BQIB7NixAyNHjmzy/Dlz5mDXrl346KOPsH//frz77rvo3bu32D9//nw888wzWLhwIUpLS/Hcc89hyZIl37kM+9SpU7Fq1SosWbIEpaWleOyxx/Dwww/jtddeAwDs3LkT9957Lx555BHs3bsXGzduxB133HHK536y9957D9FoFHPmzGly/4mZGKPRiFdeeQUlJSVYtmwZNmzYgPvvvz/t+FQqhZkzZ+Kll17C9u3bkZWVhV/84hcIh8MAgGg0ir59++LDDz9ESUkJ5s6di3nz5qUNDywsLMSkSZPwy1/+Ert27cL69esxevToJjOPDz30ECZMmIBBgwalZdYKCgqwdu1aHDp0SBx74MABbNiwAb/5zW9afPYGgwH/+7//i2effRZHjx5t8piqqipcd911yMnJwfbt2/GPf/wD33zzDW655RbxrK644grx/RUOh7Ft2zbY7XYxnHXz5s0AgKFDh7bYn5+85iKlH8qLM0SMMcbOZz/VDNGWLVuoS5cupNFo6OKLL6apU6fS6tWrG/2V/lQqKyvpqquuIgDUtWtX+vWvf01LliyhQCAgjlm+fPlpPZNkMkkOh4NWrFghtsmyTIWFhWnHTZ48mW699da0bZFIhIxGI61evbrZ9tevX09arZZ8Ph8Fg0FSFIWeeeYZuuKKK4iI6JNPPiFFUSgUChFR4wzR2LFjm82yBINBMhqNtGbNmrTtb7zxBtnt9lPeO1H653nw4EGSJIlKS0vTjlmwYAFdcsklRES0atUqstls5PV6m2zvdJ/7tGnTyGaznVYfT7Zq1SpSFIWSySQRHX9mAGjt2rXiGLfbTWazmV599dVm27n//vvp2muvFe87d+5M9913X7PHn5ghIiK6++67afjw4Y2Ou/jii+nRRx8V72fNmkX9+vVr8Z7UzyGVStFll11Gd9xxBxE1zhDNmTOHOnXqRNFoVJy7e/duAkAbN24kouPZq4EDBxLR8YzoBRdcQNOmTaOHH36YiIhmzpxJQ4YMabE/PyacIWKMMcbYeeOqq67Ct99+i82bN2Py5Mmorq7GLbfcgrFjx+L47yanp3379tiyZQtKSkrwyCOPwGw2Y+bMmejbt+8pV6U/dOgQ8vPz0aNHD9hsNthsNni9Xhw5cqTF83bs2IHVq1fDYrGIV0ZGBiKRCPbv3w8AafvGjBkDABg0aBC0Wi02btyIzZs3o2vXrsjPz8euXbvg9/tRVFSEK6+8stmFeqdPn473338fffv2xYwZM7BmzRqkUikAwJ49exAOh3HzzTenXbugoABerxe1tbWn/UwBoLi4GESEAQMGpLX3xz/+UdzjqFGjcMEFFyA3Nxe33XYbXnnlFdTV1Z3RdQCc0ee9atUqDBs2DB07doTFYsHEiRMRi8VQVVWVdtygQYPE106nE71798aePXsAHM8gPfnkk7j00kuRmZkJi8WCxYsXi8+9pqYG5eXluO666874Xk5WUFCAwsJCJJNJJBIJLFu2LK3gR0skScKiRYuwYsUK7N69u9H+PXv24Morr4SiKGLbJZdcArvdLu51xIgR2LVrF7xeL4qKinDNNdekZSqLioqazUiy/8O1HhljjDHWJLvdDq/X22i7WhjBYDC0eL5Wq8XgwYMxePBgPPjgg1ixYgXy8/OxadMmDB8+/Iz60rt3b/Tu3RsFBQWYO3cuevbsiZdffhnz5s1r9pwbbrgBmZmZePHFF9G5c2coioIhQ4YgFou1eK1UKoX8/HzMmjWr0b6MjAwASPsFVg1w9Ho9Bg8ejHXr1kFRFIwcORLZ2dno1asXNm7ciKKiIowdO7bZ615//fUoKyvDp59+ig0bNmDSpEm4+OKLsW7dOhEYrVy5Ej179mx0rsvlavGemrpHAPjyyy9hMpnS9qmV4ywWC4qLi/HFF19g7dq1WLx4MWbOnIl169ahf//+p32tXr16wefz4ejRo8jJyWn2uK+++grjx4/HI488gkWLFsHpdGLbtm2YPHnyKT+zE/3pT3/CwoUL8eyzz+JnP/sZrFYrnn32WXz88cen3cbpys/Px8MPP4yPP/4YqVQKXq8XkyZNOu3zR44ciTFjxuAPf/hDi9/LzRk0aBAURcGGDRtQVFSEBx54ACNGjMCECRNw5MgR/Otf/8Izzzxzxu3+1HBA1IqIiFcjZ4wx9qORl5eHlStXIplMQpZlsX379u2QZRk9evQ4o/bU+TCnyuycSrdu3WAymUQ76l/QT+xnfX09SkpK8Mknn+D6668HABw9erTRtRVFaTRvZMCAAfj666/RvXv3Zv9db+7eR4wYgZUrV0JRFMycORPA8V96P/jgA+zevRt/+ctfWrw3l8uF22+/HbfffjvuvPNODBo0CCUlJbjoootgMBhw8OBB/PznP2+xjdOhBjRlZWW44YYbmj1OlmUMGzYMw4YNw4IFC9CnTx+8/fbb6N+/f5PPvSnjx4/HrFmz8MQTT2Dx4sWN9jc0NMDpdGLLli3IzMzEE088Ifa9//77Tba5bds2kfnweDwoLS1FQUEBAGDTpk0YPXo07rrrLnG8mvUCgOzsbOTk5OCzzz5rMUA9UVPfJwBgs9lw2223YenSpUilUhg/fjwcDsdptal6+umn0a9fPwwcODBt+0UXXYTCwkLEYjHxrP/973/D6/Wib9++ol+DBw/G6tWrsWvXLowcORKZmZno06cPHn/8cSiKkpZNY03jIXOtKBQKwev1ntFfMRhjjLHz1fTp01FdXY0777wTO3fuxLfffou//e1vmDt3Lu688860X/zy8vLEJHsAGD58OBYvXozi4mIcOXIE69atw/Tp0+FwODBixAgAwOrVq5GXl9fiWjzTpk3DggULsHnzZhw5cgQ7d+7E5MmT4fP58Mtf/hIAkJubCwD4+9//jtraWgQCATidTmRlZWHp0qXYt28ftm7dittvv73RcLXc3FysX78ex44dE8PBZs+ejdLSUkyaNAnbt2/HoUOHsH79esyYMQMHDx5s8ZmNHDkS//nPf7B7925xnyNHjsSKFStgMBhw5ZVXNnvuo48+ilWrVmHv3r3Yv38/3nrrLVgsFnTp0gUWiwWzZ8/G7Nmz8eKLL2Lv3r3Ys2cP3nnnHTz88MMt9qkpPXr0wF133YWpU6di+fLlOHDgAP7973/j9ddfx1NPPQUA+Oijj/Dss89i586dKCsrw4cffojy8nL06dOn2efelE6dOuGFF17A0qVLcdttt2HdunU4fPgwdu3ahXnz5uGmm24CcDyTVFtbi9deew0HDx7Em2++2WitHuB4BmvmzJnYtGkT/vOf/+COO+6A1WrFhAkTRDsbNmzA+vXrsW/fPsyZMwdfffVVWhvz5s3DkiVL8D//8z8oLS3Fnj178MILLzQ7JDA3Nxf//e9/sWfPHtTV1SEajYp9BQUFWLNmDT799NNTFlNoSp8+fXD33Xc3CpZ/+9vfwufzYcqUKfjmm2+wZcsW5OfnY+jQoWlFEkaOHIm33noLeXl5yM7OFtvefPNNXHXVVWlD7lgzmptc9EN5nU9FFdxuN5WVlVF1dTV5PJ60SXCMMcZ+mn7IRRWIjk/ivuGGG6hDhw5kMpmob9++tGjRIorFYo36NG/ePPF+4cKFNGTIEMrKyiK9Xk+dO3emiRMn0p49e8Qx6gT5E8sMn+yDDz6gG2+8kTp16kSKolB2djZde+219Mknn6QdN2PGDMrKykor/7xhwwbq168f6fV66tmzJ73//vvUvXv3tH6uWbOG8vLySKfTpT3Xr7/+msaOHUsOh4MMBgN1796dpk6dSvX19S0+r1gsRhaLJW1ifUNDA8myTNddd13asScXVXj88cfpoosuIrPZLMqEn1y4YunSpXTJJZeQXq8nh8NBl19+Ob300kst9kl1cpGMRCJBTz31FPXq1Yt0Oh1lZGTQsGHD6L333iMioo0bN9KIESMoMzNTlPleuHBhWptNPffmbN68mW666SbKysoiRVEoNzeX8vPz00pmz5kzh7Kzs8lkMtGYMWPo7bffTvseUZ/Zp59+Snl5eaQoCg0cOJB27twp2vB4PDR+/HiyWq3kcrlo+vTpNGfOHOratWtaf1asWEH9+vUjRVHI5XLRz3/+c2poaCCixkUV6uvracyYMWSz2UTZ7RNdeuml1KdPnxbvX9VUsZKqqiqyWCwtlt222+1pZbdVX375JQGg+++/X2z7+9//TgDoj3/842n16cfiuxZVkOgMJrqdjwYMGEDFxcXnuhsA0jNEGo0GBoMBOp0OZrMZOp3uXHePMcbYOVBaWppWOrk1SJJ0RhPVGfuxWLZsGe655x4kEolz3RUhHo+jW7dumDlz5nm5yOxPSUs/byVJ2klEA5rax3OIWlEkEkEymYTVakUkEkEwGIQsy4jH4xwYMcYYY4z9iKRSKdTV1WHJkiUIBoO48847z3WX2HfEAVErMhgMSKVSCAaDkCQJNpsN0WhUBEbqpDgOjBhjjDHGftjKysqQm5uLDh064PXXX4fNZjvXXWLfEQdErSiVSiGZTMJsNoOI0gIjNWMUi8VExshisUCr5Y+AMcYYY+x0TJkyBVOmTDnX3QBwvNohD139ceDfxltRJBJBLBYDEUGWZZjNZkiShEAgAEmSYLfbEYvFEAwGodVqEY1GodfrOTBijDHGGGPsHGnTstuSJI2WJGmvJEkHJElqtNqZJEldJElaL0nSvyRJ+lqSpO9faL8N2Ww2yLIMv9+PSCSCeDyORCIBs9kMs9mMcDiMeDwOm80GnU6HcDiMYDAIt9sNj8fTZH17xhhj7GTfZQFHxhhjTWuzgEiSJBnAiwDGAOgD4HZJkvqcdNgcAO8R0c8A3AagcfH58xgRweVyoVOnTiAiUXEuFoshlUrBZDLBbrcjFAohHo/DbrdDo9EgGAwiGAyivr4eXq9XrB7NGGOMNWX+/PnnuguMMfaj0ZbjtC4HcICIDgKAJEnvALgJQMkJxxAAdUaaHcCxNuzf96bRaESWJzs7G8lkEjU1NSJLpNVqQUSNhtK5XC6RLYrH44hEIjAYDLBardBoeO1cxhhjjDHGzpa2DIg6ASg/4f1RAFecdMx8AJ9JkvQ7AGYA1zbVkCRJvwHwGwDo0qVLq3f0uwqHw0gmk2JFYI1Ggw4dOiAej6OmpgYARDCkVpsDAJ/PB41GA6fTiVAohEAgACJCNBqFwWDgqiWMMcYYY4ydJedb+uF2AMuIKAfAzwEslySpUR+J6BUiGkBEA7Kystq8k83R6XSiulwkEhGVR7RaLTp27IiMjAwEAgEEAgHEYjEkEglIkgSr1Qqj0SgyRpmZmSAiBAIBBINB1NbWIhAInOO7Y4wxxhhj7MenLQOiCgCdT3if8/+3nehuAO8BABFtBWAAkNkmvWslyWQSWq0WyWQSwWAQ0WgUwPFVxQ0GAzp27AiHwwGfz4dwOIxoNIpEIgFZlkWxBTX4cTqdSKVSIjCqq6tDOBw+l7fHGGOMsVaybNkyrjJ7npoyZQquvbbJgUrsR6gtA6IdAC6UJClXkiQFx4sm/P2kY8oAXAMAkiT1xvGAqLYN+/i9GI3GtHk/kiQhkUggFAohGo2CiKDRaGA2m9GpUyfo9Xr4fD6RUUokEtDpdCIwUstzOxwOJBIJBAIB+Hw+1NfXi0CLMcbYT8/8Q4fa5DpXX3017rnnnkbbDx8+DEmSsGXLlmbPDYfDmDt3Li688EIYjUa4XC4MHDgQzz///Bn3o7CwEP3794fNZoPVakXv3r0xdepUsX/FihWQJOmM2wWOj+JYtmzZdzr3+7r11ltRUXHy34Zbz/z58yFJUouv73PvZ/rct27dinHjxqFdu3YwGAzo3r07Jk2ahF27dn3nPpwtzz33HFauXCne33PPPbj66qtbpe3mPotf/OIXp32e0WhEt27dcMstt2DNmjWt0q/WEolE4HK5YDab4Xa7z3V3TkubBURElADwWwCfAijF8WpyeyRJelySpLH//7AHAUyVJOnfAP4GYAr9wFa8MhgMsNvtMBqN0Gq1otBCMpkUgVEqlYJGo4HD4UDHjh2h1Wrh9XoRDofTAiOHwyGKLyiKApvNhlgshkAggIaGBrjdbsTj8XN9y4wxxtrYgiNHznUXTmnatGl48803sWjRIpSUlGD9+vW477774PF4zqidZcuWYdq0abjzzjtRXFyMnTt34sknn/xRLFVhNBrRrl27s9b+Qw89hMrKSvEaNGgQJkyYkLbt1ltvPWvXP1FhYSGGDh0KRVHw1ltvobS0FO+++y66deuGGTNmtEkfzoTdbofT6TwrbZ/4/CsrK7F161YAwG233XbKc1944QVUVlZi7969WL58OTp27Igbb7wRv//9789KX7+L9957D7m5uRg+fDjeeOONc92d00NEP+hX//796XyVSqXI5/ORx+Mhj8dDlZWVVFdXR263mxoaGigUClE0GqVIJEJer5cOHjxI+/fvp4qKCqquriaPx0Ner5f8fj9VVlbSkSNHqL6+nurq6ujw4cN09OhROnbsGNXX11MikTjXt8sYY6wJJSUlrd4m1q9v9TabMnz4cLr77rsbbT906BABoM2bNzd7rt1up7/+9a/fuw833XQT3Xzzzc3uX79+PeF4lVrxmjx5MhERffbZZzR8+HByOp1ks9lo2LBh9NVXX4lzu3bt2uhcVXFxMY0aNYrMZjNlZmbSuHHj6PDhwy32dciQITR79mzx/rHHHiMA9Pnnn4ttgwcPplmzZhERUWFhIcmyLPZ5vV6aMmUKtWvXjhRFoZycHHrggQfSrvH8889Tr169SK/XU48ePeiJJ56geDzeYr9UJ3+esViM5s2bR926dSO9Xk99+vShxYsXp52zdOlSysvLI71eT06nk4YOHUrl5eUtPveTVVRUkF6vp4KCgib3u91u8fXs2bMpLy+PjEYj5eTkUEFBAXk8HrFffWaff/459enTh/R6PV1++eX0r3/9K629iRMnUufOnclgMFDPnj3pmWeeoVQqlXbdd955hy677DLS6/Xkcrlo9OjRoi+TJ0+ma665hoiI5s2b1+heCwsLafLkyTRq1KhG9zNixAi66667mrzXpsyePZtcLheFw+EWjwNAy5cvb7T9xRdfJAC0YcOGtDabe44+n48sFgu99dZbae0cOnSIJEmiTZs2ERHRhx9+SJdeeikZjUay2+00cOBA2rVr1ynv56qrrqLnn3+e3nnnHerdu3ej/aFQiKZOnUo2m40cDgdNmzaNZs2aRd27dxfHpFIpWrRoEeXm5pJOp6MLLriAnn322VNeu6WftwCKqZl44nwrqvCDlkgk0oopqAUTrFYrgOMV5tQFWVOpFKLRqKhMZzAY0L59e7hcLkQiEYRCobSMktlshsvlQjQaRTAYhM1mg8FgQCwWQyQSQU1NDbxer7g2Y4wxdi516NAB//znP7/3kJkOHTqguLgY+/bta3L/4MGD8cILLwD4v7+8P/fccwCAQCCA6dOnY+vWrfjyyy9x4YUXYvTo0aivrwcA7NixA7Is4y9/+Ys4FwBKSkowfPhwDBo0CMXFxSgqKoIsyxg1ahQikUizfR0xYgSKiorE+6KiImRlZYltgUAAO3bswMiRI5s8f86cOdi1axc++ugj7N+/H++++y569+4t9s+fPx/PPPMMFi5ciNLSUjz33HNYsmQJFixYcLqPM83UqVOxatUqLFmyBKWlpXjsscfw8MMP47XXXgMA7Ny5E/feey8eeeQR7N27Fxs3bsQdd9xxyud+svfeew/RaBRz5sxpcv+JmRij0YhXXnkFJSUlWLZsGTZs2ID7778/7fhUKoWZM2fipZdewvbt25GVlYVf/OIXYp51NBpF37598eGHH6KkpARz587FvHnz0oYHFhYWYtKkSfjlL3+JXbt2Yf369Rg9enSTmceHHnoIEyZMwKBBg9IyawUFBVi7di0OnTCE9cCBA9iwYQN+85vfnOrxAwDi8Thef/11TJ48GQaD4bTOOVlBQQEcDkfaEL+WnqPVasWECROwdOnStHZee+015OXlYejQoaiqqsL48eNx++23Y8+ePdi6dSt+//vfn3LO2549e7Bjxw5MmDABN910EyorK7Fp06a0Yx5++GF89NFHWL58ObZt2wa73Y6XXkpfevSll17C3LlzMWvWLOzZswd/+MMfMGvWLPG92eqai5R+KK/zKUMUi8UomUxSJBKhSCTS5H6Px0PBYJAaGhqovLyc3G63yCCFQiGKxWIUCoWourqa9u/fT0eOHBGZJTVb5PP5qKKigo4cOUJut5tqamro8OHDdOzYMaqsrCS/39/oryCMMcbOjZ9qhmjLli3UpUsX0mg0dPHFF9PUqVNp9erVZ/zvU2VlJV111VUEgLp27Uq//vWvacmSJRQIBMQxy5cvT8vuNCeZTJLD4aAVK1aIbbIsU2FhYdpxkydPpltvvTVtWyQSIaPRSKtXr262/fXr15NWqyWfz0fBYJAURaFnnnmGrrjiCiIi+uSTT0hRFAqFQkTUOEM0duzYZrMswWCQjEYjrVmzJm37G2+8QXa7/ZT3TpT+eR48eJAkSaLS0tK0YxYsWECXXHIJERGtWrWKbDYbeb3eJts73ec+bdo0stlsp9XHk61atYoURaFkMklEx58ZAFq7dq04xu12k9lspldffbXZdu6//3669tprxfvOnTvTfffd1+zxJ2aIiIjuvvtuGj58eKPjLr74Ynr00UfF+1mzZlG/fv1O696IiFauXEkAGn0OTUEzGSIioiuuuILGjBnT7LknP8edO3cSANq3bx8RESUSCerUqRP9+c9/JiKiXbt2EQA6dOjQad8L0fHn/Ktf/Uq8LygooIkTJ4r3gUCAFEVp9FldccUVaRminJwc+sMf/pB2zO9//3vKzc1t8fqcIfTNAx4AACAASURBVDoPeL1eVFRUiDlAkUgkbY6PTqeD3W6HRqOBJEnIzs4W5bWJCLFYDKFQCMDxv5Z06NABsizD7/cjHA4jHA4jHo+DiOBwOGC320UWyel0QpZlRKNR+Hw+1NTUcEU6xhj7EZh/6BCkDRvSXgAabWurQgun66qrrsK3336LzZs3Y/LkyaiursYtt9yCsWPHntFohvbt22PLli0oKSnBI488ArPZjJkzZ6Jv375ijb/mHDp0CPn5+ejRowdsNhtsNhu8Xi+OnGIO1o4dO7B69WpYLBbxysjIQCQSwf79+wEgbd+YMWMAAIMGDYJWq8XGjRuxefNmdO3aFfn5+di1axf8fj+Kiopw5ZVXwmg0Nnnd6dOn4/3330ffvn0xY8YMrFmzBqlUCsDxv7yHw2HcfPPNadcuKCiA1+tFbe2Z1aAqLi4GEWHAgAFp7f3xj38U9zhq1ChccMEFyM3NxW233YZXXnkFdXV1Z3QdAGf0ea9atQrDhg1Dx44dYbFYMHHiRMRiMVRVVaUdN2jQIPG10+lE7969sWfPHgDHM0hPPvkkLr30UmRmZsJisWDx4sXic6+pqUF5eTmuu+66M76XkxUUFKCwsBDJZBKJRALLli1LK/hxKkuWLMHw4cORl5f3vfpBRGkFLk71HC+77DIMGDAAr776KgBgzZo1qKurExnAfv364frrr0ffvn0xbtw4PPfccygvL2984RNEIhEsX74cU6ZMEdsmT56M999/X2SKDxw4gFgshiuvvDLt3BM/T5/Ph6NHj2LYsGFpxwwfPhyHDx8Wvyu3Jq712IokSRKlti0Wiwh+IpEIdDodZFkGcLzwgsFgQCAQgCzLaNeunSiQYLVaEYvFEI/HoSgKsrOzEQ6HRWU5g8EAnU4Hg8EgCjOEw2H4fD5RiEGtWqeW7Lbb7WKxWMYYYz8s83NzMT83N22btGEDqJUqXrXEbrfD6/U22q4WRjjVEB+tVovBgwdj8ODBePDBB7FixQrk5+dj06ZNGD58+Bn1pXfv3ujduzcKCgowd+5c9OzZEy+//DLmzZvX7Dk33HADMjMz8eKLL6Jz585QFAVDhgxBLBZr8VqpVAr5+fmYNWtWo30ZGRkAgN27d4ttaoCj1+sxePBgrFu3DoqiYOTIkcjOzkavXr2wceNGFBUVYezYsY3aVF1//fUoKyvDp59+ig0bNmDSpEm4+OKLsW7dOhEYrVy5Ej179mx0rsvlavGemrpHAPjyyy9hMpnS9qm/WFssFhQXF+OLL77A2rVrsXjxYsycORPr1q1D//79T/tavXr1Er/k5uTkNHvcV199hfHjx+ORRx7BokWL4HQ6sW3bNkyePPmUn9mJ/vSnP2HhwoV49tln8bOf/QxWqxXPPvssPv7449Nu43Tl5+fj4Ycfxscff4xUKgWv14tJkyad1rkHDhzAunXr8Pbbb3+vPiQSCezduxeXX345gNN/jvfeey9mz56NJ554Aq+++ip+9atfie9vWZaxZs0a7NixA2vXrsUHH3yAWbNmYeXKlbjhhhua7Md7772HhoYGjBs3Lm17MpnEG2+8gQceeEBs+65VIc8WzhC1okQiAZvNBlmW4fF4cOzYMdTV1UGj0SCVSokgRWWxWGC1WhEMBmE2m5GdnY1gMIhAIACNRoNoNIpQKASDwYCcnBzY7XYxv8jv94v5SgaDAS6XCxqNRgRGTqcTyWRSBFNut/tHUZGHMcZY28nLy8POnTsb/fuxfft2yLKMHj16nFF76nyYU2V2TqVbt24wmUyiHfWPfif2s76+HiUlJZg1axauv/569OnTBwaDodG1FUVpdH8DBgzA119/je7du6NHjx5pL3W+y4nbOnXqJM5V5xEVFRXhmmuuAQCMHDkSH3zwAXbv3t3s/CGVy+XC7bffjiVLluDjjz/Gxo0bUVJSgosuuggGgwEHDx5s1KcePXqIP7qeLjWgKSsra9RW9+7dxXGyLGPYsGF4/PHHsXPnTnTo0EH8At/Uc2/K+PHjodfr8cQTTzS5v6GhAQCwZcsWZGZm4oknnsAVV1yBnj174ujRo02es23bNvG1x+NBaWkp+vTpAwDYtGkTRo8ejbvuugs/+9nP0KNHD5H1AoDs7Gzk5OTgs88+a7HfJ2rq+wQAbDYbbrvtNixduhRLly7F+PHj4XA4TqvNV155BZmZmfjVr3512v1orh2v14vx48cDOP3neNtttyESiYjvtZMzW5Ik4fLLL8fs2bPFHzEKCwtb7MeUKVOwe/futNeDDz4o5iv16NEDiqKIynqqEz9Pm82GnJycRnOPNm7ciNzc3EYBfKtobizdD+V1Ps0hOnjwIH355ZdUWlpKZWVldODAASotLaUDBw5QdXU1xePxU84vUveXl5dTZWUlBYNBUW1OPb+iokLML6qoqCC3200+n48CgQAFg0GqqqoSFenq6+upvLycysvL6dixY+T1esX4UcYYY2ffD3kO0eHDh8lkMlF+fj4VFxfTgQMH6O2336bs7Gy655570o7t1atXWlW5YcOG0csvv0w7duygw4cP09q1a+nyyy8nh8NBtbW1RHR8XkOvXr3o6NGjzfbh3nvvpfnz59OmTZvo8OHDVFxcTPn5+QSAPvvsMyIi2r59OwGgVatWUU1NDfn9fkomk5SVlUXjxo2jvXv30pdffklDhgwhk8lE8+bNE+336dOHJk6cSBUVFaJfJSUlZLFYaMKECfTVV1/RwYMHqaioiO6//3769ttvW3xmX3zxBUmSRFqtVrT34YcfklarJZPJRLFYTBx78hyi2bNn0wcffED//e9/ad++ffTb3/6WLBaLqA72+OOPk9VqpRdeeIH++9//0jfffEN/+9vfaObMmS32SXXynLC77rqL2rdvT2+++Sbt37+fdu/eTa+99ho9+eSTot9//vOfqbi4mI4cOUKrVq1Km6vT1HNvztKlS0mj0dCtt95Ka9eupUOHDtHOnTvpscceo6FDhxIR0T/+8Q+SJIleffVV+vbbb+mNN96gTp06pc1lKSwsJEmSqH///rRx40b6+uuv6cYbb6T27dtTMBgkIqIHH3yQsrOzqaioiPbu3UuPPvoo2Ww26tq1a1p/tFotPf7441RSUkLffPMN/fWvfxWf2clziJ5++mnKzMykb775hmpra9N+l9u+fTvJskyyLNOWLVtO67OIRqOUlZXVaJ5MSwDQCy+8QJWVlVRWVkabN2+m3/3udyTLMs2YMUMcdzrPUTV9+nRSFIUuvPDCtO1ffPEFPf7447Rt2zY6cuQIrV27ljp06EBz5sxpsm/ffPMNARAV6k60d+9eAkAbN24kIqLf/e531L59e/rHP/5Be/fupdmzZ5PdbqcePXqIc1588UUyGAz0yiuv0L59+2jx4sWk1+tbnCdG9N3nEJ3zgOb7vs6ngOjIkSO0ceNG+uKLL2jbtm20b98+Ki8vF4HRt99+K0pkh8PhtB+KqlAoRB6Ph+LxOAUCASorK6OamhoKBALk9XrJ5/NRIpGgYDBIhw8fpm+//ZbKysqosrJS7A8GgxQMBuno0aNUVlZGHo+Hamtrqby8nCoqKqiiooICgQAXXmCMsTbwQw6IiIh2795NN9xwA3Xo0IFMJhP17duXFi1a1OjfMABpgcbChQtpyJAhlJWVRXq9njp37kwTJ06kPXv2iGPUCfItTdz+4IMP6MYbb6ROnTqRoiiUnZ1N1157LX3yySdpx82YMYOysrLSyj9v2LCB+vXrR3q9nnr27Envv/8+de/ePa2fa9asoby8PNLpdGkFAr7++msaO3YsORwOMhgM1L17d5o6dSrV19e3+LxisRhZLJa0ifUNDQ0kyzJdd911aceeHBA9/vjjdNFFF5HZbBZlwk8uXLF06VK65JJLSK/Xk8PhoMsvv5xeeumlFvukOjkgSiQS9NRTT1GvXr1Ip9NRRkYGDRs2jN577z0iItq4cSONGDGCMjMzRZnvhQsXprXZ1HNvzubNm+mmm26irKwsUhSFcnNzKT8/P61k9pw5cyg7O5tMJhONGTOG3n777UYBkSzL9Omnn1JeXh4pikIDBw6knTt3ijY8Hg+NHz+erFYruVwumj59Os2ZMyctICIiWrFiBfXr148URSGXy0U///nPqaGhgYgaB0T19fU0ZswYstlsouz2iS699FLq06dPi/d/or/97W8kSRLt37//tM/BCWW/9Xo9denShW6++eZG/y8Qnfo5qnbv3k0A6Omnn07b/s0339CYMWNECfguXbrQQw89RNFotMm+3X///dSxY8dmf7e89NJLRXEFtey21Wolu91O06ZNoxkzZlDfvn3F8alUip5++mnq1q0babVays3NPatltyU6g4lu56MBAwZQcXHxue4GAKCiogIej0eUv5YkCYqioF27dpAkCaFQCEQEo9EIh8MBk8kkCjCcnOr2+XwAjqcNPR4P/H4/rFYrdDodEokEtFotjEYjvF4v3G63aEOn04lUokajQTweF3OVTCaTKMwgSRJkWYbT6YRer2/zZ8UYYz8VpaWlaaWTW8P8Q4cazSti7Kdg2bJluOeee5BIJM51V4R4PI5u3bph5syZ5+Uisy355JNPMG7cOJSXlyM7O/uc9WPkyJFwOp344IMPvlc7Lf28lSRpJxENaGofF1VoRRaLBeFwGEajUQRAsVgM5eXlMJlMyMrKQiKRQDQaRWVlJUwmEzIzM5FMJhGPx6HX68UkM5vNhmQyCY/HA71eD4fDgZqaGvj9fthsNgCA3++H0WhE165dUVdXl1atzmQyQa/XQ1EUOJ1OhEIheL1e6PV6WK1WERjV1dWJ9k9VW54xxtj5gYMhxs69VCqFuro6LFmyBMFgEHfeeee57tJpC4VCqKmpwfz58zFx4sQ2DYb+85//YNeuXRg0aBBisRiWL1+O9evXY82aNW3Wh5NxUYVWVFtbi5qaGrFoqqIoMJvNIjg6ePAggsEgTCYTDAYD4vE4jh49irq6OkiShFgshmg0KtqTZRkOhwOSJMHj8cDpdKJjx44IhULweDzQarVIJBIIBoPIyMhATk6OCK4ikQi8Xq8o0202m5GRkQEiEoGRxWKBJEmIRqOorq6G1+tNK/rAGGOMMcaaVlZWhnbt2uHll1/G66+/Lv5g/UPw9NNPo0ePHtBqtXjqqafa9NqSJOHll1/GwIEDMWjQIBQVFWH16tUYPXp0m/YjrU88ZK71lJaWora2FhqNBrIso3379qIEthrwpFIpaDQaZGdnQ1EUxONxJJNJaLVamM1m2O12EBG0Wm2jjI3f7wcRwWq1IhqNoq6uDlqtVmSTUqkUrFYrAoEAampqoNfrIcsyJEmC1WqFJEmi4p0a/FgsFiSTScRiMSQSCTGMzmAwnHclERlj7IfobAyZY4wx1th3HTLHGaJWlJGRAbPZLIKciooKBINBZGZmivk9iqJAkiRUV1ejsrISGo0GBoMBiUQCfr8fVVVVCIVCSCQSjcp0W61WmM1m+Hw+pFIp5OTkwGQyoa6uDtFoFIqiwO/3Q5IkXHDBBVAURQyjc7vdoky3RqOB0+kUwVMikYDJZBJD/dxuN6qqqtIWlWWMMcYYY+zHiAOiViRJkhjWptfrEY/HkUqlcPToUSQSCWRlZUGj0UCr1UKv1yOVSqGyshJutxsGgwGyLCORSMDj8aC+vl4MoTt5GJ3dbocsy/B6vTCZTMjJyYEkSaivrwcRQafTiblG3bp1E9mfWCwGt9uNRCIBIoJer0dGRgYkSYLP54MkSTAajaIfNTU1qKur4/WLGGOMMcbYjxbPom9FoVBILKSqDperr68XQ9LKyspgt9thNptRW1srFvkKBoMIh8Ow2+2wWCxIpVIiEDIajTCbzUilUtBqtdDpdACOr4at1+sRCASQSqXgcrmQSCTQ0NCAcDgMs9ks+tSpUydEIhFUVlbCbDbD6/VCo9GIhcOsViusVis8Ho8YRqfX6xGLxRCJRFBVVQWbzSbmHDHGGDszauVRxhhjZ8f3mQbEGaJWZLVakUgk4Ha7EQwGodVq0aVLFzidTlHqOhgM4tixY3A6nTAajaKEtkajgcfjwbFjx5BMJsXcn3A4DLfbDZ/Ph0gk0mgYncVigclkgs/nQyKRQHZ2Nmw2G4LBoCieEI1GQUTo3r07ZFlGKBSCLMuor69HMBgU30BOpxN2ux0+n08EY2rGyOv1orKyMi1bxRhj7NR0Oh3C4fC57gZjjP2ohcNhkTg4UxwQtSKj0YjMzExkZmaKSnDRaBQWiwW5ubmwWq0IhULQ6XRoaGhAbW0tMjIyoNPpkEwmodfrodFoUF1dLSrPaTTHP6JwOAyv14tAIIBQKJQWmGi1WtjtdgAQQVC7du1gMBjg8XgQiUSg1+sRDAZhsVjQrVs3BINBJBIJUTJSrUan1WqRlZUFrVYLr9crhtHp9XoQEWpra1FXV3de1f9njLHzWXZ2NioqKsRadIwxxloPESEUCqGiouI7lw/nKnOtSK3cRkRiGJy6jpDFYoEsyyAi1NfXw+fziaFwwPF/MKurq6HRaKDX65FIJJBIJGA2m9MyTBqNBoqiiDWG9Hp9WjRMRAgEAgCOZ49isRiCwSDi8bhYtDUajcJgMCAcDqO6uhp2u11UmFOH0UmSBCJCQ0MDkskkbDabWOMoGo1Co9HAYrHAarWKoI0xxljTfD4fampquFgNY4ydBTqdToySak5LVeY4IGpFiURCrP1jNBoRiUQQi8Xg8/nEgq1GoxGKoiAUCqG+vh7RaFQslKrX62Gz2VBbWysq0qmZG5vNBqPRKMp2y7IMRVGg1WphNBphMBjSApN4PC7mM6nZoXA4jGQyCYPBAJ1Oh0QiAYPBgNraWgSDQbhcLoRCIZjNZphMJjHeXR0GqNfrYTAYkEqlEIvFEIvFIEkSMjIyYDQaz9VjZ4wxxhhjrEUcELURv9+PWCwGo9EIn88HnU4HjUaDUCiEZDKJhoYGJBIJWK1W6HQ6GAwGeL1ekRkym83w+/1i+FsgEBCBTjweh6IoYp0iWZbFPCM1MFIXfD2RWsJbLbLg9/vFUDmz2Zw20ffYsWNQFAUGgwGxWAxOp1NcQ5IkBAIBMexOrUQXi8UQj8dhMBjgcrkarZ3EGGOMMcbYudZSQMS/vbaieDwugiJ1OFwkEoHFYhFD0qLRqKjylkwmYTKZ0KNHD9TW1qKhoQEGgwHRaBSxWAx2ux2xWAzhcBhWqxWpVAo1NTUwGo2w2+2IRCIieEkmk0gkEohGozCbzSIwMZlMopKdOtcoGo0iHA4jHA6DiET/cnJyEAgEUF9fj4yMDHg8Huh0OhGEqQUcGhoaxHtJkqDT6RCNRlFdXQ2z2QybzcbD6BhjjDHG2A8CZ4haUTgcRjAYFHN4jEajKKSQSqWgKAoikQji8bg4VqfTQa/Xw2QyIZFIoKqqCsFgUARDqVQKdrsdXq9XDI9LJBJIJpMwm80wGAziawAiEDIajY3KZEejUUQiEZhMJmi1Wvj9fqRSKcTj8bS1kTQaDWpqapBMJmG32xEOh2Gz2aDX6wEcn18Ui8XQ0NAghgCqAZk6jM7lcvEwOsYYY4wxdl7gIXNtJBKJIBqNisxQLBaDRqOByWQS83gURQERicDo5IIH6nFVVVWimEEwGIQsy2KfWvXtxPlFRCSKLADHAyN134nD6FKpFEKhkKgep2aPJEkSpbZlWQZwPMCrra2Fw+EQxSLUYXTq943X60UsFoPVahXtR6NRMT/J6XTyMDrGGGOMMXZOcUDURtQFWNUsSSKRgN/vB3C8+oXZbEYymWxUdCEej4uskqIoMBqN0Ol08Hg8qKmpgSzLMJvN8Pl8MBqNIngxmUwi66QoCsxmM+LxOCwWC7RaragUp9Pp4HA4RKADNF10IZFIgIhE/9Rhb/X19YhEIsjIyEAwGITJZILFYhHzj5LJJNxut8hgpVIp8SxSqRSsVitsNhsvSsgYY4wxxs4JDojaSCQSEZkRNUuiBhiBQAAajQYGgwFmsxnhcFgURlALH0SjUYRCIXGcGvxUVVXB6/XCYrFAo9EgEAikDW8zmUzQaDRp84eISJTEVosymEwmUbAB+L+67UQkhrf5/X5oNBqR3TIYDGKB2Pr6ejFELh6Pw2aziYyXJEkIhUIIBAIwm82QZVlUo0skEtBoNHA6nY2KPjDGGGOMMXa2cUDURurr6wEgrSS2OoQukUiIuUOyLIvsTjgchslkEtmiRCKBcDgsggiz2Qy9Xo9YLIZjx44hGo2KggrqULtEIgG9Xg+z2SzWL7JYLEilUqLUNwCRzXE4HGmBidovtfKdOtdIq9UiFAqJoXjqGkrhcBgul0tkpk7M/hARPB4PUqmU6AMRIRwOi/6cnK1ijDHGGGPsbOKAqI0Eg0HU1NQAAJxOJwBAr9eLIgRqAYNIJIJkMgmdTger1SqyMTqdTgxdi8fjonqcmgUyGAxoaGgQZbrtdjs8Ho8YFkdE4rhQKCQKNsTjcTidTpHNSSaTkCQJWVlZYlicOq8pkUiIeUTqcD8AiMViIjBS5xap6xKpc4jUinZqtsrr9YoFZIlIFF1QK9TxMDrGGGOMMdYWOCBqIzU1NYjFYtDpdPD5fGKBUwCigIFaIU4twKDuM5vNYo0ftdiCWpxBDSbU+UUAUFdXB7fbDbPZDEVR0NDQAOB4AKbRaGC1WsVQN5PJhFQqBVmWkZmZCeB4ABSLxWCxWNKG0SUSCUQiEciyDIPBIOYaqdksAGJhV3VBV4fDIYIsm80mhuxJkgSv14tIJCIKP6jXVcuQu1wuKIrSZp8RY4wxxhj76eGAqI1UVlaisrISJpMJLpcLsVgMkUhEDBFTK7upmZ8TAyO16AIRiUIEPp9PBA/xeBzJZBKpVEpkgSKRCKqrqxGLxeBwOMQcHnXInlp6OxKJIJVKiXMcDgfsdrtYoDWRSMDlcolhdCdmi9TgJxAIIJlMQqvVIhKJAACsVisikQiqqqrSKt+p11XnOMXjcXg8HjFUUA3w4vG46JfD4eC1ixhjjDHG2FnBAVEbOXr0KLxeryim4HK5YDabxUKsTqdTBBWKooj5RWrgRETQarUi0FCzSz6fT2SXgOPrCalluI1GI7xeL2pqapBKpeByuVBfX49oNApFUaAoCqxWKwwGAwKBAHQ6HYDjQU92drZYQygWi0Gr1SIjI0MEJidmi9QiDoFAAIqiiIBGLRdeU1ODQCAg7lGSJBG4qcPo/H4/QqGQKA6hFpxQ78tut4t7ZowxxhhjrLVwQNRGKioqUFZWBkVRxHAzrVaL7OxsEBH8fr8YRqdmUgCITEk4HBbBjlrNLRqNwul0wu/3i9LciURCzEtSj5VlGdXV1fB6vaKQQlVVlZhXpC4Sqw7DU4sxmEwmtGvXTpQDj8fjokw2cDxwUivmqQFWIBBAKpWCTqcTZcPVhWGPHj0q7j+ZTEKv14sS3RqNBslkUsx7Urerc6vi8Tj0ej0cDgevXcQYY4wxxloNB0Rt5MCBA9BoNAgGg2K9HrWym8lkQmZmJsLhsKjSpgYIavAQj8cBHC99LUkSJEkSRRfU9YLcbrcY6iZJkhhKZzAYxJC4yspKEdgkEgnU1taKAg5qYBQMBsXiqolEAtnZ2bDb7YhGo2LBV5fLJRZ6VcuCazQaUSRBzRYBEMPyHA4Hamtr4fF4kJmZKarlqUGami0KhULw+/0i8FOH7qnZtZNLhDPGGGOMMfZdcUDURioqKrBv3z5oNBp06tQJHo8HyWQSVqsV8XgckiTB6XQ2GkanDhlTh6+pwZG6JpFWq4XZbBbZonA4LLIsAERVN0mSxLFutxu1tbWiGp3b7Ybb7YbD4YDNZhNrF6llwOPxOBRFQU5OjtiublODNzVbpA770+v1Yg0lte/qYq86nQ7l5eUiW6RWwrNYLACOlwBPpVLiGanb1XtXAz4uusAYY4wxxr4vDojayMGDB1FVVSUyOQaDARkZGQgEAtBqtWKNH7PZDIfDIYbRmUwmWCwWkU3RaDRiWFwwGBRD49T5NWoBBrfbjXA4LIajAenzi7RaLSorK+H3+0WG6dixY0ilUsjMzITBYIDNZhPZnVQqhWg0ioyMDHTo0AGRSETss9lsImhRy2dLkiSCFfUeZVlOKybR0NAAt9uNzMxMMedIURSxZpIsywiHw/D5fKIQhDqvSu2TXq+H0+nkEt2MMcYYY+w74YCojVRVVcHtdsPj8UCj0Yiy0xaLBVarVRQ6AIBUKiWyReraQ06nExqNRszPUbMlsizD6/VClmUQkcg4ORwOMSROLautBiRq2Wuz2YxQKITq6mrE43ExLO7YsWMwGAxo164d9Ho9dDqdKKAQCoWg1WrRpUsXGI1GUdRBp9PBZrOJIXNqUQg1AFOzSuoirsFgUMxxOnLkCBRFEWsVqUHRiesgqdkiNXulzi1SAyOHwyHmXTHGGGOMMXa6OCBqI5WVlfD5fGIujDrkLZFIIBwOi/WG1GID6tygzMxMpFIpEYiogQ4RQVEUEaio6xOpAYgaADkcDtTX18Pv94tiBLIsIxqNiuyR2WxGXV2dCNYsFguqq6vh8/mQmZkJh8Mh1kA6ca0kh8OBzp07Ix6PIxAIiNLhVqtV3NuJ2SJJkkQ/ZFlGKpWC3++HzWZDMBiE2+0WJb/VQEzNFmm1WjG3SB36d3K2SKvViiF8jDHGGGOMnQ4OiNrIpk2bEAqF0L59e+j1elGIQF0/SA001NLakiSJ+T8OhwMOh0MUXbBarWINIXUeUTgcFlXe1AIMVqsVRCQKEFRXV4uhd4qiiOptahClHhMMBqHX6yFJEioqKiBJErp06SLm/KhBiFoOPCcnB06nE8FgEOFwWAQs6tpJJwZfJ2eLACAUCom5QkePHhVDCNWgz2QyQZZl8Sy9Xq+oxKfeRywWA3B8yJ7dbheV7RhjjDHGGGsJB0RtZPPmzdi3bx90Oh06duyIkVspYAAAIABJREFUdu3aicyOupip+l+1YIHNZoMkSSKYyM7Ohlarhd/vBwBRGU4NQtQhZDqdDh6PRxRSUBQFOp0OTqcTHo8HbrcbsixDo9GI4XCSJCGRSIgqczU1NYjFYrDb7fD5fKipqYHD4UCHDh1E2XB1EdVAIAC73Y7c3FwQEbxeLwDAYDDAbDZDp9OJ7JIkSdDpdCJbpGaO1CGEJpMJoVAIHo8HTqcTkUgEZrMZsiw3yhYFg0GR4VLnOAEQ1epcLheX6GaMMcYYYy3igKiN7NixA3v37kUymQRwfNhaTk6OGOKlDqVLJpMio6IWWbDZbEilUkgmkzCbzcjKyhJFDdS1fNQy27IsiwyPOhyPiGAwGKDRaMQ6PpWVlYhGoyJgUrNUJ877qampgd/vhyzLUBQFtbW18Pl8uOCCC2C1WqHVapFMJkWZ7UQigZycHLRv316sjaTT6aDX68XaRWrQIklSo2yRJEmIRCKIRqMwmUyoqqoSwRwAUfzhxGyRx+NBIpGAwWAQwaG6+Ku6BpJ6bcYYY4wxxk7GAVEb+eqrr1D1/9h7lxjZ8jy/63ve73MiTkRkRr7uzapbj6mpoZkZS5iRdwbEyCzwwozAks0CbLFASOzMBo8sWbBBAiSQBQgLVgMbwCALjTyMxhIeeYxAnp7pme6qrqp7b77ieeK83+ewyP79OrN6pru6fPvW6/+RWl2VmTcyMvIu4lu/3+/zvbtD3/fc80PTnKdPn7JimxTcFGRotY7WwMZxxDiOODo6gmmaSNOUZQN050M3NVVVwXVdpGnKRbCmaUJVVcxmM8RxjPV6DV3XeVpEiu6maWDbNpqmwWazQdu2ME0TXdfhxYsXcBwHb7zxBtvxAPC0yHVdXF5eQtd17HY7APf2OyqBpZU7+jhNizRNgyzLLIpQVRV1XfOdEf08ZNWjFcOiKFAUBYsiHk6L6HWez+diWiQQCAQCgUAg+BFEIHpN/O7v/i4+/vhjDiVd1/Hq2ziOsCwLZ2dnCMMQdV3zrQ8pp/M8R9/3WCwW0HWd+33Oz89R1zUHKNd14TgOyrLkziC6xSmKgqcvJGjQNA13d3fI8xyWZUFRFJ6ukLzB8zzsdjuWQhiGgSiKEEURT4QA8EpckiRomgYXFxc4PT1FURSI45inO7QKSMIFAD/SWyTLMvctqaqK/X7/SMdt2zZ0Xedp0TiOSJKE1w1d10VRFNxZRAFPFLoKBAKBQCAQCB4iAtFr4nd+53fw4YcfQlVV1kObpskhhW6FLMvC6ekpwjBkEx0FA13XcTgcYBgGwjCEpmnoug5hGCIMQxwOBw4Avu+zbIE6iwzDQN/3/DHTNB/1Id3d3bGdjkx3FKpopW2z2aAsS15je/HiBWRZxrvvvgvXdbnMtWkaRFHEkyQKVbTeRvIIWg8E7qdFpOSmaZGqqkiSBMC9fIFkCjQ1k2UZlmWx+jvPcxRFwUEOAN9IkcBiNpvx8xcIBAKBQCAQfLMRgeg18d3vfhfPnz/H9fU1q7Vt28Y4jjAMg6cvsixjHEdMJhPMZjNMp1MuNiUb2zAMyPOcJx60dnZxcYG+75FlGXcdkaab1vFowlPXNU+FdF3ngHV3d4csy2BZFocGui2q65onL9vtFn3fwzRNXr1bLBZ49uwZ+r5n+UEURSjLEufn57i4uEDTNNjv9zwtomkVhS9SdOd5ziuFiqKg6zqekuV5zpY9UnNTgJIkCcMwsG1P0zQOaiRbqOsapmliMpmIQleBQCAQCASCbzgiEL0mfvu3fxvr9Rq+76Oua5YBuK7LZaaqqiLPcwA/NKX5vo/5fA7XdXmSRFMYClEkDlAUBZ7nYblccpHpOI7QNA1BEKBpGrRtyxMi0nQPwwDDMOB5Huuzb25uWKag6zqapoGiKLyKR3c+tOZmGAaur6/Rti3eeecdTKdTFEUBRVHQ9z02mw1s28abb74J3/cRRREHE1mW4Xkeh6JhGFj0kGUZTNMEcD9BStOUw5GiKHxnNJ1OWdRAQSrLMl4/nEwmfFdFHUhN02A2m3EhrkAgEAgEAoHgm4cIRK+J3/zN38THH3/MZamTyQRJkuBwOPB6l6ZpLAooyxLDMPA62WQywdHREYcnWgujiRDdJrmuC9M0sVwuWb9NExbHcbhHqK5r1HXNYSCOY+4Zms/n0DQNt7e3SNOUi1ZJEw4AZVmyfnu326FpGmiahqIosFqtMJ1O8d577/FkyjAM7HY75HnO06Ku67Db7XgdzzRNfg2oXJXW4CjYUcAqigJlWXJPUxzHcByHJ1uk8qaJEk2LqASWJlhVVYlpkUAgEAgEAsE3GBGIXhN/+Id/iO985zs84dB1HUEQwLZtpGmKNE0hSRLfxZBCu2kalhXQCtx8Pue1NypnJV013dT4vg/f97FcLlmJDdx3HIVhCAD8Z/q+5ylQVVWwLAtBEGAymSDPc1xfX7Oem+6QALDZjSZNaZqirmtevWuaBs+ePePnoCgKxnHE3d0dLMvCm2++iSAIcDgcUJYlbNuGJElskHs4LaIQRL1FtEJYVRXiOGY1eV3XmM1m3HdEQSpNUzRNg77vMZlM+JZK0zSeHM3nczEtEggEAoFAIPiGIQLRa+Lb3/42bm9v0XUdr5pR5w/d76Rpyutwk8kE4ziy0KBtW9R1zdKDIAgwm81gGAavvfV9j7Zt+c7Itm3MZjOcnJzw49O9zjiOmM1mvH5WVRVUVYWmaYjjGIqiwLIsLJdLyLKM1WqFJElYe01TJwAcVGha9VCZfXt7iyAI8PM///MA7nuIDMPAfr9Hnuc4OTnBxcUFxnHEfr/nwKNpGocTKqZVVZXvo2hdrus6ttgBQBiG2Gw2CILg0R0UhUzqPdI0DZ7n8WtH0y3DMHj9TiAQCAQCgUDw9UcEotfE7/3e7/Gal6IoqKoKh8OBe4coGA3DwOY5KlKltTPTNHmVjqYkNDEikxzdGAFA0zQAAM/zcHZ2xoWp9FhZlnGxa1VVLG0gex3JFcIw5NsimhaZpsl3PgBYWkB67zRNURQFNE1DFEXIsgyXl5e4uLjg+5+2bbFer2EYBt5++234vo84jnlaNAwDG/ko/JD9jkpp6bWrqgpZliFJEhwdHaEoCjRNg8ViAUmSHq3g0e0VTcvatkVVVdB1HW3b8m2RYRhfwN8UgUAgEAgEAsHrRASi18Q/+kf/CN/97nfh+z6CIOApTtM0vM5FIWc6nfKb/qZpYBgGgiBAnuc8KSH5gizLME0TnudxEKDHpTLWLMsAAMvlEm+99RZUVeVeoL7vufBU13UOTLRqRhMU13VxcnLC06I0TeE4zqNpkSRJ3BtEK2n7/Z7vflarFWzbxvvvvw9ZllEUBWzbxna7RZIkODs7w8XFBQAgiiKoqgpFUbg0lmQIqqpClmW+naLXpOs6VFWFzWYDXdcxnU6xWq0QhiFM0+TOIrodquuaX1/XdZEkCU+n8jwXt0UCgUAgEAgE3wBEIHpNfOc738Ef//Efs056Op3yFIQkB1VVsbRAVVW+qSnLEk3TwPM8mKaJJElgmiYHELovIttcEARseKM3+Yqi4HA4wDRNvPHGG3j27BmSJEFVVfA8D0mSsNyB7G600kdraZqmYblcwvd9pGmK29tbFjGoqsoCCJoWUcEr3ReR5KGqKpyenuKNN95AlmXcwXR9fQ3DMLjTKMsyljcA4FD0cFpErxmVuVIJaxzHHLKiKMI4jjwtooAjyzILFqjPiX4P1HXUNI24LRIIBAKBQCD4GiMC0Wvij/7oj3Bzc8NmNCofpR6hvu/5DXhd12jblqchvu9DkiRkWcahhd7MB0HA626kydY0DYvFggPCw86hqqqQ5zl838cv/uIvwvd9bLdblibQ5IjW82jtjr5f27YIggAXFxcYhgF3d3fciaSqKlRVxTAMGIaB9d5027Tb7QAAwzCwXe7nfu7noOs6yrKEqqo4HA5I0xSnp6c4Pz+HLMuIooinRAD4vqjrOv5YlmWP7o9oDe7m5gbT6RSmaWK73WI+n3OYpMeiwteqqthUlyQJf880TbnzSUyLBAKBQCAQCL5eiED0mliv11itVtjv9xxsKGAYhgHHcaDrOqqq4vsW6tChaUgYhmiahqcqYRjym3kqcM3zHIZhQJZluK6L+XzORbD7/R4AYJom9xSdnJzgl37pl1BVFZIk4Z4kKj8lc1vXdTwtStMUhmHg4uICtm0jjmOsVitomgbDMB7JEKqqYj043SWlaQpFUZBlGbIsw9nZGS4vL1HXNcZxRNd1uL29hWVZePbsGTzP4/sr0zQxjiMkSYJlWVzESmWuAHjVjr7varVCXdd4+vQp7u7uoCgKZrMZl+DSfRGFVRJO0C2Xbds8iRK9RQKBQCAQCARfL0Qgek28fPkS6/Uatm2zTIBKTrMsY9GB67qslO66Dk3TYBgGPvZ3HIdLT2mNjVbYFEWB4zhceuq6LtvUqGB1GAakacoTliRJoKoqvvWtb+H8/BxRFKHve9ZhU2EsmekojNCtURiGOD8/R9d1uLu7Q1mWbKJ7OC2ioEEWvM1mw3KI3W4HVVXx3nvvwbZtvkPa7XZI0xTn5+c4Pz8HAA6TNFXTdR2WZfHaHOm5SYhA06KiKHBzc4PlcglJkhBFEU+L6Gd6eDNVFAUmkwlUVeXXlkIcrSaKaZFAIBAIBALBVx8RiF4T3//+97HZbKAoCoeYOI5xc3PDd0NVVWEYBhiGAd/30bYtuq5DXdcAgL7vkaYpTzBc18XhcOCgRFIE27YhyzKSJAFwHwps22YJgmVZyPOchQJlWSJNU4RhiF/+5V/mCRKFqMPhwJ0+JH+g7iMKV2+++SYsy0IURdhut9A0jYtWKXA8tN89lC6Ypok0TZEkCU5OTnB5eYmu63jCtF6v4TgOnj17xtOaqqr4scdxhO/73F30J+m5SWJxdXUFADg/P8ft7S1M02TNNq0oUhCtqgqSJGE2m3F/lGVZfCMVhqGYFgkEAoFAIBB8xRGB6DXx4Ycf4oMPPoBhGFw8OplMEAQBrq6usN1uea2MOoUsy4Jt26jrGmVZ8rSmbVvEcYxxHHFycsK3NwAQBAH37Xieh6ZpWMJAq3mSJMHzPIzjyFMmEifQatl7773HdzWe53EIoX4hEiHQY5RliePjY5ydnaFpGtzc3KDrOr4tookO3UoB4Buj9XrNYWa73XLACsOQf+7dboeyLHF+fo7T01MAYE04lcpalgXTNHkN8aFFDgCv/CVJgtVqhcvLS560kYmOplaKovAKXpZlmM1mAMABUJZlpGkK3/fhuq6YFgkEAoFAIBB8RRGB6DXx/e9/H2macleObdvQNA3DMODk5AS6ruP73/8+4jhmQxtZ2ii80FSFpkxpmrI57uTkhEtfDcN4VDpK/0yBhmx14zhiOp3y1Ik6hOgO6b333sNiseB1Odu2kaYpAPCNEz0O3SBpmoZ33nkHuq5ju90ijmMWPVCQoJU0WZY58JAu2zAM5HmOPM9xdHSEy8tLAODAttvt4HkeLi8vYRgGq7bJckdBs+s6qKrKMopPCxf6vsfz58/hOA7CMMRut4NpmgjDEH3f8+tBN11lWULTNEwmEy6BNU2TQ1MYhlBV9Qv5uyUQCAQCgUAg+PyIQPSa+Pjjj/Hhhx/CNE34vs/6aQoUuq7j2bNniKIIn3zyCU95dF3nSQxNlpqm4QnQMAzY7/coioK7gvI8556gIAiw2+24ryhJEi5fXS6XLCqgiQrd/aRpir7vsVgs8OTJE5480fOhQEMdR6ZpsvChKAqcnZ3h7OwMRVFgtVphHEcYhgFN0zgI0mqaJEkcnNbrNb8u1GH0xhtvsFCiaRpeEzw9PcXR0REAcO8SrQB6nsc/i2EYj0pnqY+o6zpst1tkWYYnT55wGJ1MJnxjRaGK1uSqqsJsNuPfj2ma6PuejX80gRMIBAKBQCAQfDUQgeg1sVqtsNvtcDgckCQJv3nebDZ8YyPLMiaTCS4vL/G9730P+/2eNdxkWqMpS9/3fCcTBAHf43Rdh8lkgjAMEccx/1nLsvheZxgGnmw4jsPByjCMRx09RVEgyzJYloWzszPM53M4jsNfSyGkrmueFlFIotWyd999F4qicPkq3RVRt9DDaVGWZbw2uF6voWkamqZBURSYz+d48uQJNE3jaVQcx5hMJjg/P4dhGCxvoCnUOI6YTCa8NkeTnk8LF0jPTTdBaZrCsiwOYVSYSzdQSZLAdV04jsN6bgqbiqKwjEEgEAgEAoFA8OVHBKLXxH6/x2az4WkDhZ0wDAGAb4DosP/JkyeYTqf4zne+wxMfVVXhOA6apoEsyyweKIoCpmnC8zxEUcS9PcfHxyxFGIYBR0dH6PseURTx3U3XdZBlmdfoaKoCgK1tVF46m80wmUz4cUlEQLdBaZpiGAb4vo88z7lY9fz8HGdnZ0jTFJvNhvt9SNpAPUW0mpckCQzDwGq14pLUKIqgqiouLi5wfHzMN01Uunp6eoowDLn3iKQLVVVxfxAFmzzPoSgKCxjo+d/d3fFULM9zDqj0mDTZIuHCMAyYzWbc1/Tw3otukgQCgUAgEAgEX25EIHpNUPigHiJFUZCmKfb7PZvM8jxHXdcYhoFlBu+++y7yPMfLly/5/ojWwcicBoBvXciYtl6vebqzXC7Rti33By2XS+z3e74VqqoKfd/z6hyJEGh1jUQKeZ5D13UcHR3BNE0cHx/zChr1DbVty4HGMAzEccx/7p133oEsy1itVmjbFpqmQVVVLkodhoHvfagnaRgG3NzcwHVdlj5MJhM8efIEpmmiKApEUcSa7LOzM6iqyhY8SZK4Q8nzPO50ovJbssQpisLPfb/f4+joiPugTNPEZDLh6RNp0YF74cJ0OoWqqnxDpWkavwa+7/OKnkAgEAgEAoHgy4cIRK+Juq75+B+4X6Hruo7DC4WTIAi4l6iqKjRNg+PjY7z99tv45JNPkCQJDocD6rrGdDrlEEJ2tCzLoKoqF6zu93u0bQvbtrFYLPjGZzqdYj6f4+bmhm+VqATWtm1YlgXf97kTSNd1tG3Lz2s6ncLzPDiOg9lsxrc01DdEP4Prurzi1jQNzs7OcHJygiiKEMcxl6halsUmOgpo4zhiv9+zoKGuaziOg8PhAFVVcXx8jPPzcxRFgTRNeQ3w+PgYk8kEiqLw41GXUhAEbOsDwK878MMVurZtcXt7C9u2edWOpkU0EaNQNY4jB80gCHhKRnpwCnBiWiQQCAQCgUDw5UQEotcMrZ+R6ppuiCi80IoY9d2QYluWZbz11luYTCZ4/vw5sizjKcrx8TG6ruO1OlrpchwHjuMgyzLEcYymabi/iFbNFosFLMvi9TRSU1N/z3Q6ZZuaYRhscqOvXS6XbKsLw5AtccC9ie5wOMAwDJ76lGUJ27bx9OlTKIrCBa2qqkJVVViWhXEceVpkGAZ2ux1Pi25vb/meqmka+L7Pxrk0TRFFEd9RHR8fs/Kb7q1oQkQhSNd15HnOqm2a5rRti91ux9+DAhqV59Z1DU3TANyHXSqEnc/nfKv0UM/tOA5c14Usy1/MXzyBQCAQCAQCwZ+ICERfAGRxkySJ35Dvdjvouo44jrHdblmXres6yrJEWZaI4xhBEODNN99E3/dYr9eI4xhpmkLTNCwWC56WyLLME4zJZALgPowdDgdIkoTFYsGTHMuyMJvNIEkSbm9vuROo6zq24J2fn6MsSy4npRuapmkwnU7h+z4AYDabIQxDjOPItzp0S+R5Huq65nupk5MTzOdztuTRtMi2bZY7lGXJU5ntdgvHcfg5mqbJ64eLxQJPnz7lNcSmaaAoCo6Pj+G67iOpAoUS27YBgKdfdV1z6COhA4VJ3/c5yA7DgOl0yjdcpOemaZHrurAsi0OYYRjIsox/F6LMVSAQCAQCgeDLgwhEXyBt27JhjW5QkiSBJEk4HA5cvur7Ppvl1us16rrGxcUFwjBkdTTd0Xieh+l0it1uxzcwNBUhw9zDLqSHt0vT6RTT6RRVVeHq6orvlB6utc1mMyRJwhMd6kWiaZMsy1AUBUdHRwjDEFmW8TRlv9+zUCFNU36+JycnXMqqaRorum3bRtd1PH2xbZvFB8Mw4O7uDkEQsGDBdV289dZbMAwDm82G+5VoPVBVVRiGgSRJQH+3Lcvi159Mdw+nR6T6pp4iCmqSJMF1XWiaxkGKSnUfdhNRiKSVxKIoEATBo9AnEAgEAoFAIPjiEIHoS0BZlhwaKAyRJOGhhMFxHAD3/TkUWJ49e8Zv3He7Hd8MnZ6eQlVVrNfrRzdGpMaWJIknKb7vw7Zt7Pd71nBPp1NWhVNgoDW/MAzhOA6KooCiKKy7plsjMrOZponlcgnXdbHf7/neqaoq7guKoogFDY7jIE3TRyt7D0MIrbY1TYPtdgvP83B9fY1xHHkiQ0W3l5eXOBwOHAxJBmFZFmzbZp03medovY06i2hKRNOktm2x3+/R9z0sy2LZwjiOCIIAdV2zua5pGrbzzWYzfu4PhQt050VrdwKBQCAQCASCLwYRiL4k0LrVMAwwTRNt2/KdTxzHiKKIV9k8z2M99Xq9RhAEODs74+nHdrvltbknT56gKAruKBqGgac0NAHa7XZQFAXT6ZQ7hYIg4NWvFy9eoG1bAOA38LIsYzab8WrZOI4sL3hoqxuGge95xnHkAEQrZAD4Fmo+n8P3fX4tSLJAkgcKdnmew7ZtXF1dccg6HA68kldVFWzb5g6k29tblGXJIYT6hsiCR0ptCkCGYaDv+x/pLGqahhXodMdk2zbGceTfCU3jmqYBAO5eIksecD95evg6Pwx9AoFAIBAIBILXiwhEXzK6ruOVK7pNoRWvzWaDoijYejadTjEMA66vr5HnOU5OTjjI3N7e8hodCQ/2+z2iKOKpDk1+6I4pTVOYpgnLslii4LoufN/HMAy4urrifh8KRqSkVhSFi1qbpoFlWRyK6GuPj4+5MLZpGl6dI0U2Fdb6vs8/O+m4NU2D4zgcopIk4ee93W5hWRZ3HJmmyeHy7OwMl5eX2Gw2rDjXdR2z2QyWZXGwybLsR0KRoijI8xyqqkKSJJ6QVVWF/X4P13X5VokCJt1X6brOcoiqqtC2LcIw5NeH1hCTJIFlWXAcR5S5CgQCgUAgEHwBiED0JYXuYuhWhwLLMAxYrVZ822LbNqutnz9/DlmWORhJkoTtdou7uzuoqspGubu7O1ZeP7SrqaqKOI7RdR2HD/oejuNgMpkgiiLsdjvUdc1TFgCs6abenzzPMQwD5vM5+r5HEARskzs5OYHruliv1ywpKMsSAPjOaD6fw7IsvoOiUEXBoe97NE3D1rrnz59DURTUdc1WN1qLcxwHv/ALv4Cu63Bzc4O+76EoCocv27ahKApP5CzL4teFAg7dUsmyDFmWWXIhyzIHsyAI0HUd9x0BgKqqaNuWJ3oU9uh2jP4s3YrR6ykQCAQCgUAgeD2IQPQlh25qSIiQ5znKskSSJCwsoH4d3/dxe3uL1WqFyWSCIAjgeR76vucQ5DgOwjCEJEm4vr7mSQ1wLwowDANt2/LExDRNlGUJSZLgeR5c14UkSUiShCc9hmFwQavjOJhOp1yiSt1BJBFwXZfX4KgwtigKLogF7lfo6P6GVNW0vkZ2OcuyuJT2cDjAcRzs93scDgdWfAPgx22aBpeXlzg9PcXNzQ1PmHRdZ8mB7/vcZ0TPdxxHuK7LoY0sdLT2lqYpyrJEGIZ810RBhxTo9JpKkoQ0TTmMlWXJnUhk5fM8j0UPAoFAIBAIBIKfPSIQfQXo+55vbkzT5MlHVVXclVMUBd/hmKaJDz/8EHmeYzqdYjabwbZt5HmOq6srDMMA3/cxm82Qpimurq6gKAqb0GhljIpF6caFxAkUIIZhwH6/R5qmHFRookUTniiKePVtMplAVVUOGzRB8n2fRQOk8u66jlXk8/kcsiyjbVuealG4kmWZwwRNcV68eAFVVVHXNYeMqqpY/f3++++jKArc3Nzw6hpNimjKRXdVNKUyTfPRZIfusMiAR0p0+j1MJhNWlLdtC0VR+GemnqjpdIq+7/nzmqbx5I6U6wKBQCAQCASCny0iEH2FqOuaNdeapqEsS1RVhTRNWUxwOBygaRpOTk5QFAWeP38OAKzUtm0bt7e32Gw28DwPtm3D8zxcXV0hSRI4joO6rvkNvyRJbF0js1zf92yjUxQFfd8jjmMkScLrcRTeTk5OWEZAemoKHdTtM44jzs7O2FZnmiavqUVRxF1HjuNwgHAch//fNE1eUYvjGK7r4vr6mi14ZOmjW6W2bfHOO+9gPp/j5cuXfPOj6zo8z+NwdDgcWJPd9z1Pyf60FToKdaZpYrvdYj6fYxgGXoPr+55DZ9/33FlE4ZNWF2nq5/u+EC4IBAKBQCAQ/IwRgegrSJZlrH0GgKIoWLtNn4vjGJPJBIvFAi9fvsR+v4dpmvB9H77vw7IsfPDBBxiGAa7rwrZtyLKMly9fsnCBrHY0uSFdNhXIapoGz/P4TTut2tG6GkkEwjDkFTHqBqLVMCpiJREDdfeQlIBW6qIo4rAiSRKqqoLjOHyX5LouxnGEJEk8TWvbFuv1mlXd9GfqukZRFAjDEO+++y4OhwPW6zUryV3Xheu6CIIAbdtit9vx7VLbtnBdFwB+ZIWOxBBN0+Do6Ag3NzcceEjmQIGPAlyWZZAkidXdAFiLnqapEC4IBAKBQCAQ/IwRgegryjAMHC5M00Tf96iqCnmeY7/fo65rZFmGpmmwWCxgmiY++ugjDgK6ruP4+BhxHOPly5ewbZvlCUmSYLPZQNO0R7ptSZJYZjCZTDjg2LaN6XTK9rphGBBFEd/2GIYBwzAwn88BgO+LaCJDpjsKFfP5HJIk8epelmUAgN1uBwCYTCZsfKO+I5pgUXjrug5ZlsGyLFxfX7Md73A4sCqbbH7vvfceHMfhaZqqqvy8p9MpDMPAdrvl8Ng0DXRdh2VzeduSAAAgAElEQVRZPIUiCx2t0EVRhPl8jjRN0TQNZrMZhmF4tJb4sMOpqipMJhN+7vR5ms4J4YJAIBAIBALBzwYRiL7ifHqNjtat6LaHwokkSVgul2yjozf9nudhsVjgww8/5BsbmgJdX1/zShuAR7pueuNOOu9hGOA4Dk99AKBpGqxWK5YOyLKMIAgQhiGv0A3DwGWptG42jiP6vkcYhui6Dr7v889VliXyPOdVOVmWUdc1yyNM04Rt2zzdIslCHMfY7/e8kkZf2zQNsizD0dER3n77bazXa0RRxOY5suf5vo88zxHHMWvIh2HgyQ51GZGdLs/zR4Hw7u4OYRjy11C41HUdwzDwCp3jOFy0S6/jMAwoioKncfRxgUAgEAgEAsE/OyIQfU2gaZBlWazLbtsWt7e3jw7/TdPEYrHA7e0tr2QpioLz83NUVcVCgiAIWCJAKmwKMLZto65r7h4KggCKomC73UKWZe4lonBQliVubm4AALPZDJIk8bSI1sRUVYWmabxeRiWr1O2j6zr3CwH30yJN03h9jQpRSZJANjxJkvjWSlEU3N3dPepAIukBFbe+//77GMcRL1++ZFMcWe3CMISiKFiv1xwayaJHP+fDFTpSc/d9j+PjY1xfX/MN1TiOUBQFbduyPIEsgg9/fkVR2ESXJAl3OwnhgkAgEAgEAsGrQQSirxG0RkdTl77v0XUd4jjGbrfDOI44HA48CSKZAnB/t2JZFpbLJe7u7vjgnx4nyzIURcEBg1TdwzBAURR0XYf5fI48z1lp7fs+r35JkoT9fo/NZsOFqKZp8loZBQRN06DrOlvvSLCg6zo0TUMYhmy/o64mCgiktnYcB8B9Z5GmaTzhiqKIhQckn2iahoMTTaDOzs5wcXHBEzJ6PqZpIgxD2LaNOI5RliV83+dpjuM4PK17WOSapinSNMVyuUSaplyWS3dBNM2iyU9ZlqjrGr7vP/o8SSH6vofrukK4IBAIBAKBQPAKEIHoawhJAzRN4y4c6iKiyRFNc+gN/Xa75enSbDaDLMvYbreo6xqz2YwnIGSZq+sabdvytEiWZS509X0fq9WKV8Js2+bpT1EU2Gw2yLKM5Q4kWCiKArquQ5IkqKr6aFpEUgfLsjiopWnK0x0KUrTKR5Mjy7JgWRaA+54l0nM3TYP1es0iBgo14ziiKApYloV33nkHRVFgu93yjRPdPVEJ636/h+M4rAX3PA9t27LsgYIOmQCDIICmadwVRX1K4zjyjRGARzdQhmGgaRq+jyJxBK0oCuGCQCAQCAQCwedHBKKvMVTcSoGgbVs0TYPb21uoqordboc8zzkYHQ4HfnNOdrOiKLiklQxwFIZookJiBwphtCLWdR222y2AH05rqHQ0yzIOaGEYwjRNTKdTXqGj50y9RvQcSZvteR4mkwl3MDVNw19vGAbyPOdVO03T+Eap73sMw4A4jqHrOtbrNT9vCkXDMKBtW9R1jTfeeANBEOD29hYAOHgZhoHZbAZd1zlcmqbJr7emaTzZohU6ki1QTxP9HqjMlX5Huq5zvxIJJUj3res6+r7nOyWy4gnhgkAgEAgEAsHnQwSirznDMCBJEg45JEnYbrdI0xSyLOPu7g5d13H4IHNa27a89kZBiKY5h8OB74qapkGSJLBtG8D9hErTNCiKgvl8jizLsN/vOZhQEWrbtoiiCKvVCpqmYTabsRShKArYtg3TNDEMAzRN41VAChs0zaIenzzPecpD4YTsc1TkSo8nSRLiOIYsy0jTFFEUsWqcPk+TGN/3cXl5iTRNudOI7pUelt6WZclSCEmSYFkW30E9XKGjdbuTk5NHq3cPVeOyLPO0LM9zNE3DkzIy8NE0rGka/tkoWAkEAoFAIBAIPhsiEH1DoMBAb+Rprev29haSJCFJEkRRhK7r+JaFSlcpTAFgDfTR0REXsY7jiLqu+Y2767p8b0QFrNPpFKvVCmmawjAMmKbJU6OyLBFFEXcNOY4D13X5NikIAg4B4zhClmXYto1hGFCWJXcG9X2PPM95ItO2LSzLwn6/Z/EDqcXpcYqi4ABIa34A2HRHnUeSJOHy8hKapmG323HA0TQNjuNgOp1iHEekacqfo+JYMtJpmsYdQ0mSIEkStu/t93u27QHgP0OhiCZhFAjbtoVhGHw3RRMx+rxAIBAIBAKB4LMhAtE3jCRJ+I06venP8xzb7RamaeL6+ppNbpIkwTAMvo+hKQ1NMXRdh+u6PGnp+56LTE3ThKqqyPOcJ09kn9tsNjyRMk0Tk8mEb4E2mw3quuauJM/z2LJGd0GqqqKuaw5WTdPw6h2FhCzL4LouSxdoGkb3TL7vP9Ja08+w3+95DZA+NwwDgPswOJvNcHp6iiiKWHZAt0Xz+Ryapj0qzqXXiUIohRXDMPiuyLIsBEGA1WoFVVVZEjGOI5vraBWRupNc1+XXgIJbWZaQJIkna0K4IBAIBAKBQPCTEYHoG0jXdUiShO9eaI2OwsgwDLxGR+tbdL9DUx8qRe37HtPpFGVZomkaXtmK4xhxHHMJKt3WkEShrmsuWqVgRW/u9/s9W+BIQkCraEEQ8JRFkiS23NHtDwCeKNHk56GUgLp+NE1j0x09FoXFuq55JXAcRw6AAPj1ePLkCd/4PAyOQRDAdd1HKm8KJhRqHt4VVVWFKIowDAOWyyVP6Uj1DYBfd3queZ6zwIKCJUkt6LWmUCQ6iwQCgUAgEAh+PCIQfYMpioJLTmkK1HUdTyqiKMLhcGCJAlnhmqZh8QCFEMMw2CJHAWAcR6zXazRNg8lkwpMnKit1XRdJkiCOY15nI2same/KsuQ397qu80oYrcjR81YUBaqq8tSLwlfXdaiqikOYbduIoog12rSeRyGrrmskScIrdBT+SIoAgG+nZrMZJpMJm+toEmYYBsIw5Mdr25ZNcA8nOhTkgHsleJ7nXJ5bVRULE2RZZjsgvT5kEqR/p6JZ6lsiQx29bgKBQCAQCASCPxkRiL7hjOOIOI5ZVU2H+lmWcTDYbDZIkoSnIScnJ3xb0/c9T0KoRLXrukd3M1mWYbPZ8IocFaJSIFEUBbvdjgUEruuyMpy01xSqqGeIlNMPZQs09SKhQ9M0HL7yPIfrumia5tFaHdn0XNd9ZHeLooh7m2gVkLTX1DVE06nlcsnrbQD4Tms6nbIK/KGBjyZEdGsE3E+P4jhGkiRcins4HDhg0Z95aM9r25ZNc7Zto2ka1qA/vH2icChW6AQCgUAgEAh+FBGIBACApmmQpilrpSnUUFABgM1mg91uh7IsEQQBlsslyrJE27aoqgpN03DvEE2Ouq7j0LLdbhHHMYIgQNM0qKqKJynU33M4HHgSQjdCFJjozoeC0GQygWmavKJGiu3D4cB2OTLkTadTdF3HvUDDMPC0iL7WdV3Wc9NqGk1/9vs9hyzLsjgcUn9QGIa8wlYUBRvffN9ny11d16zMpokUrc6RGS/LMkRRBF3XsVgssNls+OsfKstpogbg0Qod3S7Rmt84jvyc6a5LIBAIBAKBQPBDRCASPCLPcxRFwW/im6ZB13XY7Xb85nq1WmG73UJRFBwdHWE6nSKKIgBAmqYYx/GR8IBWuqh89e7ujruE8jznfiLDMGBZFvI858ehCZLjOKjrGlEUoSxLyLLM06T5fM7dQFVV8U1TkiT8mDShsW2bw0Oe5wiCAGVZoixLvmWi8EDqcVJyr1Yrfn60nkaTI1qZOzo64tACgL8/6cspaFEwIRX3w0Lavu+x2+3QdR1OT0854I3jyIGNAqXjONB1HXme/0iH0cMVOnrOtNooEAgEAoFAILhHBCLBjzAMAw6HAwDAtm30fc9rdGRry7IML168YJvbxcUFd/qUZflIA900DYcjeuN/OBywWq04eNB9D2msadJDa20kLqDOn91ux+tnkiRhsVhwwWtVVbyydnt7y/c+wzBwrxBwb2ory5KnYhQqbNtm4QKFh8PhgK7r2C43DANkWebXgtbfaLWPLHC0tkfTIvpeFJgAPAqOmqaxYjyKIhRFgfl8jr7vOdwoisLBJ45jXj2sqorX+ajA1XEcts/VdQ1Zljmsis4igUAgEAgEAhGIBD+GqqqQpilM0+Q3+23bcpmoqqrYbrd4/vw5hmHAbDbDs2fP2JRGUw6yvtHqFk2QqqrCdrvF4XCA67psrqMbHAoSURTx9AMAfN+HqqqI4xj7/R4AWE19dnbG90BRFGGxWGAYBlxfX8N1XdaEP5QqUKiZTCaoqurRLROt5JG1jrqXyIJX1zWvunVdx9IEVVUxn8+hqiqrtenWh7TawzDwDZBhGKw0pxCm6zqSJMHhcIDv+7ziRytxpPum7iPXdR91MdE9F60wNk3D0gm6SxKdRQKBQCAQCL7piEAk+InEcYy2beG6LmudKRhRt853v/tdbDYbOI6Di4sLTCYTHA4H5HmOOI75tojWw4ZhYFV1kiS4vb1lsQNNkii0eJ7HYeTh3U0QBDy1yfOcb21msxmWyyV0XedOoYuLC+5YOjo6QlEUqOsajuNAVVXMZjPsdrtHFre6rln7TVrwtm2x3+8hyzLW6zVM00RRFPw5CopkhpvP5wiCgIMUTZ1o9c00TcRxDABc3Np1HSu3KXTRDdPR0RE2mw2HHU3TYBgGW+fo+VJAo8BDcoaiKLiQlm6xTNP8wv5uCQQCgUAgEHzRiEAk+Ex0XcdTEer1oR6eKIp44vPtb38bbdtiNpvh8vISwP1d0Xa7xTAMvCLX9z1PLhzHQVEU2O/3/MafdNS0RkY2OLohotASBAF830dZlthut6iqioPF2dkZjo6OANxrrefzORzHwUcffcTq7v1+D8MwOGzUdY2qqti4Ryt1dOMUBAFb6Nq2RZIkfN9DPOx4qqoKhmHg+PgY4zgiSRLYts1SBF3X+eev65pDYFVVPMGhm6Dtdouu63BycoIkSQCA75LIrEfTKFqVo8ckQx6FS7oHo2JZmmAJBAKBQCAQfNP4XIFIkqQBwGdKS+M4fmHNkCIQvXqKokCapvA8D7Iso6oqVnfTfc4HH3yAFy9eQNM0PHnyBIvFAn3fY7PZ8HTF8zxeLaPSUTLC3d3dIcsy2Lb9yMZG62a0hkb2u3EcMZ/PeTJyd3fHq2eu6+Lp06fwPA9xHGMYBhYV7HY7TCYTFEXxyGxH0yLq8KmqCgDY6kZ2uzzPkSQJqqpisxwFsizL0LYtHMfBMAyoqgrHx8fwfR+bzQa6rvO0iGQO9Do+LMwFwNMiVVWx3++R5znm8zk/Lk2LFEWBZVk8cZpMJmiahqdktM5H64nUI0W3WLR2KBAIBAKBQPBN4vMGor+EHwaiYwB/C8D/AuB3f/CxXwHwFwH8zXEc/+tX+ox/CkQg+tkwDAOiKIIkSdx/Q+KFzWbDIebb3/424jjGYrHA+fk5fN9HkiRYrVZ84E+rcSQToMdL0xR3d3fcZUTqblmW4TgOB6okSdC2LUsZZrMZ+r7HdrvlyZWu65jP57i4uMA4jtjtdpjNZvA8Dzc3Nzyluru7g+d5HIpoBY6mJ3Vds+DBNE34vs9qcpoakSWOCmPzPGfTXBzHcF0XZ2dnOBwOaJqGO5dopdCyLBY4mKbJt1eO47A5ju6KXNeF7/vYbresLafn1jQNsizDbDaDJElcikvltRR+aIWOJlIUjERnkUAgEAgEgm8K/8wrc5Ik/T0A//s4jv/tpz7+1wD8xXEc/7VX8kw/ByIQ/WypqopXwFRV5UlKmqasvN7tdvje977HdzxHR0dwHAeffPIJDofDo8BDa19071JVFdbrNWuv6eaIFN5UzloUBa+ctW2L5XIJwzDQdR1evnyJuq7heR50XceTJ08wn8+x3+/RdR2Oj49Zra2qKtI0RdM0mE6nHLwe9h89lDvIsszlq/v9noPcOI6QZZnLaclCZ9s22rZF27Z44403oCgKVqvVoyJa0zQRBAGKokCWZRxQyrLkHiESXGy3W8iyjOVyie12y1M2mrypqordbsdChjRNOVQCgKIocF2XjXdN03A4pdVGgUAgEAgEgq87ryIQZQB+cRzHDz/18bcA/NNxHJ1X8kw/ByIQvR6oTNXzPF7FGscR6/UakiRhGAY8f/4cNzc38DwPp6enODk5QV3XeP78Ocqy5PsimlIMw8AFrofDAZvNhiUBiqJwIarneXAcB47jYL1eswlPlmUsFguoqookSXBzcwNJkjCdTmGaJs7Pz2FZFqIogmVZrOAuioK1457nwfM8ngqlacpWOppu1XXNk5qyLBHHMfcT0VSLVtuapuHJzOFwwNHREU5PT3F1dQVFUeB5HgfCyWQCANzvRLIJKpSlKdx6vea7oizLeIrU9z2b5g6HAyRJQhiGvB4IgJ+f53lomobvwoZh4N+DWKETCAQCgUDwdedVBKJPAPydcRz/0099/G8A+PfGcbx8Bc/zcyEC0euDbG8PrWcA2DJHHUUff/wx8jzH6ekpjo6OcHR0hKurK2w2Gw5S1EdEb+4dx0GapjgcDqz0Nk0TlmUhSRI2zk2nUzRNgyiKOIB4nsf3Nre3tzwx8X0fYRgiDEO0bftofa0sS34cAJhOp3wzRUW1vu9zz09RFFBVFUEQQFEUDkVFUXDA6bqO19g0TePJk6qqeOeddxBFEdI0xWQyYalEEAS8aleWJRzn/r8t0G0SAJ5OZVmG+XwO4P7Oi6QQbdvCNE20bYssy7BYLNB1HYqiAABe8fM8j0tjJUlC27asPxcrdAKBQCAQCL7OvIpA9FcB/F0A/wA/vCH6FwH8ywD+nXEc/4dX9Fx/akQgev3keY48zx+9IZckiTuJ6rpGFEX45JNPYBgGTk5OcHJyAl3X8dFHHyHLMu4B8jyPw8RkMuHbpSiKOJiQtIDubCjsRFGELMu4lPT4+JilBy9evGATnu/7mEwmCIKA+3weCiN2ux0rqo+OjqAoCiRJYnvcQ0EEPQdaT6OiVJq40PSsqiruZ+q6DnEc4+2334au67i5ueHHGMcRjuNwPxJNs0jFTXY8wzCQZRn2+z08z+O7It/3+eegVbvtdovpdArDMHi9T1EUntBRpxL1FZFCXKzQCQQCgUAg+LrySrTbkiT9WQD/AYD3fvChPwLwX47j+I9fybP8nIhA9MUwDAPb5CzLYvVzkiTIsozLQ29ubrDf7zGZTLBcLnF2dobdboe7uzsODSQaIBFAEASIoghxHCPPc1Zw0y0RFZQul0ueiiRJwv1Hs9mMg8Ht7S0Mw8DFxQVPnOimRtM0TKdTVFWFw+GAw+GAcRzh+z5msxmvltG0yjAMeJ6Hw+HAYY4mMXmes2iBwgut1TmOA9M0sVqtsFgscHl5iRcvXgC4n0z1fQ9N03j6s9vtIEkSHMdhMQXdFrVti81mA03TcHR0xHdF1JFEAZJusmazGdI0Rd/3AMCrgJ7n8evf9z0kSYKqqmKFTiAQCAQCwdcS0UMk+JlRliWSJGGlNE2LaKWtLEtUVYWrqyt0XYejoyMcHx9jOp3i5cuX2O12yPMcqqpyOBjHkc1p2+0WWZYhz3M0TQPLstD3PReghmGIIAhQ1zU2mw3f4Pi+z/dJL1++RFmWCMMQx8fHAIAgCHiyEgQBT5ZevnzJjz2ZTPj7kfKagguVojqOw9Okqqr4a6kjiP5nGAavBXZdh29961u8HjidTrlDaDabwbbtR4rzhz8vmfro3mq5XCLPcwA/VHcXRQHbtlHXNdI0xXK55HA2DAN/ryAIMAwDr9BRoKSeJLFCJxAIBAKB4OvCq5oQHQP4KwDeBPAfj+O4lSTpzwG4Gcfx41f2bH9KRCD6chBFEd/b0DpckiQ8nUiSBEmSYLvdQtd1nhY1TYOrqyvkeY6iKOB5HpvaDMPAdDpFHMcsdaBAYds2Tzccx8Hx8TFUVeXy167r+OZH13VkWYabmxsAwJtvvskWucVigTzPMQwDT5xWq9Wj4tWjoyMuOZUkidfzHpakyrKMrutQliWvDdKaXVmWbKGjNcP9fo+33noLruvi6uoKtm2zVIGKaNu2xW63Y8EC/Uw0xaG+osViwQWzJG3I85ynVZvNBrPZjD8uSRIURUHXdXxTRauEZNgjtbdYoRMIBAKBQPB14FXcEP0ZAL8F4GMA7wP4uXEcP5Ik6dcBvDOO419+hc/3p0IEoi8Pbdtiv9+zsW0YhkfTDFot2+12LBc4OzvDfD7HbrfjYKQoCsIw5MAzn8+hKArb1vI8R5ZlfF9TVRUkScJiscBkMoEsyzwt6vseiqJgMplgHEdst1vsdjsEQYC3336by1apPykMQ7a23d7eQlEUyLIM13V5vY6U25ZlYT6fI45jXjmjCVXTNBwMaeJTliXatoXrutB1HZvNBmEY4tmzZ3j+/Dn6vsdisWBJwnQ6haIo2G63AMDlrJIkwTAMvhEiW57jONjv9/B9n8tmSSSx3+/556S+onEcWWph2zaLJujmiCx7YoVOIBAIBALBV51XEYh+G8A/HMfxb0qSlAL4538QiH4FwG+M4/j0Mz6RXwXwXwBQAPx3n7bW/eBrfg3Ar+O+FPaf/qSwJQLRl48kSVBVFd+p6LrORaPjOLKhbbPZAABmsxnOzs6gaRpub29ZrT2ZTDhkWJaFMAxxOBzYOkdfp2kar795nsc9SDQtapqG39z7vo+qqnB7e4uu6/D06VPuBJpOpxiGAeM44ujoCF3X4ebmBkVRsCacNN9VVXFQWC6XGMcRRVGwfa/ve15Ra9sW0+mUV//yPH8kZmjbFu+//z6SJEEURTg6OuJ7JApoNG0jSQMAtv21bcuTt8Vige12C8uyYJomxnFEmqaPAs9yuUSSJKwLp7siWs+jFbxxHLnryDTNL+Yvk0AgEAgEAsEr4FUEogT3PUQffSoQXQL443Ecf+K7JUmSFADfA/CvALgC8E8A/FvjOH7nwde8DeB/BvDnx3GMJEk6Gsdx/eMeVwSiLyd932O320HXdS4JlWUZNzc33NmTZRmKokAURTBNE8fHxzg5OUGapnj58iXSNIWqqrxm1nUd39jc3NzwdGi32/GNDd0xzedznrCQnIFWzizL4jW6zWYDwzDwzjvvoK5rjOOIMAxR1zWvsW23WxwOB+i6zuHq9PQUZVnySpnv+/A8jz9W1zVPqCRJerRCl2UZsizj50KGvjfeeAO+7+PFixfwfR+u66KuawRBANd10fc9l7wStNZHfUXjOOLk5ASHwwGyLMNxHKiqijiO+QZqv9+zppzU6TTRC4IAkiRxkWvf949W6Oh3KRAIBAKBQPBV4scFos/67qYEMP0TPv5zAH5sYHnAvwDgw3EcPxrHsQHwGwD+9U99zV8D8F+N4xgBwE8KQ4IvL4qi4OjoCKqqckjoug7n5+d853J8fAzXdXFycoK+73F1dYU/+IM/gCRJeO+993B+fo5xHLHf7yFJEmRZxm63w2azwfHxMXfoPH36FL7vo65rXjdbr9d4/vw5DocDjo+PMZvNWPxQVRWSJIFlWTyZ+v3f/30cDgdeOyMDG62gnZ+fo+s6DiCffPIJqqpinXWWZdjtdpBlmScrrutClmW0bQvbtpFlGYZhYBFE3/esxV4sFri6usLLly/x7NkzVFWF9XoNwzCw3++x2+0wjiPOz8/Rti0X047jyKt4pDa/vr7mIJSmKU/bFEVBURSYz+fc9eQ4Dug/isiyzB/3fZ/143VdYxiGR4WvAoFAIBAIBF8XPuuE6L8BsATwbwDYAvgW7lfa/jcA/9c4jv/hZ3iMvwTgV8dx/Hd/8O9/BcCfHcfx33/wNf8r7qdIfw73a3W/Po7j//njHldMiL78PFR0q6rKYoIXL15AlmUURYGyLFmsQDa6s7Mz1HXN6m7bttkGB/xwKrNarbh8dL1eoyxLnkwNwwDXdXF2dsYTkSRJWEMNAIZhcP9R3/e4vLzkVTTLstg05/s+1us10jSF7/soyxJ1XePk5IQNbZqmwbZtvsFRFIWNe6ZpsphhOp0iSRLEcYy6ruG6LgzDYH33u+++izzPsd/vuWiVJBGO47DenEIevab0ucPhgDAMYRgG4jiG53kwDANd1yFNU5imibIsAQBhGLJEgix/VJbbNA3KsuS7KSqhNQzjC/m7JBAIBAKBQPB5eBUrcz6Av4/7IOQAuANwDOD/BvAXxnHMP8NjfJZA9H8AaAH8GoBzAP8QwD83juPhU4/11wH8dQB48uTJn3n+/PlP/BkEXzyk6LYsi0tCN5sNdrsdPM/DZrNBXdfI8xzjOKLrOlxeXvLU5vr6mpXatOpFXTtkoLNtG7vdjsONbduP7nEeWuVojYzunGiKFccxDMPA5eUlCxKm0ylkWYamaSyPoPCzXq+h6zrCMHwkYRjHEbqucy9RkiQA7m9/qqrCbDZDXdeI4xhpmrKam6x8NE27ubmB7/swDIODGa0RrtdrnvIoisJFr03TYLvdwrZtTKdTbDYbli3IsowkSXjqluc55vM5F9zSFEiWZQRBwHdIAPhnAiBW6AQCgUAgEHxleGU9RJIk/XkAv4z7Vbv/dxzHf/BT/Nlfwf3E51/9wb//RwAwjuN/8uBr/g6AfzyO49/9wb//FoC/MY7jP/nTHldMiL567HY7AOCD/XEc8dFHH8GyLJ4U0RvwoijgOA6ePn2KpmmwWq2w2Ww4oBRFAUVRYNs2PM9j4xsAbLdbDiFkaDMMA+fn5zxRORwObIajKYimaciyDHVdIwxD7vqhriTqJCJBwnQ6RdM02O128H2fTXe2bQO4DxHT6RRlWeJwOKAsS/i+jzzP4bouK8pJdEBGvDRN4XkeLi4ucHt7CwAcXFzXZVvder1myx3dNFHAW6/XkGUZy+USURRB0zSYpgld15HnOaqqgmVZiOMYvu/zih8Z6Pq+51ssKtwdhgGGYXCRrqqqr/Xvj0AgEAgEAsFPy6uYEP1VAP/TOI71pz6uA/g3x3H8Hz/DY6i4X4f7lwBc416q8JfHcfzDB1/zq3wNkpEAACAASURBVLgXLfzbkiTNAfx/uJc57P60xxWB6KtJ0zQsUxjHEZZl4fr6GnEcYzqdYrvd8ht2Kj5dLpfwPA9ZluHu7o7V1zRRoomGqqrI8/yROIHKSqnPh+6XaFpDAaxtWzRNwyWo1KO0XC65bJXsd23bsrRB0zT4vo/b21s0TYMwDDGZTHiNrixLBEEAwzCw2+14BXAYBrbfpWnKem6SG5RlCVmWcXFxwRO24+Nj1HUN0zThui5s20aSJCiKApZl8Q0TTYtIQb5cLlGWJU/OTNNE13U4HA4wTRNFUUDTNDb00X1U27Y8oaIVumEY2LJHtjuBQCAQCASCLyuvIhD1AE4+LTmQJGkGYD2O42dqb5Qk6S8A+M9xfx/034/j+LclSfpbAP6fcRz/nnT/n/b/MwC/CqAH8LfHcfyNH/eYIhB9taEJDU0ahmHABx98wGtxWZZxh06WZbAsC8fHxxiGAbvdDnEcIwgCtG3L8gZVVVkhTaFlu92ynMF1Xb7pWSwWHH72+z36vkff9yiKglXUbduycOHk5ITFDaZpslqb7pOm0yn6vsf19TUkScL5+Tksy4LrusiyDLIsY7FYIEkSvn2itTOaNKVpiiiKYNs2bNtGVVVo2xbL5RKmaWK1WmE6nfJkhqZFJIGgcEI3Q67rIo5jJEnCnU50B0VfS5M1+llc130kwxiGAZZl8UpflmUcQukujGx3AoFAIBAIBF82XkUgGgAcj+O4+dTHfwnAb43jGL6SZ/o5EIHoqw/d5NAKnWVZ+OSTT1AUBYIgQJIk2G636PueO4B834fv+xyYKFDlec4rXyQgIBtcVVW4u7tjqQB1HM1ms0ePR9KGoihQVRVs2+ZJFE1vaI2M7qFoApXnOTRNw2QywXa7xWq1wmKxwPHxMYIgQFVVyPMci8UC4zhis9mgLEuYpsnrafS9ad0tDEMuerVtG0dHR9jtdlAUhYMfhRVd17Hdbvk+iPqTSOiw3W4RBAF83+d/1nWdjXRVVUFVVTbQUefRMAw/UnJLK3QA+PmLFTqBQCAQCARfRj53IJIk6du4t8m9D+C7ALoHn1YAPAXw98dx/LVX93R/OkQg+vqQJAnyPIdpmjAMA1VV4eOPP4brupAkCfv9Hvv9ngtfFUWB4ziQZRlxHHMwIL1113WQJAnz+ZxvY2haRKWuYRjy95xOpxxU6J6HJAt0BzSOI6IogizLODk54RDSdR0/J0VR0DQNfN+HJEm4urpC0zS4vLzEcrlE3/c8AZpMJiyBIPPbdDrlf46iCEVRIAxD9H3//7P3ZqG65el537Pmb631rW+e9nT2OXVq0JE6biltSAh2dGGIceIYQyAk6CKSEATjixCUCBIIcgzCmDi5iZO72M5FhDCYxPZFgh0lRBBj30RIcnWr6tSpc/bZwzcPa57XPxe73rf3LvVQVb1r6Kr/D5qu2mcPa3+lFt9T7/v+Hr5fms1mHNgoRBmGwcEoDEOkaQrDMHhqBtzebZEEYjqdYr1ew3EcWJbFPUuHw4HlESROoBsrmqCRQCJNU2RZxmY6IQQMw2DxgkQikUgkEslXgZ8kEP3mR3/5m7hdZYvu/HEB4BWAf/BRr9CXggxEXy/quuYJh2VZaLVaePHiBcqyhOd5SJIEi8UCAPgNvK7rcByHDXWO46AsS74tyvOcZQd0E1OWJVarFReuGoaBqqrQ6/XQ7XYxGAw4ZJGRLk1TuK6LXq+HKIrg+z7a7TYmkwlc1+U+Ilo5q6oKhmHAMAzkeY6Liwt0Oh38zM/8DNrtNrbbLYqiYK32fD6HaZpI05TtcKQkX6/X926XmqbBcDiEaZrY7Xb3LHimacLzPA5zpMumFTrbtrHdblFVFY6Pj/lzbNtGq9VC0zQ4HA7cT0SFrtTDVFUVyrLkGyl6rQHw+tzdwliJRCKRSCSSL5uHWJn7jwD8zselCl8FZCD6ehKGIaIo4mlREARYLBYsRtjtdliv16yFptUt6vIhyxpNd6hcdDAYoN1uI89zVFWFNE2xXC55NY4mMP1+H7PZDLqu43A48N0N/TUJEna7HdvoptMpHMfB4XBAEARwXZfXzizLgqZpuLq6QhiGePLkCd555x3s93vs93t0Oh3Yto31+nYrlbqUut0uT6qurq5YwFBVFcsRer0eT5hoFZBComma8H2fwxmpu0k4EccxptMpT7ja7TYHGVqho4BD3Uy0aljXNVzXheM496ZqH1/VI/OdRCKRSCQSyZfFQwSiXwQAIcT/8wM+LoQQv/cQD/pZkIHo60vTNNhsNmyhE0Lg+vqa34jneY75fI6yLFmHfVcEoCgKut0uT3eEECxh6Pf7HJ6qqsJyuUQURVAUBaZp8vrd8fExPM+718OzWCw4jLTbbRRFgd1uB03TcHZ2huFwiKZpcHNzA0VRMBgMoKoqB4uyLHF5eQnDMPCd73wHrVYL19fXfJ9zOBxYCJFlGUajESzLQp7nWK/XyLIMg8GABQikA6cpjed5rOA2TZOtcUmSQNd1DosUJKnE1TRNHA4Hli1omoY8zzkE0uod3RJVVcWFsbS2F8cx8jznAEXhS67QSSQSiUQi+TJ5iED0/wH460KI/+1jH/93cdst9J0HedLPgAxEX3+SJMHhcOAVuv1+j/V6Ddu2oes6fN/HfD5Ht9uF4zjcIUTq6Xa7DQDY7XYAwGttw+GQJ0xJkiAMQyyXS7ankf1tOBzi6OgIiqIgCAJYlsWTHQoc9FxxHGM4HOLs7AztdhvX19cIgoBX8cqyhGmaXMgaBAGOj4/xsz/7s1iv14iiiJ/37s/yPI8NbyRcGA6HAMChw7ZtKIqCPM/heR4Mw+CARyt8ZIezLItX6Oi1abfb6PV690pcDcNA0zTY7/eoqooFDE3TQFEUDlVVVfGtVlEUHM5oBU+u0EkkEolEIvkyeYhAFAP4lhDi5cc+/gTAHwkh2g/ypJ8BGYi+OazXa7afFUWB9XrNPT5CCFxcXKAsSxwfH7O4oGkaALdTE8uycDgckOc5yrJEFEVwXReDwQCdTge+76MoCiwWC77Tof99OI7D0yKaNgHAzc0NyrLkklQhBDabDQzDwOnpKcbjMfI8x/X1NQBgOp1yUKvrmjXbRVHgF37hF2BZFhaLBWzbhqqqPLHZ7/dQFIUNb0IIXF5eskShLEsYhsGWPvrd6PtQea2u63yXRAGT1g3plujo6AibzQamafLaHXC7xhiGIZe70mtLd0UkqaAQFYYh//NRVZXFCxQ0JRKJRCKRSL4oHiIQbQD8JSHEP/vYx/8MgH8ktduSL4o0TbHb7XhSQVMWx3GgKAp838fNzQ1GoxE8z8Nut2O5gmVZrLA+HA4sS2iaBr1eD8PhkG+GoijCZrNhXTeFmOl0ym/66edSiSyFEQDIsgxBEGA4HOLJkyewLAtXV1csZhiPxyjLEqqqIggC6LqO7XaL8XiMp0+fYrPZAADfT5HUgO58qBSVSlfp1ogECHd7m2zb5lBCf1aWJcIw5CkQrdBFUYSiKHB8fIw4jnk9sdVqAQDyPGflN/2udV2zlY7CoeM4AG5DFNn9aCJlWRY/v0QikUgkEskXwUMEov8FwCPchqL9Rx8bAPiHAK6EEP/hAz7vp0IGom8mm80GWZZxz9B+v4cQArquwzAMPH/+HE3T4Pz8HHVdY7VaIY5jWJaFXq+HVqvF06I4jhFFEUzTxHg8xmQy4T+7urqCYRgoioL7jdrtNmazGTqdDssFqqri3iDLsnhNzPd9GIaB2WyG2WyGKIqwXq9RliXOzs7YynY4HPi+qCxLLnRNkgS2bSMMQ/79KOiYpglFUdhCR6a5uq5ZRlEUBYcRusOiyQ+JEOhGiyY7WZYhiiIuwKXX2bIs/v673Y7V4gBQFAV3HdFqXbfbBXAbDmmqRpIJXde5FFYikUgkEonk8+YhAtERgN8DMAHwhx99+E8BWAH4RSHEzQM966dGBqJvLlmWYbPZcAChN/KapvFNz+vXr3F6esrTot1uh7Is0e12MZlMEMcxwjBEnue8Yud5HiaTCRzHwX6/5wmQYRiI4xhN08AwDIxGI/T7fb5b0jSNu5QorKiqijRNEccx+v0+Tk5OYBgGf0/P8zAajXjiRKtueZ5D0zSeJLVaLeR5jqIoWDcOfL8Q1TAMXF5ewnVdvh2i0EN3PY7jsB6cOotUVUWe54iiiPuI6LUNggCDwQC2bbMJj2QLwO2NUxiG/DPzPIdhGBBC8MrhaDSCoiioqopDHU2bAPDdk0QikUgkEsnnyU8ciD76Jg6AXwLw8x996PcB/LYQInmQp/yMyEAkoWkRTSjiOObJSKvVwh//8R9DVVU8efIEWZaxUc40TUwmE54WFUUB3/d5/Y0CDKm5N5sNHMfhzyMr3HA4RL/f52lRnudIkoQnIQBQliXyPIeiKJhMJhiPx4iiiA1u7XYbo9EIRVFgtVrBMAw4joMsy3h6Q1KCw+GAdruNNE0BfD8UWZaFzWaDoihYzECrhKqqIo5j1ntrmsZ6bAoxpO6mj6VpijAM4TgOBoMBttstHMdBq9XilTdaYbQsi1+buza9oigwGo145TAMw3tyBnpuep0kEolEIpFIPg8eJBB9VZGBSAKAgwQZ0EjBTUru6+trLBYLtr/tdjtsNhvkeY7xeIx+v8+rXXEcs1WNile73S42mw3m8znfI9HaGHUBDQYDnhYJIZBlGQsL7koUSDRwcnICVVURRRH3+1Ap7M3NDfI8R7/fh6ZpSJKExQi9Xg/z+ZxvchRFuXeTQ7py13VZvW1ZFhRFQRzHaLVavAJHz0KhZLfbQVEUDj1VVXF57XQ65fstWskDgKqqsNlsUNc1689pqlUUBfI8R7fb5ZsjUnPTHRIJIaSaWyKRSCQSyefFQ02I/gKAvwrgDQB/XghxqSjKrwF4KYT43Qd72k+JDESSu9AqGnXgFEWBJEn4Dfe7776LdruNx48fIwgCrFYr+L6PVquF6XTKkxFapaNJULfbxaNHjwAAL1++ZKFC0zQcxCgUDYdDZFmGLMtQFAXf3RRFwetk9L+7breLXq+HLMuQ5zmXnz59+pRX/FzXRb/fR5qmHIxOT085tNG6Gt0IkYZ7Pp/fm/i0Wi0IIfiZPM9jWxwZ6lqtFuI4vjeZIttdVVV/QrZAQQsADocDfN/HYDDg2yYyAtKqX6/XA3AbYKMoAgC25NFET67QSSQSiUQieWh+VCD6RP5bRVF+CcDfB/AcwBMA9K+jNQC/8RAPKZE8BKPRCEdHR8jznKcfpKr2fR/f+c53oGkavvvd70LXdTx58oQnNa9evcJ2u0Wr1cJwOMR0OsV4PIaqqthsNnj+/Dk2mw3eeecdnJ6e8locff18Psd8PsfLly95WkKBw7ZtdDodDh6kzo6iCJeXlwDAJa+tVgsvXrxA0zR4/Pgx8jzHarXiFT9d1/Hee+/BMAx0Oh3keQ7TNJGmKYehLMtwdHSEpmmQJAkHLpoYAbfdQ0mSQFGUe6t+JJ4gHXhVVRgMBrAsC69fv+YJke/7yLKM9du9Xg+j0eje5IwCHAW99XoNAPzPhaZWdJeUJAlP1SQSiUQikUi+CD6pVOEPAPwNIcTvKIoSAvi2EOJDRVG+DeCfCCGmn/eD/jDkhEjyw9hsNjgcDjx1aJoG2+0W3W4XWZbhww8/5OATBAEOhwO22y1M08RsNuMblyiKEAQBgiAAcBtcTk9POZhQiFFVFTc3N1BVladF0+kUYRgiTVMoisI9RkEQoK5rlGXJNrh2u41+v48kSaCqKhzHQRiGOD8/x3q9RpZl6Ha7fK80n8+haRrOz8/ZFldVFU9asiyDoij3FNu2bcNxHKiqiqZpEEURer0edxQBYHW3ZVl8z9RqtVjlvd/vMRwO4boudrsdOp0OWq0Wh5qyLLFcLmGaJjzPQ5ZlAABd15HnOaqqwmQy4T6iIAj4dTBNk8trpZpbIpFIJBLJQ/EQlrkEwDMhxMXHAtFTAP9SCGE/7CN/cmQgkvwoiqLA9fU1mqbhN+2+7yPPc0wmE3zve98DAMxmM6iqiv1+z6Y4WmejGx4KA7QK1m638ezZM7z33ntYr9cceNbrNcIwRKfTged5ODk54Z6huq4xGNzWdvm+jyiKUFUVVFXlANbr9WBZFrIsQ7/fZ7FBq9VigQFNbLbbLTabDY6Pj2FZFgevPM/hui6HJMMwsF6v+VbI8zwOH/T9e70eq7d1Xee1OjLzUUkracw7nQ5GoxHLJu7KFoQQWC6XKMsSo9EIVVXxWh/Z8kh/DoDLYnVdZzmDVHNLJBKJRCJ5KB4iEH0A4K8IIf7pxwLRrwD4dSHEtx72kT85MhBJPgmr1Qq73Q7tdptvetbrNcbjMdbrNTabDcsTaBq03W6h6zoGgwHfudDa1263g67raLfbODs7g6ZpeP78OcqyZJX0YrHg3iJav6MiWc/z0Ol0kGUZVqsVW/EA8NrbZDJBkiRsjMuyDJ7n8Zpbt9vl57q4uODJVlVVfLNEt1NZlrEIgixwvV4Ptm2jqiokSYKmafiOiv7/gqZp3B203+/heR4XvC4WCxiGgePj4x8oWwBuQ99+v8doNOLfgUQKeZ7DcRx4ngfgdrJEQop2u42qqgBINbdEIpFIJJKfnIcIRL8B4FcA/BqA/wPAXwTwGMDfAvDXhBD/w4M97adEBiLJJyXPc7x+/RqqqsK2bei6jvV6DSEEPM/D+++/zwID4PsTnDRNYds2G9/KskQcx1gul0jTFJZlodvt4q233sJ7770H3/fvTVeol6jb7eLs7IxX91RVxdHREVRVxWq1wnq95smMpmk8ITJNk9fgqN+HAsJdjfZqtUIYhrBtm8MUAJYmCCGgaRqiKEIURTAMA/1+H+12mwNKmqY4OjriUKMoChRF4XU2mjKRmY4032dnZ3xT1W6373UN5XmOxWKBTqfDt06mad4TPAyHQwDgWy+SNlCHkVRzSyQSiUQi+Ul4KMvcbwH4TwHQO50cwN8SQvxXD/KUnxEZiCSfluvraxwOB3S7XWiahrqusdlsMBgMcHV1hTzPMRwOuQyVCkirqoLneej3+xxM5vM5fN9nVfXZ2RmEEHj9+jXKsmRRwuFw4OnR8fExhsMhhwnqMSLBAq2WVVXF62sU0uj+h9bOqP+H1tmCIGD73HQ6haqqqKqKC1opTKmqymt+1IFEZrgwDOF5HtviAEBVVZ5K0Qqd67owTRNhGCIIApycnAAAoijiuyL6+rqucXNzA9M02TwHgANS0zSYTCb8+VEUcbcU3VhJNbdEIpFIJJLPyoP1EH1UzvqzuLXTfVcIET3MI352ZCCSfBaSJMGrV684UNCNjaIoEELg5uaGb1wUReGpClnTSAqgqip838diseCy18FggNPTU1xcXCAMQ1iWBVVVORgpioLRaISTkxNkWQbf9+E4Do6OjqBpGi4uLrBcLuF5Huq65v/0ej3uFhJCwHEc7HY7CCHQ6/XQ6XQ4AO33e+R5zjpwkivQuiBwG67W6zULDWhdju6lDMPgkAOAxRS9Xo/FEO12G5qmoWkaLJdLTCYTtNttlldYlsWrgEII7n7q9/u81kd3RVmWYTwe8x1SlmWIoohXE/M8h6qqUs0tkUgkEonkU/MQK3N/B8B/IoQIP/ZxF8B/L4T41Qd50s+ADESSzwpNcpIkged5MAwDRVGwOe3y8hKapnF3DgAWI9AUZTQacfC4uLiA7/tomgbtdhuz2QxCCMznc74LEkLw1Mm2bZyensJ1XazXa2iahvF4zOrq58+f8+Qpz3PUdQ3DMLgAlv4+z3PEccw/s65rqKqK3W7H2m3XddHtdpHnOQcbKkyNoojX/E5OTliXnSQJyrLE+fk5r87R60brbPv9nmUVuq5juVzCcRxMp1Os12u0221YlnXPGEd3RYPBgKddVDJLd1Ku6wK4nSz5vg8hBDqdDk/NbNtmS51EIpFIJBLJj+MhAlEN4EgIsfrYx0cAFkKIL225XwYiyU+K7/u4urpCu92GaZp8W0S2tjAMecqiqiriOEaapkjTFFmW4fj4mO+S1us1VqsV4jiGYRjodrsYjUZYrVYsQ6AboSAIeD3v+PgYQRCgKAp0u1223r18+RLb7ZYLUOM4RtM06Ha7mE6nLFCgqUxd13j8+DEHDFo9q6qKV/7oPoh6kGjqtFwuUdc1hsMhZrMZyrJk495sNkO73WbZAv0OpN4WQvBdFq0Hnp+fY7vdwjAMXq8j6K6I1hapmBW4nQyZpslrgnRXRPdJNG37eNCSSCQSiUQi+WF85kCkKMoAgAJgDeDZR/9NaAD+HQC/JYQ4+QFf/oUgA5HkISjLEq9evWLDGa2e7XY7GIaB1Wp1TxYghMB2u4WiKDgcDnAch8UAAHBzc4PD4QAhBEzT5BudzWZzTxRQFAX2+z1M08T5+TkA8PSJwtR6vcbl5SXf/xRFwVOV8XiMTqeDNE1hGAZPVAaDAc7Pz/n2yfd9aJqGqqpQFAWHKQAsX+j3+1iv14iiCLZt4+nTpwC+L5dot9s4OjriFT5a3ev1erxmR+GKVgHPz8/ZYOe67j3ZQtM0uLm5gWEYsG0bTdPwzRR1F00mE/58CqKWZfGanVRzSyQSiUQi+ST8JIGoAfCjRkgCwG8KIX7rJ3vEz44MRJKHQgiB1WqF7XYL13X5zfZqtYIQglfIOp0OgNuiUSoVJRnB8fExWq0W9w7N53NkWcbWucFgwKGIendM00QURYjjGP1+H5PJBIfDAZZlodPpYDqdoq5rvHr1CmEY8uoaBY1er4ejoyPu+qGJS1mWeOeddwDchgnqPLJtG5vNBt1uF47jALjta8qyDL1eD1mWYbPZAADeeustWJaFOI5xOBygaRoeP36Muq7vCRM8z0PTNBwOVVWFEAK73Q6TyQSapiFNUw6Vd9fv1us1W+Xu9iZRiet4PGbDHE3s6K6I5AxSzS2RSCQSieRH8ZMEol/E7YTo/wLw7wHY3fnjAsCFEOLmAZ/1UyMDkeShieMYNzc3fMCv6zqqqsJqtYJpmtxnRIEpTVPEccwBgCY3hmGgLEvc3Nxgv9+z/pqKSuM4hqqqSNOUO4niOEZZljg7O2OT3WAw4InRYrHAfr/nn1dVFcqyhGmaODo64h4lMtqFYYjRaISjoyOe9BRFAcdxkKYpCw7oWeM4RqvVgmmaWK1WyLIMp6enOD4+RhiGLGt4/Pjxvb4iIQQsy4JlWfB9HwB4zY9er263C9/3eW2PVuSA2ykUTcYI+t5JkqDf78O2b/uff9BdUV3XrB+XSCQSiUQi+TgPcUN0DuC1+DRKui8IGYgknwdlWWK5XPI9i67raLVamM/nKMsSRVHw7Y6maVAUBWEYomkaFEWB7XaL8XjMQobdbscBg26AXNfldbkoilhOUBQFdxcNh0OeHNm2jdFohDRNsdls2HqnqiqyLIMQAv1+HycnJ6jrGvv9HoZhQNd1NE2DR48eQVEUbLdbZFkGTdNgWRYOhwN0XUen07l3p9TpdBCGIXzfh+u6ePvtt1FVFbbbLeI4xnQ6Ra/X41U34HZq5rouSxloWhQEARRFwXQ65YBEN0cE/V4UisiIR6HRcRyezgG3IYr037qu8xqhvCuSSCQSiUTycR6qh+hfAfAfA3gK4FeFEHNFUf4ybqdEv/9gT/spkYFI8nnRNA12ux2/mac3+1EUYbvdQtd1nnhQuEiSBGmaoq5r7HY7aJqG2WyGVquFOI65PJUCydnZGdbrNUzT5LBEPT1N0yAIAgyHQ9Zse57Ha2dBECAIAmy3W5RlCSEE6rpmhfZgMMB2u0UURRiPx8jzHKPRCO12G4fDAVEUQVEU/p3KsoTjOGi1WkjTlNcDaR2wLEt861vfgq7r2O/3OBwO8DwPp6enKMuSXzcquhVCsIWOQltRFJjNZqwjt237nmyhqiosFgue9tztTkqShCdsRBzHSJIEtm3Dtm2kaQpN03iaJJFIJBKJRAI8zITo3wLwjwD87wD+bQDPhBAfKory6wD+rBDiLz/kA38aZCCSfJ6QiY3MabRG12q1cHl5ybdFmqah1WrBtm3EcYy6rtnyFgQBm+OoI2ixWKCua2RZhuFwyLIEwzB4WnT3VqiqKnS7XQDAYDBgQUFZlsiyDOv1miUOQghomoZOp8PTouvra3ieh1arBdd14TgOyxaA2/W2uq5RliXb6IQQrPOu65pfg9PTU0ynU/i+j91uB0VR8PjxY369ALAa27Is7Pd76LrOq4dxHGM8HnOIcl33nhiBbrkURYFhGKz8JmW5EIJ7oIDb+yff92GaJvcVkfVOqrklEolEIpEADxOI/gWA/1kI8T8qihIC+PZHgeg7AP6xEOL4YR/5kyMDkeSLIM9z7HY7lGXJa1ydTgeHwwGbzYbX3u5qrenO526nz/HxMVzXhe/72Gw2SJIEWZahrmscHx9jv9+j3W4jim47jy3LghACqqpiuVzCNE3uFOp2uzAMg9/0B0GA+XyONE2hKAp3A81mM/T7fVxdXSHPc5ycnEDTNDiOAyEE30A5jsOrb0VRsEo8DENe59vv9yjLEr1eD0+ePEGapryCR7pvEi7QtIomTnmeo9VqcSjq9Xqs0KawdleMcDgceGURuF3Ho6BZliVGoxH/GU3zFEVBp9NB0zRs8ru7lieRSCQSieSbyUMEohjAzwkhXn0sED0B8D0hROvHfIvPDRmIJF8UNFGhAEOdQaqq4urqCoqiIIoiGIbBhaRhGPJkI45jngJRz89ut8PhcEBd1wiCAJPJhMtTaWpk2zavzNGKXK/XQ7vdRqfT4QlOq9VCXde4vLzkUlaasriui7OzM6RpisvLS75vcl0XTdOgLEtEUQTLslCWJd/hZFnGhbU0dVoul6iqCrqu4+2332a73OFwwGw2uzf9qaqKwxdwG9ruBkaaDiVJgk6nw+t1RBRFCMMQtm2zIY9kE1mW8S0W4fs+ByxN05DnOUzTvLeWca/bkAAAIABJREFUJ5FIJBKJ5JvHjwpEn3SfZAfgB3UN/asArj7rg0kkP03ouo7BYMAiBZqeJEmCR48e8Zt7VVWx2+2QJAmvtlmWhdFohFarBSEEXr9+jSzL8OjRI74xmkwm2O12rOmu6xqGYbBFjaYlb7/9NsIwxNXVFfb7PXa7W/kjfd1bb72FN998kwMShYcPPvgARVHg2bNn8H2f7Xd0/+Q4DvI85w6mPM9ZhU3/Wa1WmEwmvJr27rvv8rRmPB5jtVrh9evXHGo0TUNd13xXNRgMeC2PTHf0Ovm+jzRNuR8JANrtNgaDASvK4ziGrutQVZWNdofDgT+fAhKV3jqOg6IokCQJPsm//JFIJBKJRPLN45NOiP4mgD8L4N8H8F0AfxrAEYC/B+DvCiH++uf4jD8SOSGSfBmkaQrf93nli6ZFRVFgPp9D13UcDge02214ngdVVRHHMTRNQxAErNyuqgonJycoyxLr9ZrXyajkFACvzNEKGgD0ej34vo/r62t0u12Mx2O+YVJVlYPMBx98gO12ywEEAN8Wbbdb7HY7jMdjzGYzGIbBBauKosA0TdZwG4bB9rmiKNDv96FpGpbLJZqmwWw2w9HREcsWFEXB+fk5r7k1TcNqbgospAunENbtdhFFERzHgW3b92xxTdNgvV5z+SzdJNENFckWaOWuKArsdju0Wi10Oh3keS7V3BKJRCKRfIN5iJU5A7fh5z/AbS9R89F//zaAXxZC1A/2tJ8SGYgkXxZlWeJwOPDdTRiGcBwHhmFgs9kgz3PWYY/HY9R1zeICANjv97wWRxOi5XLJgWS1WvEkhKQChmGgaRoOBN1uF++//z6KosDZ2Rnb1hRF4XumzWaDDz/8kMMN3QPRNOXm5ga2bWM8HmMwGCDPc/69ut0uttstF8uWZYkkSbjLiLqRqNT17bff5qlNnuc8OaPfvaoqvoOq6xphGMI0TV6D6/f7iKKIP+fjsgWahtHEiqZaRVHw60w3Q3fvinq9Hq85SjW3RCKRSCTfPB5Eu/3RN3oK4Bdwu2r3+0KI5w/ziJ8dGYgkXyZ0+3PXEEfq7DiO4fs+f850OuU34iQ+oJsky7IQRRGm0ymapuEwRKtfqqrCNE3Udc3BiN749/t9BEGAly9fYjAYYDKZwDRNvh0iWcLz58+xXC5Zta1pGgzDwHQ6xXK5hBAC3W4Xjx8/5i6kMAzR6/VQFAWCIEC/3+deIN/3YRgGxuMxfN9HEAQwTRPPnj1DXddYrVZIkgTj8RiTyQR1ffvvTYqi4Lse0zTZdEcihOFwiDRNedL1cdkC3QkZhsF3RHmeI89zXt9rtVr3Pj/Pc3S7XWiaxhOlu2FLIpFIJBLJ15sHC0RfRWQgknzZkJ46iiIuQQ3DkIUF1Dvk+z4cx8FoNOKJRp7naJoG2+0Wtm0jSRIuZF2v18iyjIUHTdNAVVVomsZqbdJSk3L6/fffvzeZoUkRraAtFgtcXFxw0SndNJGYoaoqGIaBk5MTeJ7HynG6g9putzAMg01uu90ORVFgOBwCALbbLeq6xpMnTzAcDjGfz/m1OD09BQCWOJimyc9Hr5FhGEjTFMPhEGVZoixLdLtdnnoRaZoiCAI4jnNvvbAoCuR5jk6nwwWvAHgV0HVd7itSFOVPfF+JRCKRSCRfTz5TIFIU5e980h8ghPjVz/hsPzEyEEm+KmRZhiiKIISArusIggAAuHSV1N1pmuLtt9/mEtE0TSGEgO/7aJoGpmkiDEN0u13ous7TIlpDI3OcEAKKotxTS3e7Xex2OywWC7iuy/dJnufB8zx+lpcvX2K1WrEBjhTcpM2mdblHjx4hjmMEQcAdTFQ+2+v1ANyGkPV6zdOjKIq4BPatt97Ccrnku6I33niDA11ZllAUhSdBdV3D931YloUsy9But3mCNBgMeNWPoJVFeiaaONFKn23b6Pf7P/CuqNvtsi1Q3hVJJBKJRPL157MGon/8sQ/9m7i9Hfqjj/7+W7hdnfs9IcRfeqBn/dTIQCT5KlFVFYIg4DufsizZjEa2uDAMsd1uMZ1O0W63eVqUZRmqquJbJOoi6nQ6CMMQVVWhKAqEYch3SKZpsnSB5Ad0W3NxcYGyLDGdTjnwTKdTWJaFpmmw2Wzw8uXLe3c9wK0ZrmkaNuadnJzAsiys12sOL1SGSj1DdPOkaRra7TbCMGRL3rNnz5DnOVarFdI0xcnJCfr9Pk+kKARalsVdR5qmcajp9XpYrVbo9/v8OxJ1XWO/37OcoWkadDodpGmKNE1hmiYGgwEHHprGAbcFt/KuSCKRSCSSbwYPIVX4L3B7O/QrQoj4o4+5AP4nAH8khPitB3zeT4UMRJKvGk3TIAgCLnBVFIVDEk2P4jjGfD6HYRh4+vQp3+OQnjoMQ56eJElyrxhVURQue6XVObLQua4L13W5BDWOY2w2G1iWhclkwjc61J+Upik+/PBDnma1223oug5FUXj1rGkaeJ6HyWQC3/dRVRU6nQ6SJOEQ4jgOPyvdHVEoAoAnT56g2+3yCl2v18Pp6SmHRAo/FLgOhwOHPlVVMZlMsFqt4LouT44Imq7RaxEEAYedIAigaRoGg8G9ryHFN4Ul0nrfvT2SSCQSiUTy9eEhAtEcwJ8TQnz3Yx//OQC/K4SYPciTfgZkIJJ8VYnjmOUANPGI45gNaYZh4OrqCmEY4s0330RVVWyTi+OY+3vILJemKSzLumdVo/U0msbQJGQ0GrG57a7qezAY8Bv/2WzGk5XlconVasVFpnR/lKYpWq0WSxiGwyHfIh0fH6MoCu4Bop9Pq2+e5yFJEmRZBk3TMJlMcHx8jO12y8HunXfegRCCQxF1DHmex9+bVNuz2QyHwwGapsHzvD8RXui1sG0bu92OQx9JG3q9HqvHge+r0zudDt9vAYDjOPKuSCKRSCSSrxkPUczaBnD8Az5+BMD5AR+XSL7xuK7LExbqzun3+zypSJIEb7zxBo6Pj/H8+XNkWQbbtiGEQK/X4yCiqiqEELBtG03TQFEUdDodKIqCbreLbrfLJax0j7RYLHhiVBQFXNfFaDRCkiTY7/coigKvXr3CdrtFq9XC8fExnj59il6vh7Is+XNs20ZZlthut7z2tt1ucXZ2hsVigaZpcHx8DMuyWGgghODuH9d14Xkeh66XL1+i3+9jPB7DMAz8wR/8AZIkga7rME0TTdPwhI1CVFVV0DQN19fXXIq72Wz4dyXa7Tba7TaSJMFwOOSA1Ov1YBgGttstT5IAwLZtDIdDBEHAggaa3t0th5VIJBKJRPL15pNOiP4egD8H4D8H8M8/+vC/DuBvAvi/hRC//Dk9349FTogkX3VodYu4Oy1KkoRtaO+99x40TcObb76JKIp4MkSihqqqUJYlr6ZpmsbTIUVREEURW+mou0jTNJyent5TVauqiu12C8dxYJombNvmaVGaprzWRiWpuq7zjRPd8SiKgvF4zKt90+kUeZ5jPp/zXRTwfcU2lbiS8vvp06domga+72O73WIymeDk5IR/RyqhNQwDjuNgvV7za0D9ScvlEqPRiNf1iLIsEQQByxZo5Y/unjzPQ6/X46+heypVVdHv99E0DU/K7q7ZSSQSiUQi+enlIVbmbAD/LYBfBUCXxxVub4j+MyFE8kDP+qmRgUjy0wCttxVFwWtttMoWRRFUVcVwOMQHH3yA/X6Px48f8zpbq9VCEAQchtI0BXAbtPI8524dVVVRVdW9NTrbtlFVFcbjMWzbxmaz4QlOGIbI85xDz2AwwHA4RNM0WC6XSNMU2+0WTdOg3W5zIAFuhQSkraYg1e/30e128fr1awCAoih8I6TrOlzXxWq14mnM06dP4TgOfN/Hfr+Hrut4+vQp30NRP5Ou6/A8D77vI45jFkiQ1rvb7fLtE0F3WPRaB0GAbrcLIQSb6fr9/r2v+UF3RZqmwbbtL+T/RiQSiUQikXx+PGQxqwvg6Ud/+4IEC18mMhBJfppI0xRxHMM0TVRVxTdB+/0eSZLg6OgIvu/j+fPnLB6glbKyLBGGIQelOI7hOA4OhwOHCPrvKIqQpimHKLobevToERaLBeI4RqfTQavVwmaz4XBj2zZPXXzf5x6iw+EAz/P4+9d1Dcdx+GNUREs9S1mWYblc8sfpPmo8HmO/32O326FpGjx69AgnJyfYbrc8MXv69Cls2753V3Q3mGw2GxZJzGYzrFYrVmnfNcVRB5QQAqZpYrfbsXp8u91yCL1b0JokCQ6HA3q9HmzbRpZlEEKg1Wrdm0JJJBKJRCL56UIWs0okXyFopYtW4ki6sN/vsd1u0ev14Hke3n33XaRpiqdPn0JRFP5c6vTRNA2+70PTNJ420b0NTXOiKGJdNwWL6XQKwzBwc3MDy7IwGAwQRRGiKOI3/p1OB6PRCE3TcP/Rer1G0zRssSODnud50HWdS2INw+CpzevXr1lQQEKJ8XiMsiyxWq0QxzH6/T6ePXuGNE1ZSX58fIzxeIymaVAUBZfP0orfYrHgW6Dj42PWktNKH0GCiqIo4DgOdrsdLMuC4zgIggBZlmE0GrFynP75bDYbOI6DTqeDoihQliVarda9iZJEIpFIJJKfHmQgkki+Yty9KyIzG3UPrVYrVFWFx48f4+LiAtfX15hOp+j3+/duiMqy5HW1KIrQbrcRxzGv4AG3yuosy3hKQzc9vV4P4/EYi8UCaZpiNpvxbRE9k+M46PV66HQ62O12LFug+xwy2GmaBsMw0Gq1+HbJMAxYloXhcIgwDDm4hWHIIYSmU77vQ1EUPHv2DLZtIwxDLJdLtNttnJ2dQdM0NuaRfKHdbmO73bLFj8JTHMccxu6SZRmSJIFt24jjmIMd3RX1+32edgG3QWq1WkHXdfR6PXlXJJFIJBLJTzkyEEkkX0FoepGmKRzHYatbVVXY7XbYbrc4OTlBWZZ4//33WZCgKAqvrYVhyHc26/Wa1deHw4GV2fT5NEEiZXev18NwOERZlri5uUGn08F0OuVbHQo7rutiPB6zxS6KIux2Ow5XVVXxjREFBlVVWXbQ7Xa5O4nW/oIg4G6j3W6HOI4RxzGm0ylOT0/RNA3m8zmqqsKbb74JVVXZQEdiCJpU7XY7aJqGTqcD13Wx3+/hui7/XIJEFqZp8lohWevW6zXa7TZ6vd69KdDhcECWZRgOh9A0jWUW9LpKJBKJRCL56UAGIonkK0xRFAiCAJZl8VqcZVk4HA64ubmBbduYTqd4/vw59vs9ZrMZ67xpKkJ3QnEcc9goyxLL5RKO40AIwUIGKlQlEQL188zncwghcHJywqtydzuTer0eut0uqqqC7/us8FYUBWVZwvO8exMjTdNYpmCaJk+VaFrj+z5ru4ui4EmSbdt49OgROp0OttstNpsNHj9+DNd1Udc1qqri4EU/Y7Va8R3UYDDAfr+HZVnodrv3Ak5VVdw3pOs6CxYcx+GJ0Gg0ujcForsiWsfLsgxN03CRrEQikUgkkq8+MhBJJF9xqqpCEAR8T1TXNTzPQxiGWK/XiKII5+fn2G63uLq6gmEYODo6gmEY/CafbG7ArXjAMAy+t8nznCdJRVGwcCGKIiiKguPjY5Y17HY7jEYj7g9K0xRZlrGYgdbLaJK03W5RVRWapoFlWRxcKKzQTRIptKlE1vd9LoOdTCYwDAN5niMIAjRNg263i8lkAtM08eLFC/T7fRwfH3MookkNAF6hi+OYNeL7/R6GYaDdbt+7K6IQWdc1G/wURUG73WY9OVn5iLIseYpEYbMoClaDSyQSiUQi+WrzENrtXwSQCSH+xUd//8sAfg3AuwB+XQgRPdzjfjpkIJJ8XaBCUpo+0CodAOx2OywWCwwGA7RaLbx+/RpBEGAymbBOOk1T1npbloX9fs83NVmW4fr6mhXbmqYhjmNeYcuyDOPxGJ1OB8BtoLIsC0dHR9wLdFfaQOtuiqJgt9shSRJsNhtUVQXDMNDpdNhIZxgGq76p+4iKZquqws3NDXa7HdrtNvr9PrIsQ1VVSNMUpmmi3+/j6OgIFxcXaJoGjx8/BgAWRdA0iu6DfN+HaZqYTqdIkoQnR3fvioQQvMLXarX4xspxHJRlCd/3MRqN0G63eTVOCIH1eg1N07ivKMsyvpeSSCQSiUTy1eUhAtHvA/hrQoh/qCjKOwD+ELcdRH8GwP8rhPgrD/nAnwYZiCRfN5IkYQEAla7SbQwJF+jW5/LyklfqTNNEHMfI85wnM3VdY7VasVnt8vISVVVB13XWStMb+91uh1arhel0ClVVOQCRAEFRFL7/URQFrVYLg8EAs9kMm82GV+ho6uR5HizLQlmWUBSFJ0ye56HVavFEq9PpYLFYYLFYoK5rvlcCwAW1hmHg5OQEaZpis9ng7OwMrVYLeZ5zIKJpTVVV2O/3rNUWQqCua5imiU6nc+/2hyZluq7zpI1scsvlkruVqM8IAFv3hsMhCy5UVYVt2/KuSCKRSCSSrygPEYhCAN8WQnyoKMp/CeDfEEL8RUVR/jUA/0AIcfqwj/zJkYFI8nWEbmpIUEDigjRNWbhAwYHKTmezGXq9HvI8RxRF0HWd19g2mw3SNMVoNILv+1y4SjdBZVmiqiqe8kynUziOgziOkWUZXNdFp9OBruuwLAs3NzeoqoonP0+ePGELXRRFWK/XSNOUjW9N0wAA2/Qcx+GfLYRAv99HXdd4+fIlgiBAr9fjrqGyLPl1IfPdfD7HcDjEcDhEmqZ859RqtaBpGncNlWV57/aHVvrurrkVRYE8zwHcWvnotbNtG+v1mm15d7+GbrUGgwEsy0Kapmiahn++RCKRSCSSrxYPEYh8AH9aCPFcUZTfBfC/CiH+tqIo5wD+WAjxpVW5y0Ak+bpy967INE1e79I0DZvNBrvdjm1uRVHg5cuX9+5uyL5GYSHPc6xWK7Tbbei6zgWtjuOg1WohiiKYpon9fg/f9+G6LgaDAd/c6LoOz/PgOA5c14Xv+9jtdrxGd3Z2hvF4zBY6Cm6u66LdbrPdLc9z2LbNZaoUvCgo3dzc8GoaTaao84ikE8PhEIfDgVfjaMpFgYfKVMMwRBiG3O1EkzfLsu7dFdFNEKm96SaLfk+aXN39mqqqsFqt4Hke2u22vCuSSCQSieQrzEMEov8TwA2Af4rbVblnQogXH90W/V0hxBsP+cCfBhmIJF9nhBAIw5CLRWmFznEc+L6Pw+GAMAzR6XSgaRpubm4QxzFOTk7Q6/Xg+z6vlQkhoCgKNpsN6rpGp9NBEAQ8Ler1elyCWtc15vM5CxFM00SWZWzAo9JSXdfx+vVr5HmOqqowHA5xfn7Ot0VhGOLm5gZ1XaPf78M0zXva8G63C9M0edIDAIPBAGEYYrFY8M+kWyHbtpHnOYQQbM8TQmA2m7Ha+67q2zAM1HWN7XYL27YxGo1YvKDrOhzH4TU30ooDtz1MeZ5zeKMy3R90V0R2un6/z7dc8q5IIpFIJJKvFg8RiL4F4LcBnAP474QQ//VHH//bAPpCiF96wOf9VMhAJPkmkKYp4jhGq9XiFTqaDO33ezaq0WrYxcUFW9kURcFyueSbJMuyEIYhDocDPM9DVVUIwxC73Y6lB0VRoNPp4ObmBlEUwXVdDmQkTrBtG91uF91uF+v1GpvNBnmeQ9M0PHnyhKdFm80Gy+WSV+FIFEEacLLAUcCiVTtVVbFer7mriW6Q7tryDMPg0HR6egrDMBCGIYQQaLfbbIpTVZXvikajEbIsY2224zi85tY0Da+/UfdRkiQwDAO6rmO73aLb7aLX691Tbu/3e+R5jtFoxH1FAO4FLolEIpFIJF8en5t2W1GUFoBaCFH+2E/+nJCBSPJNgaYUJBFomgamaULXdex2O/i+jzRNeW3s5cuXKMuSO32oqwcAf/16veZOnyRJsFqtUJYlBoMBh4ayLHlaRMIBCkW6rnMo0jQNr169QhiGvGL2+PFjmKaJzWaDzWaD+XwOXdfR6/V4gpOmKRRFQbfbhWVZHNIAoNfrYb1e8/ogmfdM04TnefyMaZoiz3McHR3xOl1ZlrAsi815uq4jCAIURYHpdMpyCfr9qXtICMGyCQpGeZ6jLEs4jsPBsd/v3+s4iuMYh8MBo9EIlmWxLc+2bXlXJJFIJBLJl4zsIZJIviaQ/hrAnyhyjaIIQRDwhKTf72O/3+P6+hrj8RjHx8dI0xRhGPIKnWEYPN2wLAtFUSDLMr41oinIYDDAxcUF4jjmCY0QgqUPZJyjwED9QoZh4Pz8HNPpFFEUYbVa4fXr16iqijXcdLdzd1pEd00kdKBwkec5FosFWq0WDMPAYDDg0lkKeMPhEE+ePEGWZTgcDhzaKPBUVYXD4YDxeMz3STQtopslALwGSJRliSzL4DgO33YNh8N7q3FFUWC9XqPT6XBfEb228q5IIpFIJJIvj88UiBRF+UMAvyiE2CuK8kcAfmhyEkL8qQd50s+ADESSbxp0V5TnOa+fkda6rmv4vo8kSVhU4Louvve970FVVZyfn6PVarE9jSY9SZIgDEP+mBAC8/kcVVWh3+8jjmMMh0MURYGrqyueeFCnkWEYUFWVC001TcPl5SV2ux0URcFwOORpEZXL7vd7mKbJ/UAkXaiqCr1eD6ZpwnVdNE1zL6S4rotXr14hTVO4rssGPCqDXa/XEELgW9/6FizLYp03yQ+oG2m73cJxHBYieJ7HAgv6/UiUQPdXQggOhWVZIk1T9Pv9e3dFTdOw6vxuRxSt/EkkEolEIvni+ayB6DcB/DdCiOSjv/6h0E3Rl4EMRJJvKlmWIYoivitSFAWKokDTNARBgDiOEYYhAGA8HuPm5gaLxQJnZ2cYDocIgoD7fujN/OFwAHAbujRN4/sk13XZ8jYejzGfz3nSVFUVW9soQJExLggC/lwy4B0dHSHPc1xdXeHq6gqqqsLzPF4/M02TV+Mcx4Ft21zmWpYlmqaB4ziIogiXl5fQdR3tdptDlKIobMo7Pz/H48ePsdvtcDgcuKCVepTCMETTNBgMBhxuVFXlYATcTpQoFNE0Ko5jni7FcQzP87iMliAD392+IgA8jZJIJBKJRPLFIVfmJJKvKXRbQ1MaCja0gkZ9OXmes6jgu9/9LjqdDs7OzgCAv74sS9i2jd1ux6WpdV2jKAosl0vWUOd5jvF4DCEELi8vUdc1BwWa6NwNKKqqYrlcYrvdcvihSdViscDNzQ2SJIFlWbAsC4qi8O0S9Qjpug7Xddl2l6YpT3Rev36NJEm424gKYX3fx2q1guu6+Lmf+zkIIbBYLNicR7dYdV0jiiJMJhMWOlAAo+chrffdUEQTIirEJcnE3dU4WmMcDAZcJFsUBVvuJBKJRCKRfDHIQCSRfI1pmga+7/MbeAD8ZpssafTGnNa4Xrx4gTiO8eTJE7RaLTar0WpYURSI45i/h2EY3C1EoccwDEwmE6xWK2w2G6iqiqIo4HkeB4rxeMx9Qnme4/Xr1yiKAq7rotfr4fj4GHme4+LiAofDgcMUFbhSUKOi1FarxXc+2+2WQ1cYhri8vISqqhzGhsMh4jjGcrlEVVU4OzvD6ekpttstrwfSnRQJF3q9Hqqqgud5sG2bf0/qc7obimiVL4oi2LaNIAhgmiY6nQ7b7YDbu6LNZoNOp8PredSZRFMoiUQikUgkny8yEEkkX3OEEEiShN9ok8GN3rTHcYw8z7Hf7yGEQKfTYT13r9fDdDoFgHshSNd1XqFTFIVXx6i3iDp++v0+PM/DixcvUBQFyrKEpmnwPI/7jRzH4TW09XqN7XYLXdfR6XTQ7XYxHo/x8uVLRFGEMAw5jFAAKsuSAx99r8FggJubGxiGgeFwiCRJsN1usd/vWeN9dHQEVVVxdXWFJEnQ7/dxdnZ279aILHTtdhthGLJJj56Ppm4UXvI8ZwMdvU5BELAKXFEUuK4Lz/P4n0/TNFgul2i1Wuj1eqz3vls+K5FIJBKJ5PNDBiKJ5BtCnueIoohX1cgmB9zeHNV1jd1uxx0+7XYbz58/R9M0ePToEUzT5AkGrYbleY4kSVi3rSgKDocDfN9nEYLrupjNZvB9H5eXlyiKgotXDcNgTTZNcLIsw3w+R5ZlPFE6OzvjoliaFpHkYTwe88/O85yLaLvdLtI0xeFwwMnJCa+kzedzDlCz2QyTyQSLxQLr9Rqu62I0GqHf7yMMQw6RmqbBdV3Udc2SBQpMpmnyrRRN0MhARx+PoohDEvVEkV6c+PhdEf0zoZAnkUgkEonk80EGIonkG8TduyJd1zkYVVWFuq75Bsf3fbRaLWiahjAMMZ/PMZvN+L6GhAz0Jj9NUwgheBJSliVWqxXf02iahul0im63i+fPn8P3fZRlCdM02XZHAghaKUuShEtj6fP6/T4WiwXyPMfhcOAwQiFCURTuW6KQ5bourq+vMRqN+PmobFZVVfT7fbzxxhtIkgSXl5cAbkUTJG4Iw5B7i2g1z/d9DAYDFEWBwWDAZjlaoauqCmV5W8FGv2dRFEiShMtzTdP8oXdFo9GIv6YoCp5MSSQSiUQieXhkIJJIvmE0TYMwDHl6QetqVVWhaRru2NlsNnzvo+s6Xr58CcMwcHx8zL1EcRzzLY8Qgs12NLFZrVY8EaIVuZOTE0RRhBcvXiCKIhiGgVarBc/zWD1NwYOCTxRFXMo6m80QxzGqqmLJQ13XfANF90plWaLT6fB623q9hmEY6Pf7XK662WyQZRlM08STJ0/gOA7m8zmCIMBwOESr1YLruhBCoCgKXgccDAYIwxCu66IsS/R6PZ4g0UoiSScA8OtBq4aapiHPc9i2Ddu2WZEO3E7y6AbKcRxUVcXPKO+KJBKJRCJ5eB4kECmK8hcA/FUAbwD480KIS0VRfg3ASyHE7z7Y035KZCCSSH44ZJqjOxV6s0366qIosNvtAIB105vNBvv9HrPZjI1rvu9zR5CiKKyQJktbkiTY7/f8vU3TxHQ6Ra/Xw4sXL7BYLLgIttPpoNMYJwSDAAAgAElEQVTp8P0NSRTKssRyueT1MZr8UPfPdrvl32s0GvHvQ31G1EmUpimqqkK3270XAH3f58D25MkT7HY7rNdrtFotjEYj1HXNYY3CFtn0COo8oqkYSSyyLOPPKYoCjuPw60GhiIQLxN2+ol6vx3dgNEGTd0USiUQikTwcPyoQfaKldUVRfgnA3wfwHMATALT/oQH4jYd4SIlE8vDYto1Op8MTHJqA0KqcaZoYDod810OTljfeeAOr1QrX19eIooi10ZqmcRBxXRdJkvD04/j4mI1tZVni4uICi8UCjx49ws///M9zWDkcDpjP5wDAExx6ppOTE1iWhSzL2CSXZRna7TZOTk7gOA7KssRisUCapiiKAuPxGIqiIAgC7Pd7Los9HA7QdZ2D2GQygeu62O/3ePfdd2EYBs7OziCEwM3NDYDbAJmmKWzbhmVZWC6XPCGr6xpxHGO/3/O0igQLdwOMZVkscKD7Kfq++/0eTdMAuA2gs9mMg5EQgjuS4jjmjiiJRCKRSCSfL59oQqQoyh8A+BtCiN9RFCUE8G0hxIeKonwbwD8RQkw/7wf9YcgJkUTy46nrGkEQ8EoXTSFoEtI0DcqyxHq95nAEAOv1GkmSYDabcWkpmerojicIAti2jbqu+c993+c7pHa7jel0CsdxuIyVSmSHwyE8z0OWZdA0Df1+H3meQ9d17i2im6F+v49Wq4UkSXBzc8MFre12G67roqoqLkx1XZc7lWj6Q1pxVVV5Da/b7eL4+BibzQZJksB1XXS7XeR5DsMwYNs2wjBEXdesCKfbrH6/z68hrdBR4ARuJ0OtVovviujjpmmi3W7zdAn4wXdF9PV3748kEolEIpF8Nn7ilTlFURIAz4QQFx8LRE8B/EshhP1jvsXnhgxEEsknQwhxTx6gKAparRaHG0VRUJYlG95s22bt9nK5RLvdxng8hud52O/3yPOcgwYVlzqOw6tf6/Uaqqry957NZvznH3zwAXzfZ+30o0ePkCQJiqJAv9/nwNQ0DbbbLVzXZbX1yckJwjBEFEV8A0XdP47j4HA43BMabLdbDnNCCFRVxb9bWZZQFAWTyYSFE03TYDweA7iVPnS7XTbrdbtd6LrOwbLf7/PKH91rkbyCfpamaVBVlVf2qOfIMAy4rsv/fPI8x2az4VsluisyDONeeJJIJBKJRPLp+YlX5v5/9t49xrJ0Pe96vnXfe132fVdVV1+qZ3rGYys4jkmckEg2IhAHDEjIKAgLKSImEVaQUGSuCSHBwhDAQCAiCCUiCCFLXAQCZCXCJjgWJpg4QXHw0cncuqe7uqr2fa/7fX38UfO+p6p9zvFM9545PTPfT2p19+5de397Vat7PXqf93kAXAB4+5s8/oMAPnjZgykUis8PIQSCIEC/3+cbf4rXJqsW3eT7vo8wDDm17eTkBFVV4cmTJ1itVhgMBhgOh2y767oOQRAgiiKOy3748CFs2+ZAhWfPnmGz2aCua7zzzjt488032R72/vvvo21bBEHA0xrDMNB1Hc7OziCl5GnJ17/+de4hevToEQBgs9kgiiLs93sMh0M4joO2bVlMUb8RTVvSNOUOJMMwsF6vubjWtm1sNhvkeY4gCBDHMQcwFEWBOI45/pveV9M0ttBRqh9dT+B6r2gymXBoQhRFqKoK+/2ed5QoIpysfxQDTpOvL3oAjkKhUCgUryufdEL0rwD4ZwH8cwD+CoB/FMAZgJ8B8KellP/ZZ3jGb4uaECkUn54Xo7kNw+BUOSoMLYqCRQIA7Pd7von3fR9HR0fo9Xpc1Eppa2VZsjXNtm3s93vsdjsOY6AQA+owOj8/x3q95oAFSpir6xpHR0c8eQGA5XIJXdcRRREsy8LJyQmapsFut8PV1RXb56jbKAxDSCkhhEC/30eSJJhOp5yYBwCO4yBJEu4XIqtc13XQNI3LWcMw5JS8KIrgeR5b+obDIYbD4a1yVl3X+ZoA4M4l6j4qyxKe50HXdXiex+JJSsl9RdPplL8XNNnSdf3z/KuiUCgUCsWXgkOlzP00gD8GwPn4oRLAz0gp/+RBTvmSKEGkULwcXdchiiIOHSDRQNHadCNOP4bDIZbLJcqyRBRFAIDT01MMBgOkaYokSdA0Daqq4hQ2AAiCAEVR4OrqiidTbdtiNptB13W2r11cXHAiG+3n7HY7jEYjPpfrugjDEFEUoSxL5HnOEeFd1+HDDz+ElBKDwQC9Xg++77PIo89ZFAVHd1NwAe1NkYihgAmyw9m2jSAIEIYhqqpiUSWEgKZp0HUdvu9zX1HTNGzbI4EEXIc2uK7LZbd5nsNxHDiOA9u2OeUO+I17RXVdoyxLFc2tUCgUCsVLcLAeIiFEH8D34Npq9zUpZXKYI748ShApFC8P7ftQBw7tFRmGgTRNOYggz3NkWQbf95GmKZeuxnGMyWTC4ma9XvPzAXB/UL/fh23buLy85KkNdQhReh1wPQHabDZss5tOp4jjGJqmYT6fo+s6FgQXFxeoqgpJksB1XU7Cu7y8xHK5hO/7/PqWZXE4Au1KeZ7H1rq6rjnim/aXSORNp1O2wfV6PZ7g0CSK9od0XcdwOMRgMIDneZBS8nVtmoYnUlVV8bWO45iv1XA4BAC2L9Jz1+s1BoMBdyCRnZDKbRUKhUKhUPzmHLyYVQjRA/B7ALwnpfzoFc/3SihBpFC8OmVZIkkSvlEn0UEJaaZpsnDSNI2FR1VViOMYtm3j9PQUjuMgjmNkWcYhBUTXdZjP59hsNlgsFpxuZ9s2T4AoRW65XKIoCg5KoCkSpdK1bQvXdZGmKdbrNUdj015QVVU4Pz9HXdcYjUZwXRemafJUjKKxTdPEcDjkcIibn19KibZtsVgsYJomJpMJDMNggUWhDEEQwHVdFEXBaXiTyYTDGG5OiCiAgoQm2e/KskRZlphMJmjbFr7vs0hs25b7kgaDAYDrSROl7GnaJ10FVSgUCoXiq8shUub+KwD/j5TyzwshLAC/CuC3AKgA/BNSyr98wPN+KpQgUigOQ9M0PI3RdZ3tbFJKTngrigJ1XaOqKniehzAMOSghz3Ocnp5iMpmgqiqO56abfRIhk8kEmqbh/PwccRyj6zqevgC4lcq22Ww4ic7zPJ6OnJ6esqjwPA+Xl5fYbDa8h3N8fAxd17HZbHBxcYHxeAzf92EYBos7SnyrqgrHx8eo6xpt23KqG3Uj0edfr9eYzWbo9/uwLIvDKSisYTKZQNd1rFYr2LaNe/fuIQgCGIbBFjpd1/ncdG0ouCHLMr4+QggucyXW6zXatuW9orIsUVUVer0ef26FQqFQKBTfnEMIoksAPyKl/FtCiH8SwH8I4HcA+EO4FkS/85AH/jQoQaRQHA66+e+67lZfkaZpyLKMrV9ZlkFKyeLl6uqKJ0iu6+Lu3bvQNA1RFCFNUwBAHMfc22MYBubzORaLBS4vL9E0zS1LmpQSvV4PRVFgu92y9YzEUZIkODo6wmg04uLWqqrw+PFjtG0Ly7LgOA4HIjx+/JhDCsiiR59D13XuK7Jtm3eDgiBAnucYj8dcFPv06VNomobZbAbXdWHb9q2OJ9d1MZvNsN1uEYYhzs7O+HVJAFHJqxCC7YVBEKAsS8RxjDRN4XkeByj0+33+/lBa3s1dJbo2aq9IoVAoFIpvzSEEUQHgkZTyXAjxFwGEUsqfFEKcAfg7Ukr/kAf+NChBpFAcHhI3FLZAe0V1XSNNUy5dBcC2t+12i91ux2EKd+7c4Z0jEgxhGHKJaZ7nODk5Qdd1+Oijj5AkCaSUbBfL8xy9Xo/T6eI4ZhsblblaloWHDx+iLEsAgO/7ePr0KTabDfr9Ptq25VCG9XqNq6srnvLoug4hBAcoUC8S9SDFcYzZbIa6rtHr9XjfaLlcIgxD9Pt9HB8fw7ZtGIaBKIrQNA00TcNkMoHneXj//fcxmUxw7949+P71P5OUPEdFtiSUHMeBEIJFpBAC0+n0N1jjKO47CAJ4noeu61jY0WsoFAqFQqG4zSEE0RMA/zyAnwfwBMAfkVL+ZSHEbwHwS1LK8eGO++lQgkih+GygwAKaFNEUgqZIJFrIAmaaJqqqwuXlJcdED4dD3LlzB1VVIYoi1HWNpmmw3+8xHo+57HQ0GuH8/BybzQZlWaLf78N1XZ5K0ZQkSRLeTyL7W1mWuHPnDkajEZIkged5aJoG7733HkzT5FhxCnZ47733oOs67wRpmnarXLYoChYbURSh1+vB8zyUZYnxeIyyLFEUBVarFbquw2g0wmw2Y5FIUyDaq6L0vIcPH2I2m0EIwRY6APz+dV3zflYYhhw9Pp/Pb/UwAd/YK7JtG8PhEEII5HnOARZqr0ihUCgUitscQhD9mwB+EtcFrT0Ab0spKyHEjwP4cSnl7z7kgT8NShApFJ8dbdvyJEjTNE43oxQ2CiOoqupWQttms+FpkWVZePDgAQcRZFkGTdOwXC7ZKqbrOo6Pj5FlGT766CPeyxmNRqiqCmma8pSKbGLU5eP7PvI8h+d5ePToEe8l0bQoiiLeBXJdF67rYrVaYbvdYjwe804QTZmoCFXXdYzHYzRNw/tRWZZhMBiwrW+1WrFAe+utt7jriISkrusYDAYwTROXl5eYTqc4OztjYUmdTWSjo/Q96ivK8xxJkmAymbC4uxnNvdls0DQNi7uqqnjaROJJoVAoFArF4XqIfhTAfQD/vZTy/OPH/iCAvZTyfz7UYT8tShApFJ8tUkqeVtDyPlnO6rpmgUM/0/QmTVMsFguUZck2sqOjI0RRhCRJoGkai6YgCBBFEU5OTmDbNj766COEYcjJa7SPRAEM/X4fWZZxUSxNVsqyxKNHj+D7Pvb7PWzbRp7nuLq6YkGn6zpc14WmaXj27BkAcNcPJcJRF5OUEpZlwfd9JEmCIAhg2/at4IUoipDnOaIoQhAEePToEZqmwWq1ghCCI7jH4zFWqxVM08TJyQlmsxmA60kc2efoelOJa1EUHP/t+z5PymivC/hGX9FkMrm1V0RnVCgUCoVC8RnEbr9OKEGkUHw+FEXBUdVCCBYGXdchSRLexwGu94pIMG02G+4ecl2XE+L2+z2A652Y9XqN8XjMnULz+Rzr9RoXFxfI8xz9fp/3kWhfhkQBRX/HcYzBYMDFq2+88QbSNOUJ1Ha75YkMhS4YhoH9fo8oirjrh+xnjuMgz3Pe+QmCAFVVcVQ32eIonCFNU+R5jjzP8eabb2I0GmG1WqFpmltR4WVZcorc3bt3WcSQcKS9oqIoOI48jmMWkbPZDG3b8vnpGm42G/i+D9/3+UzAtXhVe0UKhUKh+KpzqAmRAeAHcD0luhVnJKX8r1/1kC+LEkQKxedH0zSIooijualAFQDv+1DRKdnAaLqzXC5RVRVs28bR0RGCIMB6vUbXdQCAy8tLWJbFe0FnZ2fI8xzPnz/Hbrfj4tO6rpEkCU+LxuMxoigCAKxWK0gpYRgGhBB48803OR6cwgcoBlzTtFuibrfboW1bTnAj4QVcT3GqquLggrZtMRgM4DgO+v0+/9lut4MQAovFAoPBAO+88w52ux2iKILrunytmqbhX49GI8zncwDXopNS8m4Wvtq2jTAMuevo6OgIQggYhsFToLZtsV6vYRgGxuMxC9SmaTixTqFQKBSKryqH2CF6B8D/CuAhAAGgBWAAqAGUUsrgcMf9dChBpFB8vtyM5qa+IppC1HXNN+F1XcM0TRZFWZbd6hYaDAY4OTlBnufY7/cwTRO73Y5jpZMkwWw2g+d5WCwWWK1WKIoCo9GIn1vXNaSU3N1DXT7b7RZBEKAoCt7bKcuSk+CEENjtdgCu7WemaXIP0WazwXA45KlOnuewLOuW2LMsC5qmwfd9CCEwn885rW6/3/NUJ89znJ2dYTgc4vLyEqZpchT4zbM3TcOf9eYeEMWc03QpSRKUZYkwDDEej1lU0V4XAGy3W9R1zXtF9D2xbVtFcysUCoXiK8shBNFfAbAH8OMArgB8H4ABgP8cwL8hpfz5wx3306EEkULxneFmNDcALght25YLXGnviKZATdMgDEPsdjtkWQbP89g2dnFxAcdxkGUZVqsViywhBB48eIDtdovlcsm7QYPBAFEUcclqv9/HZDJhQUKJdRRF/fDhQ/i+jzAMEYYhi6AkSaDrOoIgYJEShiGLFNM02a5GdrY8z3kSNRwOIaXEcDjk87dti6qqUNc1hzrcv38fSZLwhIcEZRRFODo64qkbTYsoSIICHOq6huu6PCWKogj9fp9DHizLYgsd7RWRaGrblkttqQBXoVAoFIqvEocQRBsAPySl/P+EECGAH5BS/l0hxA8B+HNSyu897JE/OUoQKRTfOW5Gc9NeESWo5Xl+azeGdopuToLCMISmaVyyut/v2X5GgQyDwQB5nuPevXvoug6LxQJxHKMoCu4J2u12qKoKmqbh9PQUTdMgjmMONyDRNh6PubdouVyi6zp4nof9fs/x3hQnTlMkz/NYLOV5zqEMJJrIZkc7TScnJ9hutwCuLXBkGayqCpPJBEEQYLfbYTwec5x5FEWwbRsnJyfIsgy+72M4HN5Kq6M0v16vx3tbSZIAAMd567rOU6CqqrDZbOB5Hu8VkSVPRXMrFAqF4qvGIQTRFsBvl1J+KIR4H9c9RH9VCPEmrotZ+7/JS3xmKEGkUHxnoWhuio+mvSIhBKqqQtM0nEBHoohS6Pb7PZIkQZqmmM/nmM1m6LoOq9UKvu9juVwijmPYts2vfffuXSwWC2y3W7aCeZ6HzWaDNE3RdR2m0+mt3aHtdossy+C6LqSUePjwIQaDAdbrNTabDSaTCcqy5LjtXq+HLMs4YIE6lWzbRhzHbGGjyUtZltw7FEURHjx4gLZtOZ2PXqcsSxiGgSAI0LYtR4t3Xcfi8ejoCLZto65rjEYjAOByWLLsGYbBQoqCHObzOU+I6PrTtaTeJfqeVFV1K5RBoVAoFIovO4cQRL8E4D+WUv5PQoifBTAB8O8A+MMAvldNiBSKrzYUU037QkIIjramElISFjRBatuWO4uSJEEYhrAsC/fu3UO/38dyuYRhGCiKgsMXqLfowYMHyPMci8WCd5YGgwHvKdG0ZzKZsDChMlMhBDRNw2g0wtnZGbIsw9XVFUdj02SJ0vSonyhNUxiGgel0ysl2FKpA0dhVVeHhw4ecAjeZTBBFEU+KaCeJ8DwPbduyTY6mOK7r8m4RAAyHQ+R5ziKMOouo94gsdDSpEkJwbxEAnqCNx2OYpsnfD8uyVDS3QqFQKL4SHEIQ/TAAV0r5Pwoh3gDwcwC+C8AawB+QUv7iAc/7qVCCSKF4fbgZzQ2AC0K7rkNZlixObNvmyGzTNG9NiqIowtnZGXzf554h27axXC65j0dKiSAIMB6P8fz5cxRFgaqq+AafhJJt2wiCAP1+n6dFFN1NO0FnZ2dc1hpFEYbDIbquQ13XaJqGpzW0N1SWJWazGe//NE2D0WjE4i5NU8xmMwwGA3Rdx7a+NE15H4iiwIuigBAC/X6fwyKklCyExuMxPM9DkiScFOc4Drqu42CGXq+HqqqQZRmSJIFlWRgMBtB1nS15wPXOF8WL93o9Fc2tUCgUiq8Un0kPkRBiDGAnv8NFRkoQKRSvFzeDCrqug+M4nIZG05YwDNn2RT0/TdNgs9lwd1EQBLh79y5b3mzb5s4gir3uug537txBHMdYr9fQdR1pmvKeThzH0DQNw+GQ47HpB02CpJQYjUa4f/8+oijCbrfj8te2bbm7yDAMlGXJFkDLsjCZTFAUBaIoQq/X46CH7XYL0zRx//591HXNdrssyzjNjiZktG9FHUMkTtq2Rdd1XMh6cweL7G5d13H8OABEUYSyLNF1HQss+h6QXW673fJZAahoboVCoVB8JTjEhOgYgCGlPH/h8bsAainl4iAnfQmUIFIoXj8odrrrOp7EUOlpXdfcCUQTGADcXbRarViwpGmK7/7u74YQAmmaoqoqdF2HKIrYIta2LSaTCUzTxMXFBU9eaEJydXXFcd2UhJfnOeq65k6isixZwBiGgTAMec/Gtm0IIbh/yTAMtgeWZcliZ7/fo21bjEYjWJaF58+fo6oqnJ6eQtM0eJ7HxawkWpqmufWaeZ5jOp1iNBrd2rlyXRe6rmM0GnFZrOd5LNroOpumyWfP8xyTyYSvr2maLFI3mw2EEBzsoKK5FQqFQvFl5xCC6BcA/LdSyr/wwuM/DuCfklL+voOc9CVQgkiheH2hwAFd19kaRoWtN8VNv9/nCYymaUjTlKcsz549w/HxMXf9pGkKALx3RD1IlPBGBbC6riMMQw5cCMMQQRDA8zyYpsm7PDSd2e/3qOsa0+kU0+mU7XA0YQmCAHEcI0kSOI5za1pkGAZGoxELC9M0MZ/PsVwusVqtMJlMMBwOAYBjsquqYvsccB1bXhQFT8/u3r0L0zS5y8myLC6u7fV6XEY7m83Yigdc2xTjOOaQCBJOlARIgicMQ+R5jtFoBNu22U6oorkVCoVC8WXkEIJoD+B3Sin/7guPvw3g/5ZSjg9y0pdACSKF4vWmrmvEcQzDMCClRK/X42AFEkDb7Zb3fyjKGgAWiwUMw8BqtUJd1/ie7/kelGXJEx7q+UnTlKdF4/GYe4h838dut+PJyPPnz9mapmkaT2nyPIdt2yjLki1zp6en/B4UAjGfzyGlxHa7Rdd1sG0bSZKgrmtkWYbxeAxd1zkxjmxrT58+ha7rODo6ghACo9HoliiiIlsKTaBY8fF4jMlkAiklPM/j9wAAy7JYUFLfEAkj2ntKkoSnZUEQwLZttG3LU688zxGGIXzf5wQ+Fc2tUCgUii8jhxBECYDfLaX8tRce/14Af11K6R7kpC+BEkQKxesP3bhTsSlNOWivBbieJlVVxTfm1CtEBatSSjx//hxnZ2cIgoCnTxQosNvt4Ps+T1VGoxFWqxUsy0LTNEiSBLZt4+rqClmWYTabcbgAJeDRbtJiseDpCe0ekfjxPA+z2Qy73Y4DH0hY7fd7GIYB3/ehaRqKooCUEvfv38eTJ0+QZRnHY/d6PXiex+ENADhkwfM8jtTWdR0nJye8C1UUxS0rn23b3Oc0mUz4mpNlcLfb8URuOBxyjxFZ6Ghny7IsFltVVaEsS7YYKhQKhULxRecQguh/B/CulPInXnj8vwDwXVLKv/8QB30ZlCBSKL44JEnCezOapvEUgqK527ZFFEXwPI93fTRNQ5Zl2O/36Pf7PG15++23kaYp29a6rsN6veY9HgAcxU1Tk/V6zR1Ii8WCC1A1TUNZlmx5C4IAXdfh4uIChmFweILv+zz9OTk5gWmavKN003aW5zlb8yzLwm63Y2vb+fk5BoMB+v0+er0efN/noAUhBIsoEoY0jaKzUkhF0zTwfZ8tiHR9fd+H53mcGkfvT3tbQRDcClCgSRMJp/F4DMMwOCLcMAwOxVAoFAqF4ovKIQTR7wLwVwH8vx//DAD/AIDfBuAflFL+Xwc666dGCSKF4otFWZbIsgy6rnOXDsVN077RdruFYRjo9/s8QSEbHAUQLBYLvPXWW7AsC0VR8JSH9o/IvkbTqCRJMBgMsN/vkec5hBC4uLhA13U4OjqCYRjQdR1JkiDLMjiOw9Oi7XaL0WgEXddhGAaXug4GA0ynU6Rpyil3NBmiHSjHcTAcDrnQdTqdcu+R7/twHAee5wEAi0WaDAGA67oc2ECJeK7rcjw4vQcATtADwBY52huiniSaMDmOg16vx8EWQggOsiDhRdMzADzRUygUCoXii8hBYreFEL8VwL+MaxEEXIuj/0BK+bcPcsqXRAkiheKLB02CyEL3YjS3EIItcUEQ8I05pb1RcMHTp0/heR4ePHhwa5cHAC4uLlhs3NzBGQ6HqOsa6/UalmVx/xCVmpqmibIsEUXRLfvbs2fP0DQNPM9jEUUibDqdot/vY7FYcAS3rutYr9fIsownQa7rYrPZoN/vs3jzPI/tcFTeats29x4B11Mc+uwA+Fy0C0VCrd/v34r2pmQ6sse1bYswDFlcUfIdFdHqus57RZ7nsVAja6Ky0CkUCoXii8pn0kP0uqAEkULxxURKiSRJ0HUdgOudF4rmJvsc7R71er1bIqEsS4RhiF6vh/V6jSiK8PDhQ+i6zpHdALDdblEUBYbDIYsGIQQMw4DneTypieMYm80GruvC930IIdDr9fjP+/0+BoMBNpsNCy3DMDi1LkkSuK57y2oHXE9V8jzH1dUVC5bpdMpBE/SZaK+H+pIo7c1xHOz3e7iuy4EKu92OJ0m2bWM6nbLFUNM0Fpb7/Z7Fned53DtkGAY2mw3Hk7uue6uYlXau6DkUzd00DYqi4LQ7hUKhUCi+SChBpFAoXlvyPOddFdqdodLRqqrYygUAvu+jqiruMqIwgaqqcHl5ieFwiPl8zpHTXdehLEusViv4vn+rk0dKiZOTE2w2G2y3W+i6zgIoCAIIITAcDrHb7RCGIQaDAU9mHj9+jDiO4TgOdF3HfD5H0zQciOC6LlarFdI0ha7rcBwHV1dXLIIo0CEMQ+5fsm0bUkpomob5fI40TTnkIQxDFipUaEv7WKZpwvd9TKdT7juiqPAsy9jypus6hsMh7zXt93t0XYeiKNDv93lKV9c1X6f9fo+qqrhbqes6ntQpC51CoVAovkgoQaRQKF5rmqZBHMdsoaOJEACO5ibhRBa2LMtYLFEgwXK5RNM0uHPnDkzT5PhqIQSurq5YMADgCOrZbAYhBJ4/fw5d17FcLpGmKe/gmKYJ27bx9OlT9Pt9WJbFhagffPAB2raFaZpsmyOrGomqxWKBuq45re78/JxF12w2A3AdL951HUajEYc+TKdT2LaN7XbLr0X2uzzPEQQBT8Ns22ZhZlnWrWmQlJLDJ4DrqVUQBLAsC1mWoSgKVFXFu0gkOslCl6YphzX0+30A12l4TdPcCmdQKBQKheJ1RgkihULx2kPWNerSMU2TrUQwRvgAACAASURBVFw0Eeq6DkmSsCihHZ6qqpCmKSzLQhiG2G63GAwGODo6QpZlSJIEQgjsdjvEcczx3ACgaRp838fx8TGePHnCAQ3L5ZKjsbuu4zCEPM9532cwGODp06e4vLyEZVlwXZcnNbTb47oukiRBkiT82Ha7xWq1Qq/Xw3Q6xXg8xmaz4aCG4+NjbDYbLnilvZ/pdMq7TyTEfN/ndL1er3crwS4IArbXdV2HOI45iMF1XbjudWNCGIYAwN1KJBqBawsdWRQty+KC2bquUZYli0aFQqFQKF5nlCBSKBRfGKiPSAgBIQRc1+ViVeomot0j3/c5HlpKiSiKYJom6rrG1dUVl6FS5DYVj242G77xb5oGuq7Dsiycnp4iSRJcXV0BAK6uriCE4MkI7Redn5+j3+/Dtm24rgtN0/Duu+8iSRL0ej2MRiMWDgB4yrTf7zlJr21bnJ+fo6oqjMdjzGYzOI6DJ0+eoG1bvPHGG6iqCkmScGLeZrPhSHFKk2vblt9ruVyi3++zbY/sd6ZpcgksRWzTFI6CJ7bbLe9v2bbNf1ZVFRzHQdd12O/3kFJiOByyrZH2nXq93uf510ShUCgUik/FQQWREOIIwEpK2R3icK+KEkQKxZePuq55/6ZtW7aqAd8oL6UIado5omkRTYM0TcNqtUJRFPA8D/P5HPv9HlmWQdM0rNdr1HV9K91NCIHj42MMh0O8++67aJqGgxlomkICgvaNaI+IimA/+OADnm6RyNE0DQDYXpamKYqigK7riOMYl5eXcBwHk8kEd+/exXK5xOXlJY6OjvDgwQM8efIElmVhNBrxNCcIAtR1jbquoWkahBA8xWqahkVZXdcYDAYsmrIsQ7/f56mS53m8X0R7SZR0R1OwqqpgGAYMw+DCWOozIpFJ3yf6rAqFQqFQvE4coofIBPDTAH4CQA/A21LKD4UQ/x6Aj6SUf/4THuT3A/hPAOgA/qKU8s98i+f9KID/AcDvkFJ+W7WjBJFC8eWEJj7AtZWLbHI3LXRt26IoCmiaBtd1UVUVyrJEURQoyxK9Xg9xHHMh69HREXRdZwGy3+8RhiEnrZEYGI/HuHfvHhaLBTabDdI05Rhu2m3yfR9FUSAMQw5O8DwPjuPga1/7GqfWDYdDHB0doW1btp9ZlgUpJYceaJqGq6srLk69f/8+NE3Dhx9+CCEEvv/7vx+LxYKT5iiym4pZaaeHztB1HRaLBQaDASaTCYQQ6LoOp6ensG0bSZKwOFsul7dKZC3LQpqmAMBWuMFgwFZG2j2iaZjv+wDA195xHGWhUygUCsVrxyEE0b8N4EcB/GsAfhbA3/OxIPpRAP+qlPIHPsFr6ADeBfAPATgH8DcA/NNSyq+98DwfwM8BsAD8C0oQKRRfbWhqQVMQsoK1bYu6riGEQFmWqOsavu9ziEDbtrxv1LYtNpsNR1DP53MsFgtIKbmTqOs6jMdj7jyifiMAePz4MUdRkyigWGyy7NV1DcuyOJhgs9ngyZMn6LoO/X4fJycncBwHlmWhrmtUVYXhcIgsy7Db7Vjc0XucnJzgzp07WCwWuLy8xBtvvIGjoyM8ffqURUdRFDAMgwVImqa3SlcXiwUA4Pj4GL7vY7/fYzKZYDqd8rXt9XrY7/coioLDGMgqR7ZFTdN4SkcWurZtsd/vIYTAaDTi7wklBlL8t0KhUCgUrwOHEEQfAPhDUsq/JoSIAfzWjwXRdwH4FSnl8Dd5CQgh/j4Af1pK+cMf//5fBwAp5b/7wvP+LICfx3UJ7L+kBJFCoaiqClmWsYXOdV2OzqYiV7KP0b4OpafRtMOyLGy3W8RxDF3XcXJygrIssd/vYVkWNpsNsiyD7/s8ydE0DXfu3MF8Psfjx49ZvOR5DtM0eXeGOpPatuUpCU2znj17hs1mA8uyMB6PMZ1OWcTs93v0+30EQYDFYsGhEvQevV4PZ2dnEELgww8/hG3b+L7v+75bha9VVfEEzTRNZFnGez66rnPnked5vCMlpcTR0RGCIGBrYlmWfI0pcY56h6SU3HM0GAxQliUMw4Cu6xwdTql8JCgpLVBZ6BQKhULxOvDtBNEn/Z/qDoCPvsnjxsc/PgmnAJ7d+P35x48xQojvB3BPSvlzn/A1FQrFVwDLsrj0lEIVqA+HdnRICJGdzLZt9Pt93jEqyxKTyQTz+RxCCFxcXKBpGty9e5e7diaTCbIs40Q1KSU+/PBDvPvuu7h37x5OT08xHA4xHA7RNA2LDU3TYBjX/xRSbPV2u0XXdbh37x4ePXoE4Nqe9vTpU0RRhCzLMBwOOVzh9PQUp6enME0Tg8GAC1y//vWvY7Va4c0330Sv18Mv//IvQ0qJ4+NjDpmgMISbgnC73XLy3ng8Rp7nbMHzfR+Xl5c4Pz+HZVksglzX5b4jCqjI8xxd16GuawDXZbcU501TLupUStOUQyhInFHct0KhUCgUryufVBD9OoAf/CaP/wEAf/MQBxFCaAD+IwA/+Qme+0eEEL8qhPjV1Wp1iLdXKBSvOTSdoOhq6uChGGmaYJBAoslQEARwXRe2bSPPc9i2jdPTU7aKnZ+f4+TkhG1w8/kchmFgu91CSgnP87Db7fBrv/ZrEELgnXfewWg0wnw+h67rHBdeFAWCIEBRFPB9n5PbKMTg7OwMs9kMURTh2bNnWC6XvMszm83w+PFj1HWNt99+G+PxGKZpYjgcwvd9LBYLvP/++3AcB2+99RY+/PBDvP/++5hOp2whBMDTMorPLooCu92OrwOVz15eXmI8HqOuazx9+pQFICX6AYDruojjmMVWnuc8NQvDkEthqdh1MBggSRJOoiP7YJ7nKIriO/OXRqFQKBSKT8Antcz9YwD+GwD/PoA/AeDfAvAOgB8D8CNSyl/4BK/xbS1zQogBgA8AJB9/yTGALYB//NvZ5pRlTqH46lGWJfI8Zwud53k8tSjLEsB12SvdtNPeTpIkbDFzHAdpmmKz2QAARqMRLMvCarWCruvI8xxRFHHJKgUXHB8f4/79+1itVlitVoiiCEVRQEqJtm1xfHyMOI4BXO/ixHGMpmkwmUzYxndxcYGqquC6LkajEQaDAXq9Hr/Wo0ePOP6bBEZZlijLEr7vYzabYbvdoixLPHjwAK7rcnHtzW4gmqI1TYP5fA7g2n5IHUaj0YinakIIDAYDuK4LIQRHk5MACoIAURRxxxF1LVFBLP2ezjsYDNjWSBY6shEqFAqFQvF5c5DYbSHEDwP44wD+XlxPlv4WgJ+SUv5vn/DrDVyHKvxeAM9xHarwY1LKX/8Wz/9FqB0ihULxLWjblu1qTdOg1+txFw6JHgpNAMA392maIssyFgVd1/EkhwTKbrdDURRcBFtVFcdTx3GMIAjYBvf8+XO2wHVdh6IoMB6PYRgG9vs9fN+/1f3jOA6SJEFZlthutwDANjyK9t5sNtxNdH5+zvtNVDxLX+P7PpbLJabTKXcD5XmOMAxZrFDiHhXQOo6Duq65/FbXdU6RAwDDMBAEAYIgwGazQVVVmM/nWK1WXI4LAJ7nodfroWkaDmOgJD2amHmexx1OlELX6/XYXqhQKBQKxefFa1PMKoT4RwD8WVzHbv+XUsqfFkL8FIBflVL+Ly889xehBJFCofhNoJLWtm1hGMZvSKGTUqJpGg4eMAwDVVUhiiK0bcv7P0mScDnpbDZD0zSI4xhlWaJtW4RhCNM04Xkei6V79+7h+PgYV1dX3HlUFAXv8kynU2w2G06FI/uY7/t8btqHsiyLRQ5FX7dti7OzM2RZhouLC051owmZbdu8H6TrOubzOae70QSJIsVJfFmWhdlsxvs9NLWhM1LCnGVZmM/n6LoOq9UKvu/Dtm2QTbnrOhiGgel0ypMr27Y5VrwsS075C4LglvXOtm3ulVIoFAqF4vPgtRFEnwVKECkUChIiuq6jaRr4vv8bLHRd1/GNvq7rEELwJIOmJXVdY7vdIs9zDIdD2LaNOI7ZepamKYsMmsb4vo8333wTZVni/PycC2LJvnbnzh1+jERAklw7gzVN46JZmvxQt8/NXajpdIrBYICLiwtOyqM+ISklB0hQCavruvA8D0mSYLFYwHEcjMdj3v2RUrKFLkkSeJ4H27YhhIBhGOj3+zAMg8XbcDjEfr9n618URdjtdtB1nXePLMti293NsIcwDDn1jr4neZ7zZ1UWOoVCoVB8HhwidjsG8C2fKKUMXv54r4YSRAqFAviGhY6ipl+00LVtCwCo6xq6rvMP2hWizh3DMBDHMXa7HSe+UYAD3ejvdjsWDjSdevjwIUajEZ4/f47VagUhBLIs47LVXq+HNE1ZFHRdhyzLYNs2p7M1TcMCznVdFhpVVXFUeJqmWC6X2O/3AMCvI4SAZVksjnq9HjzPg2VZOD8/R1mW3BdEe02j0Yh3g6SUmEwmPF2zLAuj0YhjvMfjMYBvCCjDMBCGIbbbLXzfh2mabA8cDq+bGEgExnGMuq7hui5/T8qyRFVVykKnUCgUis+FQwiiP/jCQyaA34brstafllL+uVc+5UuiBJFCobgJdfm0bQtd1+H7PoQQaNsWVVUBAIsYmopQ90/bthBCsKjabreo6xrD4ZBjprfbLYsYCjCwbZtv+N944w3keY6nT5/yNGa/30PTNEynU2RZBsMw+L2qquIAiKqqePLUNA1s2+bOJcMw0DQNxuMxW9dommWaJtI0RdM0HKE9GAx4PygIAux2O1xeXsL3fYxGIy5jNQwDR0dHaJoGSZJgNBrB8zzudZrNZjAMA1mWcb8S7SSZpgnTNPHs2TO0bQvf99Hr9TiIgix0lEZHApC+J8pCp1AoFIrPi8/MMieE+HEAv1dK+WMv/SKviBJECoXiRchCR4ELQRDcstBJKTlwwbZtAODABCoqJcsXTYsoEIEEDpWTkgDzfR+apqGqKjx48AC+79+KtI6iCHme86SFEvLatuVzUbFr27bo9/tIkgRCCN7tsSyLI7VHoxGSJMFut0Mcx1wOW5YlB0nMZjM4jsPCyLZtfPTRRyx0yrJEURRo25b7hOI4hmmaODo6ghACSZLAtm0cHR2x1Y2KZSnum4pdLy4u4Lou9zT5vo8gCLiLSAjB07ib3xOacCkLnUKhUCg+Kz5LQfQGgL8tpfRf+kVeESWIFArFN4MsdBSi8M0sdDShMQyD94ratsVqteJeIwoxCMMQXdfdssmt12tOjaP9JCpmdRwHDx8+RBzHOD8/ZysahTNQmAFZ62hqRP1JZLWjKYqu6zAMA7Zt83nJmrbZbDgkgpLuSFzZto0HDx7w643HYyyXS2y3W3ieB8dxEEURR5Hf/Hw0XaqqClmWYT6fw7Ztfh+6HrR/5TgOLi8vWfiRaJpOp9A0jcMmyLJH7w+AwyiUhU6hUCgUnwWfpSD64wD+sJTy4Uu/yCuiBJFCofh2fFILXdM0cF0XTdNwnw4JCtr5SdMU+/2eu3oMw8DNcmjalRmNRnAcB1mW4e7duwiCAE+ePEEcxyxAiqLgwther8epc6ZpYr/fo65r3ieiaRBBqXC6rnP8dRiGSJKE7Xf09VVVoaoq3L9/H47joG1bzGYz6LqODz74AEIIDIdDttzRHhJNbwzDwGw2g23bWC6XnFJ3U8DRvhFdz7qusV6vYRgGxuMxR5EHQcCTtbIs2YbneZ6y0CkUCoXiM+UQO0R/B7dDFQSAIwBjAD8hpfwLhzjoy6AEkUKh+M24WeRa1zWHANy00NEkqNfr8e+rqsJms+EENXoOBRqQdawsSw5hIBuaEALz+ZwjtR88eIAwDPH8+XNYlsU7OwDQ7/fhui6LLuBaVNzsNhqNRrzHpOs60jTlNDjbtjEcDvkctLuUZRnvKKVpCtd1Ocbb8zyMRiMsFgvs93sEQcBR5Zqm8aSIuop6vR6Xy4ZhiPF4jMFgwEl4FNpAVj9K9aPn0vWidDvqM6IuKdp5onPTdVEWOoVCoVAcgkMIoj/1wkMdgBWAX5RSfv3Vj/jyKEGkUCg+CTctdCR8qDSUAgRo5wi4joSmx9brNU9LaNqUZRnSNGVbmGVZWCwWPIkiC9toNMJwOMR6vcadO3d4t6goCu4myrIMpmlyyhsJDF3XuWQ1yzLous7TIsuykGUZ6rrmnp/hcAhN05AkCe/llGXJe0V5nvOOEwVBnJycoG1bPH/+nMMb8jxnoSWEuCUi+/0+hsMhFosFTNPEcDjEYDBAnud8fcfjMQs5Ss5r2xae53EKne/7nPhHnUuu67KFTqXQKRQKheKQvJIgEkIYAH4fgF+RUm4+g/O9EkoQKRSKTwNZ6Lqug6Zp8DyP93uqqoKUkvuB6KadRAr1/1AoQ1EUHPUtpWSb3H6/51S4KIqgaRoePnzIvUEPHz7EbrfDYrHgry3LEmma8p5PnufI85wFTlVVPHVxXZe/joIKyEJHRaxZlvEukWVZ2O12LFBoWkRiyHEczGYzXF5eoigKOI7D3Utkn0uSBL7vc+T2YDBgkWnbNo6Pj2EYBvcV9Xo9BEHA6XKmaSLLMmiaxhMnmhyRcKM9rBctdBQqoVAoFArFy3KICVEB4B0p5ZMDn+2VUYJIoVB8Wmh/hSxuQRDcstC1bcvTG8uyODRASontdss39VLKWyWsZDEzTRPr9ZpDBJIkQVEUOD4+RhAEuLq6wtHREQaDAZ4+fco3/VJKLmi9d+8eT65oyhOGIXRdZ9vccDjkAAeaCpFYGo/HqKrq1m5QXde8v5QkCQzDwMnJCQdITCYTNE3Dpat1XfPr9/t9Flij0YgnN77vs4VwMBhgNpvdKrN1HId3nIBr21xd17yz1ev14LouALBdTtM0BEHA1zjPc0gplYVOoVAoFC/NIQTRrwD4E1LKXzj04V4VJYgUCsXL0HUdoihigfGihY5EBwUu+L6Psiw5ips6dW5Oi8j6RROQLMuw2Wyg6zoAYLfbwbZtvP3229jtdkjTFI8ePcJ+v8d6veaJTJIkCMMQx8fH8DyPd6DatsVut0PXdRx1TSlvADjkgXaA+v0+bNtGGIY8+bIsiwMYqO+o3+9jOp0CABzHge/7XEQLgKO3+/0+dF1HlmWwLAuTyYQjtKuqYqvd0dERbNvm/iWyywkhWNRRuAQFQ7iuy+l5tDt100JXVRWKouC9KYVCoVAoPg2HEET/MIA/A+BPAfibANKbfy6l3B7gnC+FEkQKheJVSNOUY6YBIAgCaJrGnT60O0RBBAA4yW2/33McNiW7kZjK85ynKFSgalkW0jRFnue4e/cuJpMJHj9+jNlshtFohGfPnnGynRACy+UShmHg9PSUO4uyLEOSJEjTlIXBTWsbABZO/X4flmWh1+txrDU9t65rTs2j96SJDYkUiia/OQEjkUXXhrqGqEeIrG++72MymfAuEwU9+L6PNE1RVRVfz91uB9/3ebpF56vr+paFjj6/stApFAqF4tNyCEHU3fjti2lzUkqpv9oRXx4liBQKxatCPTuGYaAoCgRBwLHPFEhg2zZPQOjGv+s6JEmCsizhOA66rmM7GE11hBBwXRd5nmO9XnOZKe3evPPOO1itVojjGG+//Ta22y1b0DzPw263QxRFOD4+5hLZNE1RFAWiKGJLG+0TOY7D/Ulkj+v3+9xpREEQNN2q6xqLxYJT+KhLybZtniiZpskCUErJsdg3QyjIRkfWP/q/JQgCFji6rvNelGmaXII7Ho+x3W7RNA3G4zFPikzT5MS+Fy10JM7oeioUCoVC8e04hCD6oW/351LKv/aSZ3tllCBSKBSHQErJFq6yLFkYANcToaIoeAJDookEUF3XHK5Ae0lN03BPDwkmspFROWuapqjrGvfv38d0OsV7772H0WiE6XSKjz766FYy23K5hOM4GI1G0HWdXzuKIo6uphAIEmE0VaLEOypLpX0e2t2hMISrqysA17Y50zQxGAzQdR2LH0rLI1FlWRbbAWl/ajKZwLIsdF3H+z62bcNxHBiGwdOioiig6zpfbxI8VHYbBAGLr6ZpvqmFjq4rWQYVCoVCofhWHEIQ3QfwTL7wZHH9v909KeXTg5z0JVCCSKFQHJIsy3jq0TQNR1nTnlDbtrBtm3uAbgqgPM+5cJUKUYHrKVMURTAMg6c5V1dXPEnJsgz9fh/vvPMOrq6usN/v8cYbb7B4ovLSq6sr1HWN4XDIAoPS75IkQRzHGAwGHIBANjoqeA3DkDuLoihCXddsgeu6js+13+/R6/Vg2zbb00jczOdznirRdIZ2iyidjt7DsixUVcVx3mQv9DwPRVGg6zqeulHRbb/fZxHp+z5HnVuWxYl5Ny10NNnq9Xrfgb8tCoVCofiicAhB1AI4kVIuX3h8AmCpLHMKheLLBO3XUNIcWcgAsNCxbZujsH3f56kHTWRudvpQxPdut0PbtjAMA67rYrfbYbfbsVUPAE5OTjCdTvHuu+9iMBhgOBzi+fPnHBFeFAULFhItmqZhs9kgyzJOiJvNZtwFRCWrTdNwOMFoNELXdRxyMJ1OURQFer0eNpsNFosFgOspEiW8GYaBqqowGAwwHo+xWq0QRRGHUZAw0TSN48EHgwHHadNZ6f1JTNLOFdn96PWopNb3fd5nokQ8EksAOHCC9p8UCoVCoXiRQ+0QHUkpVy88/gDA16SU7kFO+hIoQaRQKD4rqEOoLEuYpgnf93/DZIJS0Xzf55t9isrOsgxBEHAoAQmf/X7PeziGYeDZs2fcjUT9R2+99Raurq4QhiHu3r2L/X6PJEk4Iny/36Oua+4F6vf7bJ+L4xhRFGE6nSIIAp5gUaKe53lYLpdc9Lrb7ZDnOWazGSzL4mnQs2fPbk2Luq7DaDRiIXhycgJN03B5eQngOtyBBA0V21JMt+M4/Nls2+adrfl8zsEWNJ3r9Xrcq0QTNMMweD+JdptIFALXIpY6lJSFTqFQKBQv8tKCSAjxn378yz8K4C8ByG78sQ7gBwBUUsrfc6CzfmqUIFIoFJ8lRVGgLEsWRsPhkG1cNBFyHAdpmvJNetM0yLLrfy7DMORdmziOeaqx2WxYeFCXz3a7hRACVVVB0zTcvXsXnufho48+Qr/fh+u6uLq6guu6sCyLLXrUfURTHLLWbTYbSClxfHyMfr/PHUo0saIYbNd1oWkattstbNvG0dERdyhtNhusViu2D1LyW6/XQxzHGI/HmEwmiKKIp000raG9oKIoIKXEdDrlgArf99F1HeI4xnw+h2VZSJIEwDeS/0ajEfcnAdcWRtM00XUd7zbRdaHPRUEWvV5PdRYpFAqFgnkVQfR/fPzLHwLw1wFUN/64AvAEwM9IKd87zFE/PUoQKRSKz5q2bRHHMVvoKJ4a+MZkwrZttG2LqqoQBAGAaysXhS7QFKkoCn4+TXQMw4Bt27BtG8+fP0dVVRyIMBgMcPfuXU6bm81m2Gw2AHDLqkcih8TGfr9HmqYIwxBpmsLzPBwfH6NpGoRhCMMwWMyFYcgBDmmaIkkSHB8fc3BCURRYLBaI4xiWZcGyLDRNgyAI+DPfuXOHAxuo3FYIwbHcNFWzLIsT7yaTCQzDQJIkEELg6OiI7XNSSiRJAsdxMJlMOOabhA/9oAAJmpwB4Ckd7TYpFAqFQnEIy9xfAvAvSimjQx/uVVGCSKFQfF4kSQIpJZqmgRACg8EAQgieTADgYlXqAKJ9JF3XuZjVMAxEUQTHcVDXNZeydl2H6XSK7XaLzWbDljPHcXB6egrTNLFcLmGaJoQQSJIE4/GYBRQAtuZRJPVqde10Xq/XqKoKp6enGI/H2Gw2/HUUeJAkCdvR1us1DMNgWxxwPdWK45iDI7ruupHBdV1kWYZer4fZbMZiJk1TFmmj0QiGYXBUOYnGIAi42JW6noIgQJqm3O1UFAXG4zH3H+m6ztZF6jcyDAOj0YiT8yjkgnaXFAqFQvHV5pUF0euMEkQKheLz5GZnUZ7nGA6H33QyQQKJykdJTFE/ke/7SJKEd2bW6zXquoaUkvt8aCpD/04PBgPM53NEUYQ8z9Hv97Hb7eB5HizLQpZl3PnTNA0sy4LrujwlokQ627ZxdnYGTdNYKNE+FO0xAeAi1MFgwNOczWaDPM8RRRGEEDBNk5P3qJfI930Mh0N0XYf9fs/CxPM8DIdDthtWVcX7SfP5nB+nxDq6xpqm8YSOBCAFLADgHSmyys1ms1udRXRNVWeRQqFQfHVRgkihUCgOCO2+UEiCbdssfG5OJoQQPPWghLYsyzhxjm7SwzCE53nI8xy73Q6apnFvUBRFWK/XyLKMi1NPT0/Zgial5EnPeDxmwaPrOu8vOY6DpmkQxzF3JuV5jvl8zjHaFIxAwQVCCLap0V7OaDTCbDZDGIbYbrecEKfrOoshKqgFgMlkwjbB1WrFgmUwGHC3EQmrXq+H4XCIwWDAnxUA/0z9SmVZ3ooKF0JwvDeV5VLZK02hVGeRQqFQKJQgUigUis+ALMtuLfyPRiPuLKJQhV6vhyRJYJom7x2FYQhN0zgUYTAYIAxDFgaXl5cQQvC+km3bWK1WHJJgWRZGoxGCIOD3yfMcSZLg6OiI47VHoxHv9LiuCyEEiqLg0ILtdssCy3VdrNdrTtYTQrBFjcIjuq7jZDjP8/Ds2TMWgJQwR4W0JHiEEJjP5zwFi+OYPxOFLlAhKwDMZjMEQXCrd4gCKwDw9aYgCSEET4sMw0AYhjwtcl2Xi2JVZ5FCoVB8tVGCSKFQKD4jmqZBkiR84+77PhzHAQDu/On3+2iahstGKZ6b9n3W6zWnosVxDM/zkCQJi5O2bTm+m7p/HMfhRDiKwa7rGrvdDoPBAL1eD1EUsUhbrVZctEpnoR+UFjefz2EYBp4+fcox3V3XcYoe7fQAgOM4ePjwIVarFafLUZgC7VkBYCudaZo4OjqCrus4Pz/n/ibatXIcB2VZYrvdotfrYT6fc2hEr9djYUb7QHVdo9frsZ2Qyl0p8IEsihTiQOIrz3M0TaMCFxQKheIrhhJECoVC8RlDV0Y+CwAAIABJREFU4oX2W4bDIS/+Z1nGiW1xHLOYIeudaZqI4xhlWSIIAuz3e7bHLRYLSClZAFCS23K5hJSSAwuo94f2gtq2xcnJCbIs41+vViukaYogCHjP6KaFjyK6R6MRkiTBcrmEEILfm3Z5SCzVdY3ZbIbJZILHjx/zjg6JPfr8NM3pug7D4RCTyQT7/R673Y7tb5Zlwfd9mKaJ7XaLNE0xm83geR7HapumiSRJuM+IPu/Nz06iiM5Be1n9fp+FInUeOY7Dz1UoFArFl5uDCSIhxB0A9wHc+h9ESvlLr3TCV0AJIoVC8bpAkdqGYSDLMoxGI95ZocmE67rI8xxd18HzPLbG0URls9mg3+8DuLbkUeEqJdXRxKRpGp7OUC/QbDZD27bQNA1ZlmG1WmE6ncJxHERRhJOTE3Rdh4uLC7aNtW3L4khKic1mw1azIAhwdXXF562qivea6rrmXSEhBM7OzpAkCdbrNRzH4fjsmxHZNC3SNA1HR0ccHEFJdCQagyCAlBJXV1fQdR3Hx8dcIktx4dTj5Hke6rqG7/scWqFpGgzDQK/XQ5ZlKIoCQgjouo5+vw/P82DbNgdf9Pt91VmkUCgUX3IOEbt9B8DPAvhBABKA+PhnAICU8jvmO1CCSKFQvE50XYcoijj1zXGcW4ELaZqyPS5NU7iuyzY2ChNIkoTtdWEYwjRN6LqOq6sr7uExDIOnRZvNhpPeKA0OANvThBA8LdJ1HScnJ1gsFoiiCL7vc5R1HMfo9XrYbDZomgae57HIophuEny0X3RT8Hieh+l0iouLC/76LMu4j+lmEpyu6zBNE8fHx5x+dzP0gOx0aZpiu90iCAJ+bDqdsi1us9nwNM40Tfi+z1MxKSWLzjiOWfSQRY+iycuyRK/X4+umUCgUii8fhxBE/x2ACYA/CuBvAPj9AI4A/BSAPyal/PnDHffToQSRQqF4HaGbcuA6Fno8HnPgQpqmLAyoq8d1XU5067oOUkrsdjs4joO2bTkljSK3qbeIggUWiwWSJIGu6/A8D6PRCACgaRpPbihgoCxLHB0dQdM0PH36lAMUbkZuG4bBe0ckQqhINk1TlGV5S+h1XYemaaBpGsbjMZ+fzhPHMdvtyNrmOA5HbFMprGVZnBSnaRqCIIBhGNjtdqjrGkEQwLZt3LlzB7Zto6oqLBYL3rOSUmI0GvFnuRk/nqYpiqLgwAeaSlEKn2EYvP+lUCgUii8XhxBECwA/IqX8VSFEBOC3SynfFUL8CIA/KaX8XYc98idHCSKFQvG6QhMh2h3yfZ+tajRtcV2XE9A8z+PdHLJ+0c4M2b9oF2e/37PgAq7T7Ha7HcIwZNvceDy+lahG06LpdMp7QdPpFMvlkvuMaIqTpik8z0MYhiiKAqZpYjQawXEcFkWUjNfv91nEUbhDv99nEULR45qmYbvdslWt6zoWKzcFDU3ESGRRVHfTNNjtdryTNBwOce/ePdR1jSiKsNlsYNs2T39ot6iqKrYrCiF46kZTNiqjpe4iFbigUCgUXz4OIYgiAN8rpXwihHgC4J+RUv6fQoiHAH5dStk/6Ik/BUoQKRSK1x2ya1VVBQAY/f/svXusbHl+3bX2o/ar9t71rnPue3qaiSbW2JacBGxFiMQISP7ACBMpCk4INpEi/ogS8R9CIgkSiP8ihAQCbEisGJBQsEmCZJTYIOWPEBg5cSzGcdLumdtzb59z6rlr137Ufv744/T6dp3rGU933zMzfbt/HylK97n31N2n7shdS2t915pMxOHJ81xuZ/I8l9uXvu9lB6htWyRJInEyuhlZlokrBEDExPX1tdz4UEy4riuuTZZl8H0fQRBAKYWLiwsAwHvvvSeuEwApJHBdF4fDAXVdSzkBG9u22y3SNBW3hXE+OjEUHWVZoqoqLBYLZFmG3W4nBRSM28VxjKqqMBgM4LouhsOhiBkA4hYxLsfiiSdPnmA6naIsS/nZLcvCeDxGGIYi1oqikDrusixR1zUcx5H3Afhwh4llDxqNRqP5bHAfguj/AfAfK6V+2TCMXwKQAfiPAPw5AP+GUupL9/nAHwctiDQazZsAa6PZKDeZTKTh7Lxwoa5r1HWN4XAoVda80WHki6UFFAcUK67riuuUJAmyLJOa7PPq6aIosN1upaGN4iGKIiRJgqurKxFpjOtRHBRFgbquEcexxPzSNMV6vUZZloiiCJZlwbZt9H2PsixlKHYwGEhEcDqd4vr6Wlwm4DbeF0WRxPpc18V8Pr9TPMGIG6N1FJuj0QhPnz5FEAS4ubmRmnDbtvHgwQP5M+i+8V6I8cMwDKWym/i+Lw13Go1Go3mzuQ9B9FMABkqpv2oYxo8A+GXc3hRVAP60Uup/uc8H/jhoQaTRaN4UKB7omNi2jdFoBOBu4YJlWcjzHK7rwnXdO/s/jIexNY3lAVVVIU1T2ePh7cz19TUAiMAIwxCj0Qin00mEFAAMh0MEQYDJZIK2bUVU8Bk4ABsEAeq6xvF4lO8bjUao6xrb7RabzQZKKakW9zwPRVFIVTfdJwo7DrzSvaEjNR6PRQxOJhMsFgtpt+OOEF+fo7Su62KxWODRo0domgbX19fitLE1TyklA7UAZBOK9eCj0QiGYcimEtvtdD23RqPRvNnc+w6RYRgBgC8DeE8ptXnN53sttCDSaDRvGoxrmaaJsiwxm83kfiXPcwCQWFfXdXL7wm2fpmmkTpoCg9G6PM9RliWCIJBoHO+A6LT4vi+117zpYdlBHMdSb10UhewgBUGArutE2ARBgCRJRDQNh0MpRri6ukKaprAsS1wWipCu69D3vYzVKqUQxzGyLJOabbo0rC0vyxKmaeLRo0fwfR/H41GEnG3bslW03+/lXuni4gKXl5fiXJ1OJyil8OjRI1iWBcuyUNc1uq6T90UpBdM04Xke4jhGXdeoqkoa89hmp9FoNJo3Dz3MqtFoNJ8yuq7D8XiE67oiXNjaRsEThqGIJDouvA2iK3Q8HqWcAIB8yD8ej1JMwFrpq6srOI4jdzmTyQTz+Rx5nmO/398RTIvFAsPhEG3bYrfbYb/fy50QxdlgMIDv+1iv1xKjY6V4mqbiMnmehyiKZDOI8UHbthEEgbg10+kUL1++xOFwkL0h7hLx2aIowpMnT2Tn6HQ6yWhrHMcYDAZYr9dyv/Ts2TM4joP9fi8juWzNowhl7XjTNDgej1KwEEURPM/D6XQSh2w2m8lOlEaj0WjeHLQg0mg0mk8peZ6LwKnrGrPZTKJjLA5gwxydGgByQ8QP62ygOxc8ZVmiLEsMh0OkaQrf95FlmewNZVkG0zRxeXkJ13WxXq9lgPV0OonLQhFzc3OD0+kkjXHArdvFeNtutxORE8cxmqbBzc0Nbm5u0Pe93DHxe7MsQ13X8H0fg8EATdOIuHn58uWd4VeKMeDWDZvP51gulyiKAnmeS8Od53mYTCbyvnAziSKK7zddn/ObJcbmWPE9HA5h27bcXmVZJoJxOp3K82g0Go3m048WRBqNRvMppmkaiZ6laSpOC3B7a8ORVtZzU0CwmpubO3meo2kacTjYWsc6ahYk0EVhUcLhcMB4PMZyuUSe59Jox9jb22+/Dc/zpAL85uZGNoTOn2M2m8keEp0dCq/3339fXKjzex6lFLbbLZRSiKIIpmlKLC/Pc6RpCtM00TSNlDOw7MHzPFxeXiIIAqRpeqeAYjQaYTqdYrvdisAMggCLxQJN00gdN/egxuOxRBjpTq1WK3ieJ6OtcRyj73vsdjsopaTFTg+6ajQazacfLYg0Go3mDYCNaYzFTadTqaU+Ho/wPE9uagDcuetxHEfuijj8ypseFhEURSHbQMCt2GK5Ab/30aNHcBwHh8NBniNNU1xcXODJkycSU9vtdsjzXNrweKtEN+Xly5cAIFFAwzCw3+9xfX0t5RGLxUI2hfI8x263k9+vlELXdRJja9tWNpLOR1WVUnIT5fs+ttstuq6TsonZbCZ3R3xv4zjGaDQSNwyACKbJZCLv12AwwOFwwPF4RBiG8DxPhFFZltjtdlIAwTIMjUaj0Xw60YJIo9Fo3hCqqkJZljLmOh6PxckpyxJN0yCKIjRNI4Ottm1LlTSjdqfTScoVLMvC8XiEbdsybMrbIo6wMm622+3gOA4eP36M0+mENE0B3Io10zTxpS99CUEQYLfboWkaqe+mKKKIWSwW2Gw2cstEQVFVFbbbLW5ublDXNebzuewysRWvqqo7LtnxeJTYXtu26PtexAfFEcsVWMSQJIkIG8/zMJ1OYdu21JpXVYXJZILxeCwNfkopNE2D2Wwm0UM6VmmaSsyOYiwMQ+x2O/l7iOMYnufpmm6NRqP5FHIftdv/CMDPAvgFpdT+np/vtdCCSKPRfNY4r+dmO9xkMgEAGSUNgkCa4Lgn1LYtuq6TmmzeEHVdJ01uHFulS1MUhUTuzveGkiTBcrmE53niMtGtmU6n+NKXvoSiKHA8HnE6nbDf7xEEgWwC8U4pCAI8f/5cbnKGw6G8/na7FedmsVjA8zx4ngelFF68eCE/t+/7qKoK+/1enCM21LElzvd9cXAojLquk5+Zt0/T6RSO46AsSxRFgaZpsFwuEUUR6rqWCCDvlACg73uYpim3WsCHI7G82+KzeZ6H4XAo5RIajUaj+XRwH4LoPwXwpwAsAPwSgJ9VSv3KvT7lJ0QLIo1G81mFIsW2bWRZdmcPJ8syAEAYhjidTlJOQLeIcbIsy1BVlTTZua4rjXF0f/hnNU0jYoO13U3T4PLyUkQTBZlSCm+99RYmkwlWqxXqukaapui6TuJjFFOz2QzH4xG73Q6macqGEKN3aZrKgCsrvyeTibTb2baN8XiMIAiw3W5FLNZ1LXdIFHOM8HHjKI5jET502CaTCZbLJQAgTVMRfE+fPoXneeKW7fd7OI4jW1EcyqWIBCC/xvebQ690kDzP08JIo9FoPgXcS2TOuP2/6H8EwE8D+AkAVwD+BwB/VSn13j0968dGCyKNRvNZhjc8rusiz3MZDwU+dIt4o8O9Ht/3JQbG2yI6Rk3TYDqdIk1TKRVgkQBLCbhLZBgGgiDAarXCcDjEeDwW8cU/ezQa4a233pKWOdM0ZTjWtm0pgwBuxdvV1RXKshTBANyKkjRN5Y4piiJEUQTXdRFFEa6vr6WoYbFYwDAMvPfee1LL3bYtbNtGnudS/80mPL5fFHh93+NwOMAwDGnROxwOKMsSm80Gnufh2bNnIqq6rkOapuL8MKrHYdqu62Capjhftm1LayCHXeM4huM4WhhpNBrN95HvxjDrFMCfBfAXAdgAfgXAX1FK/fLrPOgnQQsijUbzeYBjrnSLznd0siyTEgU6PWyBq+taXKXj8YiqqqSCOwgC2ezhfhFvgLgNxO83TRNJkiAMQwRBILEyukJPnjzBYrHA9fW1FCBQyLFxjhtAbHDr+16qrXmPVJYlqqpCXdcSbxuNRlBKyYjscDjExcUFNpsNVqsVAIizYxiGiBXeX9m2LVtIHH4tyxLH4xGDwQBPnz7FeDzGbre7U6Lw7NkzcbR4lzUYDDAcDuG6LsqylJ0lij5G/mzblp+r73sRgPy70Gg0Gs33lnsVRIZh/CiAnwHwxwFscesSPQDw7+A2SvcXXu9xPx5aEGk0ms8LHFz1PE9GXeM4BnArXIqiQBRFAG4FFF0OOkGO40gLHXd6FouF3AHxfoY7PedO0el0wnQ6xeFwQF3XGI/HUkLA5wrDEI8fP4ZhGFitVnLjxEFVFg4opaTJ7nA4YDAYIIoiGIaB3W6HJEnEuVJKIY5jaXPjvdLpdMJyuUQYhnjx4gWSJJEWPpZIsFVvNBrBtm1YloUgCCRa2Pc99vu9bCl94QtfAACJ6vFnfvr0qTg8/HnoXlmWhSRJoJTCcDiUoVhWd3NQl4UQjPVpYaTRaDTfW+7jhmiJW8Hz0wDeBvA3Afx3Sqm/c/Z7fgzA31FKhffy1B8RLYg0Gs3njaIoRKgURXHHLeJ9DV2cuq5FiHDLB4BE5tI0heM4GA6H2Gw2GAwG6LpObob6vpeBU+4NRVGE9Xot/8w2tsPhANM0MZ1OMZvNkCQJyrKE53kSU/N9X8TFYDBA27YSWWMxwul0EgfJsiykaXpn8NW2bbRti/V6DcMwpBHv5uYGeZ4jCAIRHPv9XgQcG/dc14XneXAcB77voyxLea0HDx7g8vJSXKzdboeu6/DgwQM8ffpUYm9lWSJJEkRRJCO0aZoiCAJ4nidiji11vI06b/QLgkCPu2o0Gs33iPsQRDWAdwD8HIC/ppTafIvfEwP435RSf/g1n/djoQWRRqP5PMIbHtd1kWWZRMKAD6u7OSR6Op3ELaqqSgZV67qWGB3LD+genZcEcMS0qio4joMsy2RvaL1ei7gAIE10URRhPp/LCCwjZJvNBr7vYzgciigyDAN1XYv44GhrmqbY7XYyfMpbniAIEEWRCKOrqyv4vo+HDx9it9vh+vpahl7pUjFWOBqN4Pu+1HW7rivxwdVqhSRJMBwO8ejRI4n5bTYbuYt666238OTJExRFIfXeaZpiNpthOBxKEQXruff7PSzLkhKGy8tLtG2LPM+llU4LI41Go/nucx+C6F9USv29e3+ye0ALIo1G83kmz3OpnmYEjrE0uj8UQoxsGYZx55+zLJObGpYArNdrWJYlDgfrplnz3batFDTkeY7j8YjhcIi+7xGGIbbbLYDbO54oimTTaDwe43A4IM9zTKdTEQJhGMr90Ha7heM4iKIIVVXh+voap9MJk8kEh8NBdn+iKJK43Xa7xX6/x3w+RxiG4u5wA4l7S0VRSNTQdV0RJZ7nYTweo6oqbDYb2Sm6uLiA53kizlju8AM/8AOyB+X7Pl6+fImiKHB5eQnLspBlmTh1g8EAu91OyhaGwyHm87kIUY7Lskpdo9FoNPfPfQiiXwXwk0qp5JWvxwB+SSn14/fypJ8ALYg0Gs3nnXO36Hg8IggCaXBjGUMURTLGapomHMdB0zTi3LAEgR/S2Q5HAWCaJrIsk4Y5bvawVCCOY9zc3IjQ4vfsdjvEcSzlCWmaintD0TWZTNC2rdR1syY8SRKMRiNxYlarlcThdrsdAIiYoaB58eIF8jzHcrmEaZpYr9fSzscKbFaRs+yB7lYQBAiCAOPxGPv9HrvdTsTTbDaDaZrY7/dIkgRFUWA8HuMrX/kKAEhk8eXLl+j7HsvlUsol6AIppbDf79E0DUzTlGHYsiylRv38xkmj0Wg098d9CKIOwAOl1OqVry8BvFRKfd+8fi2INBqN5hbWSgO3Qohu0Xl197lbxFsejrnSZcrzHHmeAwCGwyEOhwP6vofv+3J3BEAKBLquQ1mWmE6nME0Tm80GpmnCNE2EYSh12LyjoYCL4ximaeLm5gaj0QiO40AphTAM0bYt+r7Hzc2NCCjeDZ3H++hYsVAhiiIEQYBvfOMbUEphsVggz3McDgd0XSdjqhynresaw+FQSh1Y4jCdTgEA6/Va3qs4jjEajdD3PZIkQZIkaJoGjx49whe/+EUpUSiKAtfX1yL2mqbBYDAQx6htW6xWKzRNgyAIMJ/PZSSXThzFGWu+NRqNRvN6fGJBZBjGj3zwj18F8K8C2J39sgXgXwPwZ5RSX7ifR/34aEGk0Wg0H/KqW8RoGfDt3SKWG9AtojPEeyLf9wEAh8MBjuPAdV1pm2uaBk3TyN4RAEynU5xOJ2lf830fvu8jTVOJ5NE96boOi8VChM6DBw+kCIJ14BQQrBYvy1IERxzHUhBBUce9IsbtWHmd57k051mWJf+PzXEccmW07eLiAlEUyU7SYDCQAorhcChV4Wzme/bsGS4vL6VlLkkSbLdbuVOybRuO48C2bfi+j9PphPfffx/AbbRwPB6LoNLCSKPRaO6X1xFEPQD+hm+1KFcC+HNKqf/+tZ/yE6IFkUaj0fxOvpNbdF4HTeeEbg+FBTeLTqeTfJ0lC0EQwDAMbDYbdF2HqqpEWJ1OJ8RxLO1yfJbpdAqllOwRnb8eXZrnz59jOByKS+R5HmzbhlIKSZJgv99LGcJ+v5dmt/NhVt/3xdGaz+fIskzKHAaDAcqyvFMp7jiOxPLatkUcx9Ke57ouHj9+DABSJW5Z1p3GvLZtkSQJTqcTgiDAgwcPcHFxAdM05T1KkkQqtylwbNsW4UrhNp1OEccxBoOBuHWGYcj3mab5/fyflUaj0byxvI4geoZbIfQugH8ewPrsl2sAK6VUd4/P+rHRgkij0Wi+Na+6Rbz1ASAFBnREuFX0qlvU971E6E6nkwiCNE1hmiZGoxH2+z2yLEPXdWjbVkQHANkA2u12OB6PcBwH4/FYnKUwDCXCp5TCbDZDVVXY7/cioPgsjuOg6zopWWApwn6/BwAYhiG3ThRRlmVhPB5jNBphs9kgyzL4vo+u62TUtus6uatyHAf7/V7a7obDoewoPXv2TLaTWKjAKJzrutKUp5TCaDTCbDbDxcUF+N9ZttVxw4hlD6Zpwvd9bDYbbDYbBEGA0WgkTX4cgDUM486ek0aj0Wg+Ovc6zPppQwsijUaj+d151S3ibtGrt0WMp7Fdjns5AGRnp6oqKQVo2xZVVWE4HMKyLGw2G9R1jb7vYRiGiB7XdcXxYVPbZDKRrSTgthyBjXkcU+X9zmw2u1MAMRwOkec5rq6u5M9P01R+D4dl67qG4zioqgq+70vl9mq1EgHoeZ4USvBnZ6Rvt9vBNE2Mx2N5v6bTKR49eoRvfvObME1TxlgZv6MQ2+128DwPvu9juVxiOp2KI7XZbGRYdzabIQgC+btyHAer1QpZlkk0bzQawTRNidJZloXhcKiFkUaj0XwMPpEgMgzjJwH8LaVU88E/f1uUUv/r6z/mJ0MLIo1Go/nOcPtmMBjIbtG3c4uapgEAuSeiEFFKyW0QHRbWWRuGgclkIu1wFDqmaYpI4od4jqh2XSeFAlmWwTRNuemxLEtKGtbrNVzXlaY2xtVc10WSJOIY0c2xLEsKH+q6FgeoqipxXgzDkJibbdvidFGU8WtlWeJwOMC2bXGslFJ48OABoijC9fW1vI8URrzLOt+DsixLbpJYk75arZCmKeI4xnK5hOd58r6ynKKqKnGURqORvN9lWUpphRZGGo1G8535pIKoB3CplFp98M/fDqWU+r5de2pBpNFoNB8dfuA3TfPOFlDf9xJp831figIY6VJKwXVdALfiioOuLEZg7I4V03RB+r6HbdtomkaieLzlORwOWK1WcF0Xi8UCjuPgcDhgMBhIc10YhhJPY8U3t4u6rrvTBnd9fS3PS0fneDzKbZRlWSL2GEtrmkY2mFhgsN1ukee53CGNx2NkWSalEPwzTdPEkydPUFUVTqeTlFWUZSkC0vd9eQZWfy8WC2mbA25vk4qiwHw+x3Q6lcIFvv/H41H2k7jrxL9LCkDtGGk0Gs3vjo7MaTQajUagW+S6rrSnTSYTAHeb6JRSqOta7ngobriRU1WVFBEwpsYP+ePxGKfTSSJyg8FA7mEMw4Bt21LMsFqtsN/vMZlMZLCUzk1RFLBtG+PxWGJ6ZVlKkQIb7sbjMdq2xYsXL7BaraTpjbdDbdtKDJDPTvF3XqpQFIVsCDGyZ1mWNMUdDgeUZSk13BSKi8VCooRBEKAoClRVBdu25efldpNlWbJ35LquCMX3338fTdPg4cOHiKIIjuPgdDrJ93Hc1nEccboA3HGMhsMhfN/Xwkij0WheQQsijUaj0fwOiqIQoZDnOSaTiWwB8YP3q24Rt3rYRNd1HYqiQJZlUEqhaRp0XSdCZTQaYbvdSlEBxcK5uOI20suXL9F1HZbLJSaTiez8ALdCjbXUlmWhrmu5HwJub5ziOJZa7nfeeQdJkogo8n0f19fXElfjqCyFE0XRcDjE1dUVAGC5XCJNU+z3eyil4DgOLMuC7/vY7/c4nU5wHAez2Qx932MwGGA8HktjHyN9/O8sSyEoVs4rvOl6GYaBly9fwjRNPHz4EGEYSoywqiqEYYiiKKS1bjKZyAgvB2fZSqeFkUaj0XzI69wQfST0DZFGo9G8mZxH5XgLNJvNANzexPBDOHArOvq+h2VZd9rfAKCuaxlwpYvDexuOme73eyRJAsMw4LquNOAppeB5HjzPw3a7lWHXJ0+ewLZtbLdbmKYp4oglA4yjtW2LMAzF/RmPx7J79LWvfQ1FUcD3fTx69AhpmmK9XotTQ0HHCmy+PgC8//77CMNQRB3fn/PK7P1+L+KPwsg0TcxmM3ieJ+8Biy0Y6aNoAiD3UK7rynBs27a4ubmB67p4+PAhXNeFaZo4Ho9omgbz+RyHwwH7/R6e52EymYg4PBdGjAFqYaTRaD7vvM4N0UdB3xBpNBrNGw6jcoPBAMfjEXEcw/d9cYsGgwGCIJCSAsP4cJqObhE3hugWcWOI7kocx7IJxM2eqqqkOICRr77vsdlssNvtEIYhvvCFL6AoChFcrOumAxIEAZIkAQBpfXMcB5PJBJ7n4cWLF/jN3/xNcZ8ePHiAFy9eyE2Q67riWjmOI87XxcUFkiRBlmWYzWYwTRPb7VZ+Jgox27ZxOBzQNI3cCJ2PtXKrqK5rueGiIxQEgdR3c3OJjhVviVjF/fDhQxloPRwOME0T8/kcu90O2+0Wvu/faa1jVboWRhqNRqMjcxqNRqP5CPR9Lxs+POqfz+cAbh2gsiwxHA6lvQ2AxMEGg4G4RSxd4P0R3RGlFOI4ll2i7XaLvu8RRREOh4OIE8bSjsejODPL5RLL5RL7/R5FUYiooIAajUboug5JkmA4HMJxHJRlCdd1MZ/P4TgOfv3Xfx3vvfceXNfF06dP4fs+3nvvPam4NgwDWZbJc5xH4na7HQzDkN2kw+EgIvD85oqizfM8TKdTue358pe/LNXZdV2LyKTjRLEYBIFUnbNNz/d95HmO4/GIKIqwWCxgGIbUhfMeab1eY7/fw/f9O1E6CiMAeuBVo9F8btENcpDfAAAgAElEQVSCSKPRaDQfGZYaOI6DNE0RhiGGwyGUUtKYFoah3AvxvyOMwlEoVFWF4/EI4DZ+VxSFfBCfzWYoyxLb7RaHw0GE0PF4hO/7sCwLg8EAjuNgs9mIA8T4GKu9Kaj45z948ABJkuBwOGAymcA0Tanknk6n6LoOX/3qV7FarTAajfD222/L/VJVVYiiSKKCjuNIBHA0GkmxwWAwuCNu+Gf0fY8wDNF1HY7HI5RSsiPEhryvfOUrsunE/991XdlfsixLnCe27SmlZJD1dDqJMJpOpzAMQ/6+hsMhoijCer1GkiQiyhilK4pCSi183xdxq9FoNJ8H9A6RRqPRaD4WdHboRFRVJYOuTdOgKAppeuPmEO9lBoPBnWrs8+hWmqao61qqotl0t91u5UP9eY01ywnqusZut8PxeEQYhri4uBCRVVUVLMtCFEWo6xqj0UiGXU+nE8bjsdSCz2YzjMdjrFYr/Nqv/RqKosCDBw/w5MkTbDYbvP/++3LPlGWZOFGMyU0mE2mFs21booYUMnmeA4DcNKVpKiUH3EkKwxA/9EM/hDzPsdvtcDqdcDqd5OYoDEOJ7VEYsV6bu0N07OgOtW0rN1ae5yGKIqxWKxmInc1mIozyPBcxyefSwkij0XzW0TtEGo1Go/lEUPxQuJwPuvIehmOjrNzm5g/dIuDWdWJ0jlEvNs1RsOz3eylUYMU142RsccuyTO514jjGeDxGURQoigKn00k2gtq2xcXFBWzbxs3NDZRSmM/n8syXl5fwfR/vvPMOvva1r8E0TTx79gzT6RQvXrxAkiQYj8eo61riZoZhSIGC7/sAIGOxx+NRxNPpdJICBs/z0Pc9qqqSXaIgCFCWJebzOX7wB38QSZJgs9mgKAr5cxzHkXsmRvUsy5L2vyiKEIahCCPXdTEajeRZWc4QhiE2mw222y1c15UbIzYLlmUJAOIY8UZJo9FoPmvoyJxGo9FoPjEsS2CDGiu62YbGOJjruvLBH4AIBMdx5HX4IdwwDOR5LjE6z/OkMnu1WslrGoaBw+GAOI6lkc40Tex2O/le/lpZlvLaFAeO4+Di4gJlWWKz2cD3fcRxjMPhAMdx8PDhQ1RVhX/yT/4Jnj9/Dt/38dZbb8F1XTx//lwKHCik6IKxepxtdZ7niRvGFjpuFvHfeZvVdZ00yzVNg8vLS3z5y1/G4XDA1dWVNMT1fY84jkUU2bYtN1NZlok4fVUYsYyBFeUsqzgXRvP5XAsjjUbzuUILIo1Go9G8Nl3XIcsyOI6DoihgGIY4Mtw0CsNQ9oj4PYy9MZbVNI24RX3fY7fboW1bOI4jrW3H4xGr1Qpd191paRuNRlL7Xdc1NpsNAIggO9/siaJI9oYmkwmWyyVubm6Qpimm06nUZkdRhPl8js1mg9/+7d+W+6IvfvGLKMsSV1dXcBwHtm0jz3MopXA6neTn6vtehAgdoqZppNabMUHTNGFZFhzHkR2lMAxFGD169Ahf+tKXsN/v8fz5c3HXKGgojBg3bJoGZVliMBhgNBphMpmgrmsRS47joKoqKZzg6+x2O6zXa4nSBUEAy7JEoJ47WYw+ajQazZvOvQgiwzB+BMBfAPADH3zpNwH8FaXUr93LU35CtCDSaDSa7y3nFd1ZliGKIvi+f6eljhXd3AZq2xaDwUC2fvg6FFZVVcmIKV2cuq6x3W6RJIkICb7+dDoVJ4W3OHQ8zp0l7ipxF2k+n2M4HOLm5gZFUeDi4kKcndlsBsdxcHNzg5cvX2K322E2m+Hp06dYr9dI0xS+74uY4V2SbdsyYMu7KMbrgA+jdsfjUSJtFE903niPZRgGHj58iN/ze34Prq6u8PLlSwC4s9VkmqYIxVery0ejEWazGaqqkiY7y7JgGAbiOEbTNHeqyrnJRMeId1GsTvc8785wrEaj0bypvLYgMgzjpwD8PIBfBfD3P/jyjwL4cQD/rlLqr9/Ts35stCDSaDSa7z0UPyxZaJpGtnpYinBeusCSAEbNWNHNYVjWcqdpKq/LZjXG6OiGMObFVjU2vCVJgrqu4fu+3OE0TYM8z0W0MYrHBrrVagWlFC4uLqQ1joIiSRK89957OJ1OWC6XiONY/oxzMXPu9vD9oJPFxj2Kvqqq5N6J4o2vRTHIeN3jx4/x1ltv4fnz51iv1zKG67quiL62bWXUtWkaacebTCa4uLjA8XhEmqawbVtEJSN23CdK01RGYDnwytpy/t3QMWL8UaPRaN407kMQfQPAf6uU+s9e+fp/CODPKqW+cA/P+YnQgkij0Wi+f/B2xXEcHI9HcSnOW+qGw6GULlAw2bYtH+r5OlmWycYRhYfruojjGJZlYb/fy3aRZVkiRjgiyyHYzWYjkTE6KXQ8ptOpCLg4jjEajVCWpThMo9EIWZYBuC1MYGHD8+fP0fc9Li8v4TiODKMCkF0kCrPRaISmadD3PSaTiYgi7g5lWSYV2IzWsZyBbXasHrcsC8+ePcPDhw/x4sULbDYbEZWmaWI0GslYruu6UhXOevDpdIrHjx9jt9shTdM7Iox3T/xZj8cjbm5uxIGj20VhxNunIAjuOH0ajUbzJnAfgigH8MNKqXde+fo/B+AfK6WCe3nST4AWRBqNRvP9hWUJdEJ4s0OHpigK+L4vNy0ApG2OH85JlmVSo02h0nUdJpOJ3OusViuJ2vF1bNvGaDSCYRjS8pZl2Z2YGACp7Q7D8E4pQxiGSJIEWZbJfdHhcIBt2zBNE23boigKfP3rX4fruphOp+j7XgQFRUhVVSjLErZtI45jiciNRiOYpimCpKoqqSOv6xpFUUik8NxNo3C0bRtvvfUWRqMRdrsdrq+vAUAqzlk5/mo0kZXgi8UCDx8+lAgiiyf4/U3TiGOU5zlWqxUMwxDHiNXnWZaJK+V5nrTtaTQazaed+xBEfxvALymlfvaVr/8ZAP+WUuqP3suTfgK0INJoNJpPB6+WLiilMJvNANzeC7VtK+UALBlgdMv3fREtHDblP6dpKgJoPB5LnGu1WskH+bZt5RZnOBzK/dJqtQJwK0iKopCmt6ZpcHFxIZXYrutKVGy/38vgK+NsXdeJC7Pb7XB1dSUbPm3bSoECnTGKI8/zEAQBmqYRVwYAXNdFGIY4Ho84HA7ouk6idLwTYrNc0zRyp2TbNp4+fSrV3S9fvhTRdt7Ux+8Jw1CGYymMLi8vsd1usdls4DgOZrOZ1JqzQY9NddfX1yKehsOh3IZlWSY/E10jjUaj+TTzOsOs5AGAvwTgbwD4vz/42o8C+EkAf0kp9V/d29N+TLQg0mg0mk8XFAOM0QVBgDAMpbyAH+7btkXXdeLqsCnu/HXotuR5LqUE/OBv2zb2+z0OhwP6vpeYGtvUgiAQt4jPYZqm/J7j8YjBYCDtbBQCjKMxFndeNkAnx/d9XF9fS1sbnRLbtkU8UcgppTAcDuXXHMeRuCBF1Xa7xW63g2EYIozYbGeaJmzbFreHAmSxWGA8HkvUje17/Nl5E0X3jO8jSxQuLy+x2WywXq8RBAFms5m4bfxswLIIOlKj0QhBEIjIy/NcbqooKhmD1Gg0mk8TrzPM+lHQw6wajUajuUPf9zJO2nUdqqqS7aLfrXSh6zqpgSbH41HciMPhgMPhAAAS5TJNEzc3N7LxQ+HAnSC6Kby/CYJAomW8EWJMrqoq+XA/GAzk2elisaqb0TrTNHF9fS0bRxxUPW/X22w2civEwgfuAzmOI7E9tt/t9/s7JQyM2rGM4nQ6yVgr754uLy+x2+2w2+3kfYuiCK7ryr0S77tc1xUxOJ1OcXl5ifV6jdVqhfF4jPl8jtPpJMUXvFnqug43Nzdo21ZihkEQiKPHaKLruoiiSAsjjUbzqULvEGk0Go3m+wJviDzPw/F4hGmamE6ncncE4E6hAEsX6MzwQ/V5jK7ve6RpijzPRUxYloWqqrDdbsV5ottBR8a2bSRJgiRJpHSB0TK6TIvFQkSH4zh3KrQp2jhcenNzI/dNSikRM9wkomNDZ2a9XksMjm1tdIpYoDCZTOD7Pl68eIE0TaGUuiMuOc4KQNwquk+z2QyLxQLH4xFJksj2EIUco3yu68rPSccojmM8ePAANzc32O12mEwmmE6n4tCxGMJxHCilcH19LRFItv0ppUQYAR/GAvXIq0aj+TSgBZFGo9Fovq9wuNW2bWRZduf+5jyGxtsfxujoupDzGF1RFPIhn/cytm1LdXff93K7FMexODJKKazXa9R1jSiK0LYtgNu9IIolFjQ0TSO11m3bSnFE13USA7y6uoLruhiPx2iaBldXV0jTVO6HiOM44uJQFPV9L8KLNzymaeLi4gKO4+C3f/u3UZYlgFu3ic19bN9r21bqyMMwBAA8ePAAk8lESinY7kdhlKapOEYPHz6EYRgoyxKWZSEMQzx48ACr1QpJkmA6nWI8HktNuGmadxrzVqsVTqcTwjCUv1PWoldVha7r7kQcNRqN5vvFfQ2zTgD8UQBPAdwZIlBK/Sev+5CfFC2INBqN5s3g3Olo2xZN02A6ncKyLGlbY3EAXaK2bdG2rZQDAJDiAsbe9vu9FAmwEtowDGw2G/l+ljJEUQQAcsP0/vvvS+01yxV4wxOGoZQ98NlY6MBK777vMZ/PsV6vsd1uEUURJpMJiqLA9fU1siy7I4woKjabDQ6Hwx3BRFHI1waAhw8fwrIsEUa8JWKN+Lmw5K/zPXz48CHCMIRSCqvVSoQRb7V44xQEAR49eiQCkFXm8/kcSZLIjtNkMkFVVSLa+Mzcc6KAZZRuMBggz3O5o3JdV1d2azSa7xv30TL3owD+dwAVgAWAl7gtWqgAfEMp9UP397gfDy2INBqN5s2CNdOu6yLPc1iWhfF4DKUUiqIAcDdGxwpuy7IkLgbcOiaM3fV9j8PhILXejKy1bYv9fg+lFKqqQpZl8oGdrXSHwwHr9RpxHEMphbZt4fs+0jSViBxvfxgbo3jgcCxjZ9fX1zgejxiPx5hMJtjv97i5uZGSCc/zJGrWNI38mud54oz5vg/P8+S1DcPA06dP0XUd3n33Xaklb5pG7ql4G0Shads2BoMBHMfB5eUloiiCZVm4urqSJjm23tExGg6HePz4sWw8USyNRiMppxgOh5jNZqjrWv4cvpZt29hsNsiyDEEQwPd9DIdD+TnyPJdSCd/3dWW3RqP5nnIfgujvAfiHAP48gBTADwPIAfxPAH5OKfUL9/e4Hw8tiDQajebNQyklcbZXY3RN04gL43mexOhM00RZlr+jjY7bP6yX5pYRBYFlWRKtO6/Fns1mcr8TBAGeP3+Ouq4xm83kPsmyLBFpvA0aDAao61rid/y14/EosbSrqyu0bYvxeIwwDHE4HKT4gfXerPE+nU4SbeNGEQApWmBb32AwwJMnT1AUBV68eIG6ruW9ZBEDt4WapkHXdVLeMBwOMZ1OMZ1O0XXdneIGljUcj0eUZYkoivDgwQP4vo++73E8HiX2xnY+13Uxn8/RNI2MwNL9GgwG2O12d94P1qGfTicURSFiiq+r0Wg0323uQxAdAPwBpdQ/NQwjAfBjSqnfNAzjDwD4H5VSX7rfR/7oaEGk0Wg0by6vttHVdY3xeHxnL+g8RkdnpGmaOwf7LGlgkQBdDwouxuiSJJFbIA6ULhYL1HUtjXXvvvsuHMdBFEWyXQRA2t1Ys81In23bsuND8cX7os1mI1G98XiM6+tr3NzciHAYDAbo+15qvRmFOy+XGI/HUpu93W7l9ifLMmw2G1RVJSOx+/0elmXJ72esj69JYbRcLtE0jdxacaeIovJ0OiGOYyyXS4zHY1RVhTRNpdQhiiIcDgfZNqIwYjkEcFsYsd/vkaapCEnP8+Rui7FH3nadxyI1Go3mvrkPQbQG8Ac/EES/BeDPK6V+2TCM3wvgq0qp4Xd4ie8aWhBpNBrNm09d1+IK0ZGZTqdSjEAhAkDchaIoYJrmHYeBW0dsZzsej+K4sIyAzXeM0SVJAt/3MZ1OUVUVgiDA8XjE1dWVDMsWRSEf9ruuk7gcb2VYzABA3J+2beE4Duq6xvF4RN/3mEwmiOMY3/jGN0RQcGcIgAgSvgemaaIoChEM8/kcfd9ju93C930sl0uUZYkkSXA8HqUg4TxiaNu2tPCx9c73fczncyyXS9R1jaqq5O+g6zoRU7ylWiwWuLi4QFmWEkGM4xiz2UxE33K5lPeKzhvf8+PxKC2DjMzxvokFDACksls302k0mvvmPgTR/wHg55VSv2AYxn8D4PcB+C8B/EkAoVLqx+7zgT8OWhBpNBrNZ4eyLGVMNM9z+L6PKIokRkeXgdXajLTxQzbh1hFjdhRJFEosT+CN0uFwwPF4xHQ6lcKFMAzx8uVLZFkmo6UUFUEQoK5rKVugu8HqcOB2pLVtW/R9D8uy7giP2WyGMAzx/PlzHI9HEUSGYUg8sKoqeb22baUyezweYzab4XQ6SSteHMfigNF5qetaXC3XdSWCSEfOMAwEQYD5fC4uD0sozneFAEicbzab4dmzZ0jTFPv9HnVdYzKZyMhr27ZYLpfy90f3i8/AZkD+HXDMdTAYIMsylGUJpZS4cLqAQaPR3Bf3IYh+P4BIKfV/GoaxAPDzAP4ggH8K4KeVUr9xnw/8cdCCSKPRaD5bnMfoGOeK41iGU+u6hud5cstzHrejIwJ8eKfED/ZpmkpFd9/38mE9TVMAt2Jku92i6zosFgt5jcFggG9+85sAIHXWjLNFUYQ8z6WIgcUMdLEoKLhjxGgbY27T6RSO4+Cb3/ymCD4Oy/K/zxQqvPlp21ZueKIokrIIRvCGw6E4Royy8TUty4LnefJ7AIiTNJ/PMZvNJGJX17UUVZimKaUSg8EA8/kcX/jCF5BlGXa7nYzbPnjwALvdDlVVYT6fi9t2fs/kOI48M4UWXasgCJDnOcqylBjiq/XlGo1G80nQO0QajUajeeNgi9xgMJBNm8lkAgBSkOB5ntRi8w5HKXXnHqXrOvl613U4HA5S2X3uwHAPqe97iYGNx2OJtNV1jRcvXshOET+4B0GAMAxlDDWKIoRhKC4W74VYDsHnYOyv6zpcXl5K6xxHYSneuq4TcUTH6dxJWS6X8DxPonbcNloul9jtdtjv9+I28XX6vsdwOEQQBEjTVMQHW+RYvsD3ltXmdHqAWwE5nU7x9ttvoygKrNdr5HmOxWKBxWIhd1zT6RRxHEs0ju8n3+skSUTMApD3kz8PxRRjgxzr1Wg0mo/DvQkiwzDeBvB7P/jXryml3r2H53sttCDSaDSazzaMv3HXxrZtjMdjiZGxNKHveyk54O87r+lm7I6jr3Sh+KEfgMTgWAmeJAmCIJD9Itd1sdlssN1uMRqNEASBRMfo9iRJgr7vMR6PJd7H5xoMBiLm6G45joM0TWWQ9Xg8YrvdStSO90B0mUzTRN/3shnE+vDlcimxva7r5O7p0aNHSJIE+/1eBnIpyrquk+fknZNhGAjDEHEc4+LiQpy0uq6x2+0kfhgEgcQC5/M5vvjFL6Kua1xdXaGqKkwmE0ynU9R1LZXdvNPinRFbAA3DwG63Q9M0GA6H6LpOhBGFMX9+13XvFGpoNBrNR+E+InMzAD8H4CcA9PwygL8N4GeUUtt7etaPjRZEGo1G89mHG0X8wF4UhdR0V1Ul9dGu64pIoPA5r+lmkQI/XB+PR+R5LoUNFExlWQKACByOkwZBIA7Fzc0NiqLAZDIRodS2LR48eAClFHa7HSzLQhzHCIIAp9MJXdf9jj/rvCI8SRLYto3JZII8z3E8HkUMUkjRuWGs7nQ6SQQwCAJx0fi1NE3hOI4Io8PhcOd+ivdGo9EInufdqcX2fR+j0QgXFxcAIE7XdrvF4XCQOyTHcdA0DUajEd5++230fY/3339fRl6n0ymUUlLZvVgs5FYJgLQAWpaF/X4vUTq6XRRAeZ7jdDrJ9/DP1mg0mu/EfQiiXwTwJQB/FsA/+ODL/wKA/xrAO0qpn7ynZ/3YaEGk0Wg0nx/ofJzfDbFimvc1vElhPOtb3RfxNomiYb/fo+s6+L6PpmmkPIGFDXQw6Fywdruua1xfX6NtW3GIrq+vxZk5nU44HA5S400BAtzWUvPPouPjeR4Mw5CoIHeY2BwHfBgXpHPDcVTe3dDh4bgtCxQ2mw1c18Xjx49xPB6x2+3ufA+fI4oiDAYDEVt0ZVjmQPHSNA32+z2SJIFSCsPhUFr8RqMRHj9+jMFggKurKxGCcRzLrhIru1lqwV0mwzAwGAyQpqmIRbpIHMlle6C+M9JoNB+V+xBEBYB/WSn191/5+o8B+Lu6dluj0Wg030tYnc0oFyNqdIAYx6JosSxLhEQUReLysDkOuBUaaZrKB+8sy2Tz6HQ6IYqiO7/H9314ngfLsnA8HkUIsRqbAuTRo0c4Ho9I01TEFABpkwuCQAQPxYnjOCLazssZiqJAXdd3HDMAd/Z/zh2yKIpEBLqui67rsF6v4bouLi8vUVWVROm6rpP3li17vu+Ls8NoYhRFWC6XstvUNA0OhwN2ux36vpexVYqgy8tLRFEkDhpvsyiMAGA+n8P3faRpirqupXyB7XP8O/V9X6rR+ffBvSnTNCVOp/eMNBrNq9yHIHoO4F9XSv3jV77+wwD+llLq6b086SdACyKNRqP5/HI6nVBVlRQU8L6Izsur90Ws6bZt+078ra5rNE0D4FZ0HA4HuK5750M6HSgWKlAkDAYDieTx/odNbHyt4XCIy8tLqfeeTCZ3ChM4mspIGD/g07GiWAEgN0fnt0J0gtjkBkAa7SzLkjFUABgOh1BK4fr6+k58LU1Tacyjc9Z1HQaDgVRgUwxS9Mznc4RhKO9vkiTSXuc4jtxwOY4jDhPb79q2FceIcULuNBVFISKNt0p1XctwbRAEqKrqd+wZ8S6LcbrBYPC9+R+iRqP51HMfgujfA/BTAP6UUurlB197BOCvAfiflVI/e4/P+7HQgkij0Wg+37zqlrD5jfdFLDRgnIvOTFmWcF1XbnroLnVdd2fTJ4oiuK6LJElQVZUUNkRRhCRJpPSA2zl1XSNNUyRJIvXY5ztHi8UC6/VaigcAiOCxLEuqqvM8BwBxSnj3RIcoiiK5t2GsjqULjOZxlJVFClEUiYNEJ2W73YprYxgGsiwTMcIRWlZu0zXi/ZDjOOI2RVGEruvkbulwOMjfyWg0guM48hrL5VJKLs43iRhvjKIIk8kEXdchTdM7UUillPz5fL9ZHe66LrIsk/eId1DnG1UajebzyScSRIZh/AaA8198C4AH4OUH//4IwAnA15VSP3R/j/vx0IJIo9FoNMCH90XArTvCD9bcvem6TsQFW+Uognzfl+N8fi8/3LP9jIJhv99LSx0jWvv9Hk3TSDmC53nIsgxZlklUbjabyWbPYrFAFEXSJjcej0V8MPrlOA4Oh8OduuvzLSAWMIxGI2y3W3G5siyTuyc20lmWhcFgIHXjnuchTVMREpZlSeQtDEMRj4fD4U6bnWmaUvc9HA4lrsbnXS6X4kYppeQ94L8Ph0MZ2nUcBxcXFyIAGZWjq0RhSzeNm0iO44jQY2U4f96maSROx3jhq3E6Xdut0Xw++aSC6C9+1D9AKfWXP+GzvTZaEGk0Go3mHDoPrKpmzI3uCgA51OeHcH7gpzgAbu+LuN1TVRV2ux0AYDaboW1b7Pd7+SBP4ZUkiYgO13WlHOB4PKIsSxEEbI9bLpfwfR+bzUZcJ5Y90HWyLOuOE8UYHcXdarWSwoLdbifxPt4f8Wfh/g9rrVlUwE2jKIpgmqYUHDDyRsenbds7d050dobDocT3lFLwfR+z2Uxuuvj3QdepbVsEQYDxeIyqqmBZFiaTCRaLhbyfFE9KKYk6TqdTKVTgczBOdzwexRFzHAdFUUicjrdY/LvXcTqN5vOJHmbVaDQazeeO8/0iNrTRiWHMiq4QnRkWLAyHQ7nFocvAONl+v4fjOLKps16vxalg412WZSIcGNc6Ho8S5zpvS+u6TjaE9vu9RLwoVM5FDIsJGFWrqkqiZKvV6s5I7Ol0EiFg27bcBFFI8PaGLhIjeiydoMNimibiOJZyBTpxjPmdR944jgsAvu8jjmPMZjPZXeJ7z1IM3jDx16bTKZ48eSLOUt/38H0flmXJXdN4PJboH2+pKHBYTsG7J4rIV+N0AORGS7fTaTSfD+5zmPXHAfwAbqN0/59S6v+6lyd8DbQg0mg0Gs23g9XRFAVFUWAwGCCOY3GPKIx4M2OaJk6nk9zzMKbGD+2macrQaRzHGI/HyLIM2+0Wu91OYmx930s1NCNb3N7hFpLneRLh6/sei8UCXdchyzLZ2KEw4p1PURRIkkQKD/j9URRBKYXVaiUbTawTz/NctpooCPq+l40k0zRFEFKI0FXjM7O1js1vvFuiyBoMBiK2hsMhkiSRO6M4jjGfz9G2rUQDgVshyorx0Wgkt12TyQRvvfUW2rYVZ86yLLkhYj14HMeyXcQ4HW+VOHYbBIHcWQ2HQ4RhKGKPotW2bcRxrNvpNJrPMPdRqvAIwC8C+H0A3v/gyw8BfBXAv6mUev/bfe93Gy2INBqNRvOd6PteYlYAZLA1CAKJe1mW9S2LF+g2MCbGSJdSCuv1GkVRYDabIYoipGmK9XqN7XYrLhJvcABIbK2ua4mmURhx3JSODCvBz90PCrjRaISyLEXwOI4j5Qnj8Rht22K1WiEMQ3ieh8PhgLZtkWWZPMd5e91oNMJkMhEXqaoqaa87LzPgM3Dslm4Rx3EBwLbtO7c8WZah6zrYto0wDLFYLCRK17YtfN9HnufI8xyGYYjLluc54jjGs2fP4Hke9vu9OHu8h+LzcRw3TVO5I/N9H7ZtS+sdhd/57RdF63mUcjgc6rFXjeYzyH0Ior+BWwH0byulvv7B174I4K8DeF8p9cfu8Xk/FloQaTQajeaj0nWdOC50j4bDoQygKqVEGHGcle7QeSPdqy7HZlsqIDsAACAASURBVLNBXdeYz+cIggBpmuL6+hrb7RZhGN5xpM5dCIoJvh4dDgqI4XB4x93gnhKjgLw52u/3ACAf5DnO2rYtNpuNRMMooLIsk8FW/vm85YnjGMCtaGJtOJ0e/hlFUYiYMU1TXud0OqEoChF+TdNIZXfbthI9ZMkEf0/bthgOhyiKAqfTCU3TIAxDadfzfR+PHz9GHMfS9sdnoYjk81PkJkki7xs3j1gA4XmeCD6KxvPKcTp6w+FQlzBoNJ8R7kMQpQD+kFLq1175+u8H8CtKqdG9POknQAsijUaj0XxcWBDASBiHSM8rqrkxxFHQvu/vuDl8HX7IP51O2Gw26LoOi8VCHIsXL14gTVNEUSQNbHR62IxWlqU4NmVZinvFWJxt21JAQBFS17XEzeI4RpZl4uCwTME0TURRhKqqkCSJCK48z8UJ6vv+TiSQDtRkMsFgMIBhGNjtdjgej7AsS+6OeKNDh4oNdHytJEnk99u2Ddu2pSSC+1FxHEuVNwVpGIao61rEFUsQWFbx6NEjTKdTlGUprhL/fhhvHI/HIuzY1EenjzE9OlaM/rGYgnFG7jaxXILvqUajeTO5L0H0Lyml/uErX/99AH5VCyKNRqPRvInwwzAb6XibAnxYtMCKZ45+8taI9z98HX4g5z2RaZpYLpdSkf38+XMURYHRaIQgCCQ2xjganR9+EGe0y/M8cSzOv8d1XZimia7rcDweRfzQ6aCwA26jYBwzZS03R2pZGsFx1XO3ajKZyIaQYRjYbrcySMvn9H1fvu+82psDsqz3ZvkCa8M5yMrWOZYwUAQNBgNp+KOrx3pvts7NZjNYloXD4YDzzzN8ft/3MRqN4LquuF0cduX3GYYhJRpFUcitFIUb43Rs/dMlDBrNm8l9CKJfBLAA8CeUUt/84GtPAfwCgLVS6ifv8Xk/FloQaTQajeZ1oWNhWZbEsVhSQDfHtm1xdABIzTQ/vAOQmJ1hGDgcDtjv9xgMBri4uJCvvfvuuzidTpjNZuLA0GVhgcHpdBLn43g8Sqsc73lYCc52N0bL9vu9FAlQ4J27Hb7vS/kB74nokvHZ2TjHGJzneRiPx5hOp/A8T9ruyrKEbdsScWMFNodtWXLg+z7SNMXpdBIx6fu+iEq6O7zrcl0XcRyLwOJ7T/HEuCBFYRiGd6KKTdOIM8WIou/7iKIIQRDIthRjkHw+RgCHw+GdNsDzvSW6aY7jiKOo0WjeDO5DED0B8DcBfAV3SxV+A8BPKKVe3NOzfmy0INJoNBrNfUA3oqoqaVyj68IP8jzo54dtpZQ0z3EwlK/DCNl2u0WSJBgOh5jP57L181u/9Vuo61oqty3LgmmaGAwGyPNcRlH5mnmei9hhhOtVMcJbqP1+L41vFDlsm2N7HuOBrMEGIPG/c8eK+02u6yKKIsxmM3ndzWaDoihESJZlCd/3RThZloUsy6RFjjtDjNqxJY83SowNsm47DEOJqtEpa5oGTdPIXhPdJcdxMJvNEIah1HrTmeLPx8Y7OkBpmiLPcxmk5X0Vfx/jdZZlSQSvrus7rlEQBHJbptFoPr3chyAKADQA/hCAL3/w5d9USv3d+3rIT4oWRBqNRqO5T87b1FjBzXuT82ru86rubyWM2EjHnZ/VaoU8z0UYMYL2zjvvoOs6zGYzEUau64qY2O/3aJpGXCgKIzo33Axi+xtvXrquw83NDaqqEmcIuI2TMfYWhqHcI1H4nE4neS9YRpBlmYiRIAgwGo0QRRHCMIRhGFitVjidTnKflGUZPM+TcVWKQBZBcDyWwoj3WqzApuDouk6cMTb9eZ4nr8nXKYpCKrUpXiaTCUzTvFMgwd/veZ6UXbBZcLfb3bkRS9MUABCGoWwYNU0jG1J0rNhcSNdIV3drNJ9OXksQGYZhATgB+GGl1Ne+C8/3WmhBpNFoNJrvBt+qqttxHCk7OG8jYzyNwohOEiNkvEfqug6r1UpuiSaTiQiKf/bP/hkAYLFYAIC4QRxs5R7P+c4O2+Tm87k4QLzJ4bZOXdfYbDYiUviarP5mmx2/xtui8xptx3FwOByQZZlEAnljNBwOxXFZrVao6xqe5yFJEqRpKqUIFJCM6rE1ryxLcY1s2xb3iVE63jYxPkdH5lxAsSTj/GekazSdTuG6rrhpbBBsmkZKHCjuAIhrxKgdnTLWiFOAmaaJ0Wj0O7aV+Iyu637v/seq0Wi+I/fhEL0D4I8ppf7RfT/c66IFkUaj0Wi+m3RdJ/EsRsnoWHwrYcRtHwqj840g3iPVdY2bmxucTidMp1MZQV2tVnjnnXdkpJU3ShQxNzc3UrFN4UDnIo5jLJdLtG2Lw+EgbhOdpLqucX19jaIoxB3yPA+n00lKIEaj246kuq4RBIG4Q3StbNvGfr9HnucAIDtA4/FYShEsy8J2u5WYXZqm2O/3UlbAOF2e51BKSWseo4YsNjgvL2CZBJ0hCsEoimAYhtwZ8XU5rMv4nuu6UsnN+yv+fgqyIAgwHo+l7ruqKokeMhJ33k5HB48V4Ry9pUCiaNSukUbz6eA+BNGfBvAnAPxJpdTmnp/vtdCCSKPRaDTfC3jQz5scRq/4AR+ARObYOgfcOk10jM6FkW3bKMsSq9UKVVVhNpshjmMYhoHr62u88847ME0T8/lcGtr44frly5dIkkSEGAARArPZDBcXF3ccIOD2Bmc+n6NpGrx8+VKiZGEYYjweI89z7Pd7KKUQx7HUZ/u+jyzLkKap3Cl5nieNc/z5zhvd4jgWZ4slCrvdTgZizwsOuINE8cdtouPxKAUGnufJLRCdGAAihJbLpcTiDMOA67o4HA7yPYwM0jkaj8cyvMvXYJGCaZoYj8eIogi+74sbdx5VpNsURZGULpRlCeB25JZRSj4r3T59a6TRfP+4D0H0GwDeAjAA8AJAfv7rSqkf+ogP8kcA/BcALAA/q5T6z1/59f8AwJ8B0AJYA/gZpdTz3+01tSDSaDQazfcSCiPgw4FWRrgogliOQMeI8a9zYcRfY4nCer1G0zSYTqdS/X11dYV3330XADCfz6UyOo5j9H0vwsgwDAwGA7iuK67OYrG44xhRqAVBIF9/8eKFCIfxeIzZbIY8z7Hb7dC2LSaTiUQHwzBEURTY7/dyp2PbNtbrtYyc0kkajUZSpGBZFpIkkUrzm5sbpGkq0brhcCjvAe98BoOBNOpRVLEeG4D8eXTh2FgXx7E4TiypKIpC3mtWqHOMdzwew3EcKZ2ge3detEDXiDXcdOgoNMuyFLHKogYOzbIoggUcFLaMC2o0mu8d9yGI/hKAb/sblVJ/+SO8hgXgnwL4V3Arqv5f3NZ4f+3s9/xhAP9AKVUYhvHv43YM9o//bq+rBZFGo9Fovh+w6QzAndFWtsLRrXhVGDH2RWFEN2kwGCDLMqzXa7RtK41pAHB9fY2vf/3r6LoO4/EYlmUhiiJxI77xjW9ICQBLFRhtm8/nuLi4QNd1SJJEHA7P8/Dw4UNUVYWrqyspFZhOp7i8vESSJEiSRBwdACJWuq6TmyYOuG63W4nSAbeOVBRFUorA+Bxdqc1mg91uJ/G2KIpkm4jCiHc8/F7eNdHxYUMen4vlE7xr4n4S3+fj8Si3R/y7ieNY6rUpjFixzp9/MBhgMplI5K/v+zuuEf9sRhfpGhVFAeCua8QCC7pNLIvQaDTfXV5bEN3TQ/wYgP+fvXcNsSxfz/uetS9rr7Xvl6rqnpmjmTNWEpAgAXMONsYCDTghUhB2QLKIIhmfEHNIggj6FotANMfEhOAPCdiGIIhyQgg4QZ8UIjAxkYQJJuSE88VOsCJrTveZ6emq2lW1r2vf98qHmt/b/11T3V3Vl+rqrvcHxXRX7b3Wf629pvg//bzv836a5/m/+dXff1OS8jz/L57y+j8r6e/lef4Xn3VcF0SO4zjOm+SiMFqv14rj2OK5pd1SuqsIo/F4rKOjI+V5bhtxSXr06JEePnyo9XptZV/NZlO9Xk/z+VwPHjywMjmckOFwqNFopP39ffV6PeV5bqEAlP3dv39f6/VaR0dHGgwGmkwmJoym06lOTk6sV4a5RfRO0R/EkFSiuEnXi+PYSulwsUitS5JE0+lUjx8/trI5IsG3262Vz+FsVSoVrddrTSYTmxvE/CaGtzJzifI+XCMCGOhTQiyRDliv11Wr1ayPikG7cRxrMpnYHKVGo6F2u20uD71GeZ6ba5Rlmc00KpVKFjdOuSF9RoRGIOJIAnQc59XzwoLoq7jtvyPp39Z5udw/kvQfv0gfURRFvyTp5/I8/xtf/f2vSfrzeZ7/+lNe//ckPc7z/D+/5GfflfRdSfrwww+/9eDBM6vqHMdxHOe1c5ljFA5tlWQbbJrvabanxIsNO70zo9HIhFG327UY68PDQz18+NA26IVCQZ1Ox4TRn/7pn2o8Htvx2+22RqORBoOB2u223nvvPRv6ijAqlUp6//33VSwWdXx8rMPDQ2VZpkajoQ8++ECr1UpHR0cW700qHdHYBBB0u13Fcax+v78TRoEbQ3khbhCldFmW6fj42FyfSqWiQqFg9wYRwUBWXCOS8ejlopeHzwJxWqvVLPSB/i3cGj4TXk+ZXKVS2RnGutlsbPhruVxWu922a2LY7Xg8tnI9SipbrZbSNDUxtt1ureyRXi1cIlLy3DVynFfLywiivyPpP5L0P+o8evtXJP1hnud/9QUWcWVBFEXRr0n6dUk/m+f54lnHdYfIcRzHuU2Ewmiz2Wi9Xl9JGLEBxt1ZLpe2ER8MBur3+9put9rb21OappKko6MjPXz40FyGcrmsbrer/f19zWYzffbZZxZzHUWRhScwKBYBhGNDSdr777+vSqWifr+vL7/8UtPpVNVqVe+9954KhYKOj49NRMVxbD099AKx4aenBpFCn1G9XreACFwg6XzmD0ET9GohYHB4JJkLhGtEqAGpdaTS4S5R9lYqlZSmqZW+UXbH50VyINdWq9XU6XSUJMlOHxi9WlmWabPZ2Nwj3K3VamXlduHMJHqmCH1YLpd2HlL0cI74fhzHr/V5dZy7wssIon8h6T/N8/wffPX3Pyfp/5CU5Hm+ueYirlQyF0XRvy7p7+pcDB0977guiBzHcZzbCMIoz3PboF8mjOg/eZ4wwoU5OTmxQa5Ebx8fH+vzzz+3DXupVLK0uSzLrMeIcr1ut6vFYqHT01OVSiV99NFHkmRDaHF+9vb2VKvVNBgMdHx8rNFopDiO9f777yvPc52dnWmxWNjA1HCgLT0zuB3MNiJ6PIoiEydheSFR3vT8TKdTEwn0ZpVKJevVQjRSesjrcccQpcxACkv3whlK2+3WeoKISqdMjgAG1sp9TNNUy+XS+pvK5bL1fjFAliAGPluehVarpWq1qtVqtRPfTQQ5ZYncD8SW4zgvxssIoqWkj/M8/yL43kzSv5Ln+Y+vuYiSzkMV/pKkL3QeqvDv5nn+z4LX/FlJv6tzJ+n/u8pxXRA5juM4txmEEf0qCCNcDwRQ2JiPYKD5HpGCMMIxInwhFEZffvmlOQ/FYtFCFWazmX70ox9pOp2aG9FutyVJJycnkp44Q7PZzBLSFouF9TFlWaZ+v69+v69yuax79+4piiILEEDgURYW9lAhBGezmTk/oaBptVo2dJa0PiLFh8OhZrOZuTe4Ltw3joUww6VB2CGecMBwzeI4NmGUpqnq9fpOPxJDVplvxAyidru9M3iVMj4S/rbbrarVqglK1oNwov8K95Dzj8djE9GtVsucM/7LfCYcK8dxrs7LCKKNpPt5nh8H3xtL+tfyPP/sBRbyb0n6r3Ueu/07eZ7/7SiK/pakH+R5/ntRFP0jSf+qpC+/esvDPM//8rOO6YLIcRzHeRt4Wikd/SaAEEEY8TPERiiMhsOhpdJ1u90dYcRwVNLvOp2O3nvvPc3ncz18+FDT6VSLxUKr1cqS4vr9vvI81/7+vvXk4J7QT9RqtbRer3V8fKyjoyNLYGODPhqNVCwWVSwWraRssVgojmPFcWwlcvP53L6POCgUClbORmABblChULCIcCK6Z7OZSqWS5vO5pdFRbobrRP/RYrGw81Catlwu7RjMKCIuXJLNSULQVSoVi/EOXaNQ3NXrdRM/iCiG71LquFgsNBgM7LlA8BIAUSwWNRwOrVeJz4IQBi+pc5zr8zKCaCvpf5MU9vH8vKQ/kpTxjeeJlteJCyLHcRznbeKiYxT2tzxNGOES4YJcJoxwjNrttqrVqvX6nJ6eWoAAJV3vv/++lsulPv/8c2VZpvl8rvl8rnq9rkajoZOTE3OG6vW6pcVtNhuL7Cbhrd/v6/j4WIVCYScpbTqd2oyg9XqtLMusj4Y4cZwkyuhIpmOODyIlyzJzvAqFgiaTiTk+3E/K4nB9EEWk4tFbhEikrI7PInSNqtWq9fqE86UolavX61aCx3ykXq+nSqVirhhCJssyDQYDC5/Y399XvV5XuVy2+0K4BZ81fVbValXz+dxcvVqtZs5hONvIS+oc5/m8jCD6765ygjzP/70XXNtL44LIcRzHeRuhHI3SMpwCSsCk3fCFUBgRCU2ZHWVnk8lER0dH5vowpPT4+FjD4dBESaFQULfbtfS4x48fW7R0lmWqVCrq9XoaDocmgLrdrgUnIEaKxeLO3KOTkxMTaQw8ZeOOYGFzXyqVLDqc70nnrkyaplqv1yYWmWe0Wq1MnEVRpMViYelw9PtMp1Prv+F9BE5w7ZTmjcdju5eSrOxvMpmYa4R4CaO7mS9UrVYtsW6xWKhSqajdbqvVapm4k6Rms6n1em2BFqQChp8RvUj0k1FmRz9SmqZWckeQw3q93hFHXlLnOE/nVswhel24IHIcx3HeZijnooyLzfBFYYSjQEQzwgQBgjAg6Y0kuE6nY6Vq/X7fNtX0yXQ6Hf3ET/yElsulxV7P53OdnJyoUqmo2+2aS1EsFtXtdk2Y4WrgnPR6PY1GI/X7fXNEwiGos9nMUu1Io5OkbrerNE01GAxM4CGMKJ3L89wGqErn4gX3CpeIcrzVaqXZbGauD7HbiAscMxwX+poINOBeskb6fHDeuJ+lUkmTyUTFYtF6fngPPUT0IEmyHiRcI4IY9vb2bFYTZXrD4VB5nms2m9n3KakrFAqWYsc8p9DFoseKkjoXR47jgshxHMdxbj2IHXpFcFH4IqGMlDOEw8VZObgF5XJZi8VCX375pebzubrdrjklJycnNiyUZLhWq6VvfOMb2m63Ojo60nK51HK51MnJiQqFgvb3920OTxRFlrgW9vjMZrOdGTsII0oBGV6KKxOugRlGnU7HyvxIq6tUKjbHZzabqVqtWqw3AQ1pmlrvTqVSsZS7+Xyu09NTu0dEZBOxjRtE3xPJewgLeoim06mkc1eI2U/ch0qlYi4X4QzT6dQEYKPRsMG14SDYQqGgLMt0cnJiIurevXvmPIUldbhsuHLVatVS6sbj8ddmNyHCwvvng1+du4wLIsdxHMd5S6DZH5cCF4CZP9ITYYGbgRiSZA33NN/jLD169EiLxULNZtOONRwONRqNdnp8arWa7t27p1KppLOzMyvhOjw8lCQ1Gg1Vq1WdnZ1ZJDT9RMzooYSMcITxeLwTI826EB6U6+GutFot9Xo9ExWUFDLclRlF9PNQTrfZbNRutzWbzWxAKmVu8/lcw+HQStYob+t2u+ZazWYz1et1c42Wy+XXnBeCIiipazabVtqGe3N2dqZSqaRmsylJJpbiOLaABVw1Sep0OprP55pMJhoMBlZO2Ov1doIYiC4PB7nWajXrIeIaWA8x7GG/UZqm5rw5zl3CBZHjOI7jvGVst1sTRpTTSTLRgWPEph93CWFycRYPQ02/+OILc1kqlYqFMlCiRchCtVpVt9u1OGl6gHCPqtWqOp2OCSoEAi5FrVYzYYIwos9Hkq23WCxayRex1URmV6tVc6ZwSRBGtVpNpVLJeoYoiSOeu91uK89zDQYDc6Q4z2Aw0NnZmd2jRqOh+/fvm7Ci1A7XCJGCc7fdbs19QnCF85T29/fNMZvNZlYWh8CTpCRJLM2PREGOM51OdXZ2puVyqWKxqP39fYv6pqSOz4RSQa6D/q2w36hWq9m9RhxJsuCIMMzDcd5VXBA5juM4zlsKwz0JBAgb6BEazLWh3yaM9MaJ4L1s8h89emSb9SRJrPcoyzJzR5hH1G63laapldchNAaDgeI41t7enpbL5U7YAMNSm82muT+SzLHCeQlFEpt5nBzpvFeI1LdyuWwihJ6fOI7VaDQsxpvACJLnSGujDC9c33g81uHhoc3+IQWu1+uZ+zYej60ET5KVwXENhEFwjDRNrdeI8ro8z01wkuQ3Ho8t8rvRaJhTxWfUaDTsOo+Pjy1M4v79+2o0GlZShzgKBSYldWG/0Wq1UhRFJqp4HiTZWhHajvMu4oLIcRzHcd5y2KATMIBrxAY47M0hXICobXqLJNmmmzK8w8NDjcdjm2tTKBRsk80xKB1rNptfm4kzmUwsdps+pdFoZHHQzB+iZ4YwgTRNbX2SrMxOOhdGiJjRaKTlcmmJc/wsFFT8rNvtarlc2pyiTqdj702SRK1WS6PRyNwmBsIuFgsTiIjAWq2mDz/80EoTJ5OJCS7OS5IcopWQCUraSKljCG6SJF8LqGCuEj1ARJ2HQ23b7baFXRwfH6tYLFppI+KLn08mE/u8SqWSlcjRM4WjFw7LlbQz34iZTi6OnHcJF0SO4ziO8w5xsZSO0i/ED2KBWUYMOK1UKjuuQPg6EuiIq6YMjxlFpLeFTfoXI6tJqWs2m2q32xoOh1ZOx/lrtZoajYYGg4E5NrgfcRwryzJNp1Mr/2u1WppMJjo5ObF+IlL4mDmEWCRgodlsqlKpWAAE555OpxZ6EEWRjo6OTAgcHBxos9nYTKf5fG5BB91uV91u18ItEIDz+dx6ppIk0WKxMAdLkvXzILA4b6vVst4qkubu379vvVS4Vb1ezwQon2+z2dR0OtV0OtVoNDLBtLe3t9NvhLhDZJJwx2cXzjcKZzyFYjuOY+sPc5y3HRdEjuM4jvMOEs4yoq8lFABAeAEOByICQYMwop+I1DNKruhboWRuvV7bRppj4SiQ6jYajWx+EWKF+G02561WS9Pp1FwNNv31el3j8dg27ThMJOARbMDgVVLm6AHKsszK1+r1uhaLhQmParVqQqLT6ShJEo1GIw2HQxODzWZTo9FIg8FAw+HQenlarZa63a6azaYJouFwaOV0kkwMhefM81zT6dQG07ZaLRukWqvVtN1uNRqNlOe5Go2GWq2WxuOxsiyzIa2dTmcnaTBJElUqFbvfzIXa29uz3q/tdmuCFvFDEAb9QwyPzbLMxBvPEEESuH2UVjrO24gLIsdxHMd5h0GgsOFlg474KRaL5qyEyXQ01Id9SZSSLRYLHR4eWvIc5WA08tOzQvkVx06SxMrMzs7OdHh4qEqlYq7NcDg0EUPvCgNaT05OzJnhPev1WpPJRJPJxMIaSqWSTk9PdXZ2Zv1SDCitVCpqtVrabrfWC4XTQRR52G+1WCxsDhLuD8NoO52ONpuNhTAgtOjPOTg4sJI1epQQPavVymYe4axxD4kZbzQa6nQ6ks7FKKEQYQx5uVw2sUK/Ua1Ws/tNmh0R4f1+31y5e/fuqd1uW1Q74oiSwc1mY+l4CCx6m7iXknZSC10cOW8rLogcx3Ec5w5wMZkudIEIYED4XAxgiOPYor7D12y3WwseqFQqKpfLJrwYaBqei4Z9jklKW7/f12KxMAdmPB5Lks3Nwd1IksTEx2QyUavVsrKt4XBo8eDM4RmNRibcQmGEq1Sr1XZK0YgJl2S9RwRIIII4F9HirVbL+n/G47EGg4EJHI5HSt16vVa/37dhsbVazVwdEvTo48LNKhaLarfbFtNNjDZhCZK0v79vs6oQRzhc3EdcLMTPycmJlTjeu3fPSvXW67WV0yGOCHzgeugFWywWJu64jvV6rSiKtNlsLIyBFEPHua24IHIcx3GcOwQuEMIIoSLJRE3YP8RsmziOzd1gkyw9iZ8+PDzUZDKxBLmwj4kUOc4fBhA0m03FcWy9QIPBwMrZSGujnI4AglqtJkk6PDzUdDpVqVQycYQwIaWN4xApTn8REdn0AWVZZg4XPUu1Wk2r1cqGmdK/tL+/b+WAp6enlnaHI0QPD85VFEVK01TNZlN7e3sqFosWn01vE/ct7MlCYIazm7rdrolJxNHZ2Zndp729vZ1UPeYW8WfOVavVbMYU72f4K8NlKWeczWaaTCbmEuLocb30OyEiw7I6SXZsF0fObcUFkeM4juPcUXAUwmS4sA8F4cO//NOLws94XxRFiqJIcRzr9PTUSt/o2+G4lIhJsj4b+psQOvS9nJ6eWh9SpVKxAADK6crlsjqdjmq1mvr9vs3mOTg4sPAIhpGu12ubBfTll19azHWSJNbbVC6X1ev1LHBBkjk29XrdRFS5XLY+KsINEJmnp6eSZCVmeZ5rNBqZQMGFQ4QhPAaDgfUFUfZHORx9WaVSyYQRs5WYLUR5Ifefz4MeLcQR9wzBUigUrL9qvV5rPB5beEa9Xte9e/csAZASwnBeUhRFtoZqtSpJlrhHz5EkK8uTzsVRrVaz9EPHuQ24IHIcx3GcOw7lVvQLIY4QP4QnUMIWlpgVi8Ud14iNdzhAtF6v70ROUw7Ga3GhFouFms2mBRMgjCjDIgQhLKXDsWg2m9psNvriiy+UZZmazaZ6vZ4JisFgYA5GtVq1gIjFYqE4jq2HR5IajYYajYatdzqd2jmJw0YE4Zy0Wi01Gg3r88myzIRNkiQ2LJXrJuQC16darVrUOcKn3W5rs9koSRIbMotjRa9WnueWUlcul1UsFk0c9ft9c4ZarZbdYxymTqdjwg5RhbMTiqNWq6X9/X3V63VJMheLsj0iuWu12k7ZIT93ceTcdlwQOY7jOI4j6et9RiSJSbK5QWxmETL0GVUqFXsfjsbFKjCSHQAAIABJREFUPqNGo2Hvkc7L58bjsQkj5u6QwNbpdNRoNHR2dqazszMTJuEAUYIeNpuNSqWS9vb2VK/X9eMf/1hnZ2cqFot67733VCqVrB+IEj7mHZEYR3kbApAZPThkJMKx+e90OppOp+YErddrpWmqVqtlgRSj0chS7xBVk8nERBUlhMxRIgVOko6Pjy0pkCS9MEgBUYWTJMnK2RA5zWZzJ6kuSRITqJThhf1FCOAwLIMSQHqmLhNHJOqFw2NDcRQ6R7hTiCN6jlwcOW8KF0SO4ziO43wN/mUfIXBx/gx9RjTiEz+dpqmJIjbHbH4PDw/NOZG0MwdnPB6bcCgWixbKQHP+Bx98oOl0quPjY43HY9tEU5omaScyvNFoaG9vT9PpVA8fPtRqtdL+/r56vZ6m06m2261t4klEG4/HFm6A24WLg4OCaGCDH8exer2eBTasViuNRiObh4QzE0WRiQp6ojgPvTmIUe4jztd4PNZwONRsNrNwCIQDjhTCgjLEKIrUbDZVKpXMEWq1WrY+rotBtgzE5X2r1crK5Wq1ml3fZDKxksJms7kjjihPZMYUIpX+Ko5PzxHhE9wP1r3ZbKyUz9PqnJvABZHjOI7jOE/lsthuyunSNDUXCGeF/hJ+RkkVZVUklFFO1Wg0rDQrjmPb4BMJvlwubU5PqVTSN77xDZVKJfX7fZ2enpqLRUgDIQ/00URRpIODA1UqFT148EDj8Vhpmmpvb89K+9brtabTqb03yzIre9tut1qtVrY5x/kK5ywNBgMTDr1ez4QcG38CKXB+CCtAjBEeQTId/ToIqTRN1el0VK/XLZGP8AdJqlariqLI3C9EFqJDktrttiRZJDZCbTKZ7CTs0dOFw9RoNLRarSzOm14hQibox7roHIXiKHSOarXajjhCWCK8ucfsQRGgJBM6zuvABZHjOI7jOM8FYRAKnDCdLkkS23yXSiXN53OLuE7T1ByD5XJpm97tdmuzfer1upWSwWg02onzZlbOdrtVp9PR/v6+hsOhiYTtdmvlemyqSYqjJOvg4ECTyUQPHjyQdC4Uut2u9TWRNHdxKCkDTBEOSZLYJp55PZSWVatVCxvAPSOhjtJDxBdBE6vVygbh0rtVqVRM5NC31Wq11Gq1VKlUdHJyIulcfNBP1W63rVdpOp2aUEWA4XSRNsdsJgITKBUM3TbK3kimq1arKpfLJmoQlOPxWNvt1tL0iAp/mjiqVquq1Wo25JcIdO4FwpP7Qr8T4ohBt47zsrggchzHcRznWhDAECbIsZEnEpthr5vNxoIQcDJ4vyRzjY6OjqwHqVAo2KBTembYDG82G3MnFouFSqWSPvzwQxUKBT1+/NheS8ke5Xo4Tmyse72eyuWyHj9+rMFgYO4OM5cmk4m9n14g1s7GvV6v26afTXy73bbyOIIR6NNhxs9sNtspxUvT1FyS5XJpkdcMyG21WuasjUYjc+FI2SuXyxoOhyqVShbyUCqV1O12NZvNNBqNlGWZ9TFxb3Gf+AxwonDH1uu1CUCEDyWRlA8SxBA6R/P53Mrmms2mut2uDZlFHNFzhTgiap17hUuHM4kzR38XjiMBEi6OnJfBBZHjOI7jOC/EZrOx5nz+Hg4lJf5akrkhlGcRYx26RnEcK8syDYdDS5zr9/u2EWYmT7gBRhitVivdv39fnU5Hp6enGo1Gdvywn4VNdJ7nVgqHQ3J4eGgBBt1uV4VCwdZC+R0bfRyN0Whk6XMMQh2NRqrVamo2m+aMhBHVCJ4sy6z3h14fBBkx53mem2NVr9dNcDGziVK/vb09ez+CiaCIarWqer2uLMss5AFxGEZo4wQlSaIkSdTr9UwckRSHu4RAzfPcHEBCEbgPuIqkDTYaDfV6PYv+RhyNx+OdkIg0Tc05KpVKWiwWtgaiz3HYKJlEjCOcHOc6uCByHMdxHOelIBCAf/HnX/DpRaFxX5L1BSEqcJQIcSAmulAo6OjoyBwERA/gsoTpdvP53IakMgD1+PjYyvyInaYUi8GiYShDuVw2oUMQQaPRUJ7nVqJGL9XZ2ZnSNNVqtbKyvWq1qoODA3NKVquVDVOlLI0+Hq6dOUVc62azsd4dnCXKBXFnOp2Out2u1uu1Hj9+rNPTUxvyyvmSJLFkvSzLTOikaWrzkYgiR2zi0OGo4Rzt7e1psVhoMpnYoN40TS3hj9lU/B3nCueI+49zlqaper2eer2eisWixYgTakH5Jc8PYisURwhpnhneQxkjpZmO8zxcEDmO4ziO88pAFNHTg3goFovW+4E4IoSBTT4BA2x2eT1OyGq1UrVatTht6YmQqlarWi6Xkp4IDAa+drtdjcfjHScCAYIzValULJqbMjtitheLhTlJ9Xrd0uhYw2AwsFCE+Xxug1vpc6L/KM9zdTqdnSGrlKM1Gg1bV9hTRB8UQmWxWGg2m9m1NhoN3b9/X91uV5PJRIeHh1Z+yPyhJElUq9WsDA0hQT8O9xYBhjjiM8KRK5fLqtfr6vV61heVZZkdB6cIAUysdq1W24kCJ2p8PB5rNpspTVO1220bjEvoBPc+HBCMOGLoL9dDWSYuIJ8HZX18zo5zGS6IHMdxHMd55YSuUdhrdJlrRAkZ5Xaha4RAieNYeZ7r+PjYghPCuGnORRM+gQcktiVJona7rVKppMFgYIKIvh5KwOiJYTPP8SVZT0u1WlWz2VS1WtXx8fFO5PVkMrEN+dnZmSaTic0mYnArIoISL0QQpWDNZtMEFPcPiNsulUoajUZWescMo/fff1/tdlunp6d69OiRuWyIMQIf6IPiniOQKOPjs0FsIGoRR8xiOjg42BFHURRZzDZiiH4fepIQNPQDEcowmUwUx7GJI9w3+q4Q2RyvUqnY3KU8zy2qnecNhwtIMqRk0/uOHHBB5DiO4zjOayV0jRBFbLBJU6PcKYzuDofBho5OpVLRYDBQlmVaLpdKkkTD4dDK8egPqtfrVlqHkxRFkW3I2YhTUjefzzWbzVQqlawcDOFGRDT9TAiwWq2mvb09S6RjPbhElA4OBgMtl0vVajU1Gg3V63UNBgMbbEusNddJH1aapnY/wvvA/SHkgFI0ztHtdvXhhx8qTVOdnJzo4cOHVlZXKBTUbrctxAA3hrhyBBLljwQbIC5DsUGZHGWKzBmaTCZ2DfV63cQRbg+BEURw05fENQ4GAxvw2u12bcAsLhfrYNBrHMfmhuHU4R6Fg4IRq4RKIEq9tO5u44LIcRzHcZwb4aJrFM41YlPN3oMQhfV6rSiKVK/XTdgQ4kDfSujS0G/DppgNviQ7Vzh4laGjlGlxTsQFPTT0/DDEdDqdWn8MZX/NZlPtdttKwXBfzs7OFMexzTwaj8cqlUo2GBVBJ52n7jWbTUVRZKWDlBvST0TyHQ4PQRU4UIgBShEPDg704Ycfqlgsfk0cUdrXbDYt0GE+n+98bmma2nnoY6IsERCulMYdHByoWq3q9PR0J7EO94/AhDCqPRRHfJbr9dqEY6PRsBJI0vK4Xp4thE+j0TC3jz6qUEwSfY7Y3W63Jo7K5bK7R3cMF0SO4ziO49w4oWskaac8jX6Uy1wjNtwIE/pekiTRYDDY6ZFBFIQlezTm48YgWiqVioknnBAS8C6W1IXrGw6HWi6XOwNJ8zzX3t6eCZfxeLxz3IvlXWEfU7lcNsGEk8M1EDMex7H14iCSiAnfbDZqtVqqVqsWgJBlmaWwfeMb37BEuqOjI33xxRc6PT216+W91WrVBJckE431et3K6bj/oTjj88O5SZJEBwcHajabGgwGFppAYAXBB5QoUg6Hs0SaHD1Tw+HQ+o5arZZdCyKQzwohTbw5s5sIuyDEgWtDBCGOcAkJbXDebVwQOY7jOI7zRgljpnEGwjkzbP7ZrLKRrdfrO24JTlOhUFC/39+JAUdQ0eNTKBRso03/D2Vg9LtIsnXhas1mMxNQYQLaeDzW2dmZBSQwzJVIbEnWnxO6XDgthALwRY8N4kGSWq3WjlMTXgeColAomKNCqES5XNZisTARgNv1Ez/xE+YM9ft9PX78WEdHR+aONZtN1Wo1K0NDxEqyeHJcPsRdnueaTCY7ZXEIpTiO1ev1tLe3p8lkovF4bAKRXiCEISV69Ao1Gg0rbeP5yLLMPs9Go2FOF6WQ3G9Jdt/K5bLa7baFWXBf+IwRR9xz9sKhe+S8e7ggchzHcRznVkA5G64DPSXSeYlTrVbbcY0olQoHwiIupPOyLDbNbK43m43Nv0FAsNknYY1BoGmaWk8Srg69RgQ+sIGvVCqq1+sW2jAcDhXHsYmjLMtMXDBklQGkCA16kCRZTwuCJ4RAA8rnsiyz14eCgmAHgina7bbdZ8QCIQ4ffvihOVSj0UiHh4d6/Pixlf5R2sfxEabsFRm6GyblbTYbGwLLPUVA4fAcHBwoz3P1+327v/V63WK2uRbuC/eZAa48I/RpUfrWbDbV6/VUKBRMHBHrjgimFLPRaKhcLptQDd0jxCZ9U2FZoLtH7w4uiBzHcRzHuXWwoaafBQETBjFQuiVpp6+IRDo2/QwnPT4+NueGfpnNZqPpdLrjzpBKNxqNlKbpznwi1sDmnXOs12vbwNPPI0nHx8c2ewiBNZ/P1W63LbwA0ZFlmQqFgsWDMwyVsriwHwoxwDBWfkY4wna7VZqmStNUhUJBo9FI0+lUs9nMnC2ONZlMrNSt2Wzq/fffN5dqsVjo0aNH+vLLL21uEc5dOIQV54wStXK5vNOTxRBYgi14LfHqJNbRd0S/VRRF2tvbM4GK6Apj2ZvNpoVd4DKOx+Odgbak1pEEiPBFUOEedbtdpWlqgo8STFyuUASxT6a0z92jtxcXRI7jOI7j3FpwB3AeCBtgzs3F4aoIJ+lJSV3oVLCh7ff79tpSqWRlU/P53FwJNtgMDq3VaqrX6yaq+Bl9QwgbHJUwKGCz2ajf79smnZS71WplA1NxUuj7yfPcxBHR4zgchAGEa2XDzvcQRwQS8P7RaGTOGWshrpzSwjRN1Ww2de/ePbtvURTp8ePHevTokbkoODJ8FpShSbJACoQPjhIOUhjeQB8Qbl+v11On01GWZRaTTmldmqYmOBEuYaIdfVaI6s1mo9FoJOm89K3VaqnT6dj9RdzybEnnzly9XjexxfrDGVBh0h7uESLR3aO3CxdEjuM4juO8FYQldWFKHWEJpMABG3M2t5J2UtSSJNFsNtNkMrFZPuHQUIIUOA9ipFgsWskXzgtihmQ4YqE5T7lctlS52Wy2E7nNZpq/08fEWkKxRmlfuFbuQZqmks436iTPMYwUd4syMVLezs7OlGWZiRGEBf1L0vnwV8rQwh6nfr+vL774YicgAiGIs0bSXxzHtr6wh4r+L+4XpWz8rFqtqtVqaX9/3wIqptOpuWPtdntHgNBLhjuGi8RMJ4TifD5XmqaqVqvq9Xo7z8LFviOETrvdthh2+snCMAkS7kLCuVaeXHd7cUHkOI7jOM5bB303uBRhTxApcAiSsAclLPOif0c637ienJzYkNF6vW7N+cwyIvEMF2kymahWq1kq22g00mQysflDnAN3o1wuW6IcAm4ymWg0Gu2kzVHGRbACJXGsJeyTImiAXiJcmEaj8bWBqLhQ0+lUi8XCXJ1ms6k8zzUcDq3fhpk9iCOuqdPpqF6v27VIsrK/L7/8UqPRyBLfKCFEFCCwmPEUx/FO0AThFmF6ICKJErl6va6DgwNVKhUTRzh1RG0TpU65HmWWuEfcE0QoJYPValX1el2dTkeSbLYT/UO8h9cy6BeBHn7WPId8BjiRCFGfe3S7cEHkOI7jOM5bDaII4UKpFAllSZKYQOFf9yVZrHKYjCadi6bT01Mrk6pWq9psNhZQgJMSltTxOmbkDIdDTSYTSbLwg8FgYK4DIoGvSqWi5XKp4XC443oR9EAZGGVa4/HYnB1K6jhW6CxRZkbvD8KsWq1agl6WZTYHqt1um0jIsszcmHBYLfey1Wqp3W6beCMhsFwu6+joSCcnJyaOKO9DCPFZkB6XJIkJCq6HP2dZZs4R54iiSGmaan9/31yb6XRqbh3iiZj08DkhFIFyQT4jniHEHO5RrVbTdDrdSc9jHTxnrVZrx4Xk/uNk4vohrnCxEJZeXvdmcUHkOI7jOM47AU4QG1tK3MLUOESBtNtvVKvVbKOKkKH5fzAY7Lgmm81GJycntrllkCg9Tmz0SXUbDAZWgsfXYDCw99EHRQ8Q/TyU1RGuEMexOVpJkpiQGA6HJrbCNeHsrFYrEzadTseCIRA6zWbT3LLJZGJiApeJErOwnIxyPIRYvV5Xq9WyWG/mPaVpqslkopOTExOJlKCFM4ik89I8ygERa7gvuICLxcKCIcK+n3K5rGazqf39fYtZxzErFovm/iBacI8KhYKV13HuzWZjQmY8Hls5Yq1WU7fbtSTBcI5ROO+KcsokSczJDGckSbKSR8obeQ6KxaI5gs7N4YLIcRzHcZx3jjCMYT6fm+MgPYmtZtMZltRJT8QRCXSSzKmZTCaWGofg6vf75l4guHA5ttutut2uiZ7RaLQjXvI812g0MpeFTXE45PSiY0XwAIKOBDuOTwleKIwo7dpsNlbW12g0zNFB/DUaDUuDy7LMZhZxTyhRCwfB0h9FnxApe7goJPohOPr9vo6Pjy0OHYckTJIjeY4/c88uukeEQEhPhAnCEneHwAvK8yipZDCspJ2gDnq9uH8ENxCNTmohone5XGo0GpnQJsadRD3EYqlU2kk2DMMx0jQ1Fw9Ryxo8ve7144LIcRzHcZx3mjCMgV4VBqGSBHeZOGIziwvB5ptkOfptarWa9fCcnZ3Zv/zTJ0JJmiT1ej1zR87Ozuz19NFQ8kWfTpqmVnJGqdtgMLBeIr5Hr0utVjNxdHJyYvHVoeuAA0OP1Hq9tsADSeb81Go1G9IaDq5FSPDe8XhsG336dRAV1WrV1ogw5TNpNpuaTCb6/PPPlWWZJeuRGojQKxaLlhhYr9ft3ocpcrhHOFSUHUrnAqXZbKrb7ZrDhWODy9ZoNMxB5N4QIU6JHe4RX+H5KpWKut2uarWaRqORPSuUViKocNOazaY9V6QKUrbHeSnHw+HEFfT+o1ePCyLHcRzHce4MbJ6Xy6WVReE6hDHRvDacm4NjgVMgyVwTNvQ4I+PxWIPBQJIs9EA6F0f0vNy/f99E2Xg81snJiW20wwGyzWbTRBTCh/k7o9HIBAllV5SXEU+d57mJI0IawmQ6IrARNeGMJ85L7xC9MQg+4rxJd2MtCE4cpmazqWazKUkWQ05cNi5XuVzW4eGhDWmlBJH7XK/Xd2Y9kfZ3cnJiJXCSTPwSg06pYVhOuLe3p1qtZuIXlw4BxHDYsCctDMTgz/RrMQMqjIPvdDqK41hnZ2e2Nhw7otopWWw0GjvPJsdCRDEclv8i0C5LtnOujwsix3Ecx3HuJOEGlA3z08RR6BqE4ih0jgqFgoURLBYL2+ROp1ONRiMrT6N3KMsyO8f9+/clnQuQ6XSq4+NjS5NjACyuCnHSlF0xUHW5XOr09FSz2czcHMrv0jS15DyitqMoUq1WM2GIG4GgYb24KggRXks/Dy5IkiTWjxQOmGXzj3vU7XbV6XSsHI57wWsIGpjNZvr8889NIFB2h3vUbre1Wq3UbDZVLpdVr9e1WCw0HA53UuQomSMAg3huXLs4jnVwcGCBCQje0JVD+OHm4d4woDYMtEBk8ZlR/sfso+FwaM8gJXIEYMRxrFartVMSOZ/P7f7QLxUGZBAiwTpcIF0fF0SO4ziO49x5ruIcSTKHCHFEr8dl4ogBqMvlUq1WyxyUwWBgLg9hCtPp1ETWwcGBORmLxUInJyfmvFAaluf5zmwgQg8YqEpww3g8NsGCy0MAwXK51Hg8tlI2SuS22629B3HAnpANufRkxg4zi5jJgzjgHMVi0UrCwlK1OI7V7Xa1v79vLgj9QbhHrDlNUx0eHlq5YJZllr5H7xPODeEM1Wp1J8iBdEGuKezZIWACkbi3t6csy1QqlaynCrFBvHfoPIXBHaQBUtpG7xquIhHgrVZLi8XC+tQkmXsXDsjlfPQ5zedze89Fkc31uEC6Hi6IHMdxHMdxAhBH9Hfwr/5scnF1Loojmu0RCGxqoyiyvpLlcmmN+FmWmZuB8yLJhoaWy2Xt7e3ZxjrPc/X7fQ2HQ3NdOEeSJOr1erbW6XRq5WpxHGs0Gqnf71vQQ5Ik5oDU63WLFQ+Ht1K+xyYb4YboQTAQloDjgviYz+c7goVr4L6yTul8llG73da9e/esbwhBhgAktY2I8pOTE3Pk6LOSzkUFM4foQ+J+9vt9K0ejbDCc6xRFkTliiNV2u61Wq6XJZGKzkxCN9FTR34MjRSkkpW0Mp+Xe4PzgktFXhBMGSZLYvZRkTl8okBCI9MYhyPh8XSA9HxdEjuM4juM4TyEUR/SKUJJG2hvi6GLPERv79XptPTZRFGk4HNoA0larZc4JgoTEMYIamKXT7XYtEY7Sq9PTUxvYijDjtZTLkYDGRjrLMh0dHVl5GCVqCL04jnV8fCxJlnzHrCaOWS6XLXWP8j16krbbrYVRSNopQUM8XUx3I/0OAVatVrW/v69ut2tCC+duPp/bbCjEHWWG8/ncZjkhYBGGzGRK09SCKBCX4XyqzWZjbg69VNyLKIrU6XTMOWJArCQLV2i32zsR7bhHRGpzHMItuAf0TCHoms2mxuPxTkAE4RQIOOLAmSsVCiTpfCZS6ERe7EEKnay7jAsix3Ecx3GcK8CmmQ0z4giRwowbggIQR8Qq4yAQmiCdN/OzwcVFmU6nGgwGWiwW5gTQW0SpVq/Xs/NK5+VYp6enOj09tZIzNuGdTsdSy4jkrtVq1otyeHhoQQQ4GwQgMIdpvV6rXq+rUqnYdSNk2GyH35vNZuZCIYBwTigjDEUj0dwwHA5NKMRxrHa7rV6vZ/HViCNEKoIUR2o8Huv09NTcI0r9CoWChRHQr0MiXpZl9nnwOePCITbDvTGOC2WLCGUCLijha7Va5thwDNaJQEJMEmwRCrQ4ji36nLlIfO5pmlrQhXTuKPFaBNLFHqQwypteJNZxV2O+XRA5juM4juNck3AIbCiO6L0hipsSNTbJ0pOhppSkkUA2Go2sfIsSr/F4rOl0qslkYq5GHMeazWaK41jValXtdltpmtpGebPZ6PT01Gb9IMzof6GfiVlCiBaGvOLUIGAYRkoZ4Hw+V61WMxcIAYYDxjVT1hem0tEPhGBgphH9L5R74ayR4ocoKRQKarVaajQa2t/fN0cKEYEjguBCiJydnenk5MQixAkiWK1WJlYrlYparZY5cpPJxOZOhTOQSK+j94igB4QWwpgyy7AfqlKpqNFo2LNBxDjXT3qeJHMKcSn5rJijVa1Wd/qP6Cubz+dWSkkaIY4an0fYg8Tr6C+TZPOYKAt81wfFuiByHMdxHMd5CfiXd8SRJCt/IlmNhn1JO/N42HgisOhZGo/H5mwgVsbjsfUdEYDAsM8oitRqtawsTpJtrAeDgY6Pjy2emn4cmvsrlYol4xEukCSJDRzl+6vVysQXAQ+ktTWbTSVJotFoZNfPGkik4wtXCQcLISTJyr2YOUQMeChwKC1cr9eqVqsWUNDr9ZQkiQnTMGWOPS2OCjOg6GcKQyQI0KjX62o0GjYTCnHE/KXQyeHvXDPCL0wk5DwIJQRSs9m0hD3EJD8P783FOUih0OWzpDSR55JSOkoaEdGINtZP2V/oykmy5xbBiIPE8/uu4ILIcRzHcRznFRL2hPAv+/S0IIAkWaIaDfoIETbPYarYYDAwIVGv1zWZTOz7bFrzPLfZNZ1OR5VKRZ1Ox9ZFEMLp6am++OILEyf07ITx3QgFSRY3PZ1Od+YVEbPNGkltS9NUnU7HosalcxFIiR7leTgvbK5Jp+M+4Ebh+jAfiXS3crmsLMvs3JLMMWu1Wmq32xZwASTcsdY4jm0GFE4X5YYIHtZNXw8lcpQ2kq7H60MBiZhAhIZpeog1RCjXjfMWOkj8HKGEwyY9CbEI10uZXTjLCQeJKHieSWLF6Q+jnyt8dulDIuobV/Fiot7bigsix3Ecx3Gc10RY7kQZE/NwECKSrESMsix6XQgv4Ger1coGfRJewDwg4qU5Fm5Eq9UyccRGP01TGyb74MEDDYdDK93C2WBuDmtGdACuEk4VrhOiAkeh1Wopz3ONRiOVy2UrWUuSxMrdiACXtOPmMN+IUi9K+ejBoaQLIUCJIGl57XbbhqxyPYjAcDYRAqRcLuv09PRrMec4TpyH8sNarWb3lyG5oWjk2hCqCKTNZqNqtWrlgXxmrBsBQgIdrhHCA2EkyQQS9wSnimcPIY5bFEKJHveNczYaDXOkQjGMWEeccT8uCnrW9LbggshxHMdxHOcGoCwuz3NrcmezfbF/BgFAYEDokCCMVquVJdZtt1tLg5vNZhbfjBPBnCRcIDby8/ncNr7z+VxHR0d69OiRCRWS03AcKD8jQCFMYVsul5pMJpJkLoX0xB2qVquW+IZ4C39eqVRM8CAsEITcH0QLIpEgA8RAOJOHuGocolKpZENP0zRVt9u1a6Bfa7lcWh8NztVoNNqJw55MJnZfuUeUxjWbTbXbbetBov8LkRa6LogfPu84js2N47+EJYSfA0EUvI61cu18halyzEq6GBEvyRxKSeYYEXzB9YWlmDy3YVADr+OcnANX7LbHfbsgchzHcRzHeQOEpXW4CGz+cY9wBvg5fTS4L2xaESPj8dhKsHBjKD2TZJtjnCR6f/b39004JEmiLMs0Ho/1ox/9yDa+lElJ5/019K4gPOgboh+GfiBcDTbnkiwtDydhNBpZOR2JdrgZCD/K6+jzCYMJEBq4HDgmYWkZPU+IukKhoF6vZ301e3t7O2lyk8lEy+XSBu+GM6koB4yiSIPBwEQa97VYLCpNU7VaLTWbTdXrdesLY/ZUGDnOZ7her3fcIdbO/ef04bgGAAAgAElEQVQccRwrSRKLS0dshC4SPUiSLMmOe4JjxTMRRZGJF0QhJXKNRsOS7HCcENYIM0I6eIZCoR+eH2FPyMRtwQWR4ziO4zjOGwYxFAYz4BBRioQYIp0OF4BNJmV0DH0djUY7fUAkv1H+Fg6WpQG/0Wio0WioWq1quVxaWVuWZXr06JGOjo5MVOFYJUmiSqViG/NQhLGRx4EJZ+pIshlItVptR8RRloWDRSlYoVDQZDKxpDdJ1tcSDnMNxQN9R9wvro3eGzb0xHDTL8QsJ+4h14QYm06nFoLArKc8z3V2dmbrCGOuS6WSut2u9SLN53PrA6M0j889DIRg3QQbSDLRhluDqKPHjEQ/zo0YoqSNY16MA0fQ8Po4ji2yPHSdiIHn/pVKJSuzo1QOF0mSib2wD2p/f/91/291ZVwQOY7jOI7j3DJC9yjsIWJjTYwyCW5sfsN0sjAWPIyP5l//caYoUwvTy3AAkiQx50Q6d4/m87lOT0/1+PFjO2ZY+sXQz06no/V6bel4CLYkSbRery28AdeFwIkkSUxcIRTZrFMadnE4LBvuMK0NscJ+lnUuFgvrS4qiSI1GYyfWG3HA4F36eIivnkwm5rBkWWYx6sPh0Fw0QjAQS2EseBirTZkd4RcENVAOGMZuh9HtOEE4hVxbmD7HvWTOEmIndIsQ02HJG/cANw+BGb6Xz1mSlQvyLHGNzGAKj0fpYblcdkF0U7ggchzHcRznbSfsPSI+mc0tAojNLK9lY8vPcHUQEAxoZaPLZh3xhcOCqKLvCAeJTS3lbicnJzo+PjZREhLHsRqNhprNphaLhfU9EdmNg0FIA9eHMCIaXJKV/knaKe2ijCx0p8IY7FDo4D5JMqGBwEQgIbAQZaFThxvW7XaVJIkJJD4fyt1wR+jJmU6nJlCzLLOUPNaIwEEgMYiVnjCcPe4BDhzXF0aYI8B4fnBnGMhbr9ctgQ/3DJFDCiKfHeWFkkx0cWzOu1wubXaWJBPt4/HYXEj6oEjRC8/zpnFB5DiO4ziO8xYRugZZlplbgXuC+0G8NGVb/Ks9zooka/on5IAENI6PO8OfcVcor+t0OuZQMOj0+PjYktpChwZRliTJzswgBFI4n6hUKu302hAZTXM/JWHT6VTlctnipRn6Sh8VQ13DGPFyuWxiJwwa4H0k5AH9TDh0kuz1iKNyuaxut6tqtWr9VJQPIiiiKLKhtlEU6fT01ErlJpPJzn1G5CRJYgEYrVbLIrMRSIRG8JnNZrOdOUE4bQgZnEA+lzRNVa1W7TyU7THol/tOSSYCKLwmSi/DIbOIy/D89GJNp1NFUaT33nvvxv6feR4uiBzHcRzHcd5icI/YiLM5xi2gRC2Mdg5n/oTfH41Gmkwm5tTQXxMOIcXBwalgU91qtWyeDT05k8lEjx8/NkeK9XJMmva73a7FZpMwF14DTlQ47yhJEnU6Hetpmc1mms1mllZHYlpYAkf5nnTeE0RPDGVeofvBZj90ogh8CIUUbhPHStPU5gnV63W7V9yX2WxmseOct9Vqqd/vW58VLhfx4KyfPqter2fHRyAx2wnxR68Z/V7r9docIK4lDNkIywTL5bKazaaJSsoCufeUwuEy4kqF84hC0YnjiGCvVCo6ODi4yf9NnokLIsdxHMdxnHeEi9He9CIRLY14IFmMTTEbbTa0OCXM1rm4eea9vJYSONLVwp6bMAHt7OxMx8fHmk6n5iogfij1a7fbthkn7Q7xQjkaPTZZllmyW5qmFnlNORozkug/ajQa5gRFUaTJZKIsyxRFkUWJ43SEXyEXe6a4rwgp3KXwnjcaDcVxbOVizKQinGG9Xlss+WKxsAG5x8fHJnBwm5jzhFtDoEKn09k5PtHZlBHiJBHCQJ9VGGkezk/iuolMJzWPY+DGcQ84N/1sknaCG8J7Vy6X9c1vfvM1/p9wPVwQOY7jOI7jvKOE6XVsvCmXomelVCrZ5heRw0Y7jFWez+c2k4fjIDRCJykUYzgCRE9TXsYaTk5OdHp6arOUcCQQAXmeW7lYuVzWdDrVeDy2a+IaaOYn5IHepFarpTRNTVxxfVwvwoveJxLsisWiuW1s8Dknm/6wtwYXhC8ExsU0NwRns9m0NeKu0POEoxQmx61WK9XrdZ2cnOjs7MwCNygVDMvmuCck5dVqNQu3YIZUmDbIvSPGm7JGYrFx1EJXjHlI9XpdrVbLAiBI4Fsul1biSJkevWLSeTiHC6IbwgWR4ziO4zjOE+gNQiCxyZe0I5D4Hv+iT0ADZV/0upyenlpJV1jmFror9DohGuI4Vq/XM9eB1LjNZqN+v6/hcGhiCAeJtZJo1ul0TAhMp1NzTxjQSgkgIgCBV6/XrWSLeG827MRt0z9DAAXlgwhAxBP3EtHIvjlMtyN4Yrvd7swLCufwbLdb1Wo11Wo1EyOITM6B0ERcIoQKhYI5bpTahWKVzxFhWq/X1ev17Pr57MIkQIImcLgQdqyfIb6UE3I93D8COOgVQiStVitL1qtUKvr4449v9Nl/Fi6IHMdxHMdx7ijhhptNdVhiFwokRIH0xEFi475arUwg4fZMp1NJ2nEGEEgIFdLGOp2O9SKlaWqOBwKJTT5x4ZPJxL5HwAPnYUAopXQIuIvlZggjQiLCwa2U2uFyUMpGf1M4RJYyM66N+ydpZ0hs2HNEyRmx2SS8IeYqlYqFRyCsKpWKlb4RDCFJ3W5XaZpqPB6bk9Xv93diu3GD+LzDAI5arWY9XOGAXaLaEb+IR0orGdAax7EWi4WVNdJXRIgHpXaENqzXa3U6HX3rW9+66cf9qbggchzHcRzHcSTtOkgIC1LD2JQjMiTtiCfCD0IHaTAY2BBVYqdxRhAJm83GUu5wTrrdrokCgglIsGOuT5ikNxgMLCqbUrNqtbqzFkIduKYwQY/gAfppGo2Gle8hKIiSRiBJ0tnZ2U4gQxhoMJvNdsIL6KORnvTWUPYXukjh/SFIAeeIQbmhk8R5CIdAIJZKJU0mExWLRU2nUxOruHHcLz6DUCSlaar9/X2b24SgpKcrTB2UngzYRWgizAh1QLzx+XY6Hf3CL/zCzTzUV8AFkeM4juM4jnMpYekVfSd8P4xVDkvGLqbD4SBtNhsNBgMLQiCWOyzLog+Jn0myMjHcI/pSlsulzs7OdHZ2tjP/qFgs2nkkmftycdgrooiAA64pFEsEJNADRXjEZe5UHMcaj8c7wg8xgVtD+h1leGEkdpIk5tAhuPI8V71et9CL0HnhHJQcSueJf/Q+JUmyI6aYPTQejy14YTAYmOhD0IX/RSQRrLC3t2frxzUkmIIhwjhJOEih0OJ+l8tl/eqv/uoNPcXPxwWR4ziO4ziOcyUQItJ5sz0lZnyFM4LCMAI29GEJ23a71Xg8NseHMjhmJjEUlJ8hUuhVabVaiuNYrVbL+lmGw6HN98GVSJJEWZZZGEEY212pVKwUL+xJQmAgOsLhopSNdTod63FCDOBqhb1R3KdKpWK9VqS/UV5IKSCOUdhrdHEwahRF1odDSV3Yd4TjRMkgseqSLGUPsVqtViXJEvam06mGw6GVyvF5I1T5HkIMQVitVnd6rebzuQ2jRWBx3xk++4u/+Is3+uw+CxdEjuM4juM4zguDg7RcLr+W5BbHsbksOA44C6G7QX/NZDKxmUWj0ciEFRHPlUrF3AjKtgqFgs1BYn4OYmo8Huvo6MheS4DBbDazwAQS20ijQyzgWp2enlqQAEKtVCrtDF1lDayT2UCksbXbbXN16KHC8eHYOGM4PESbh2ER/Bk3KxRK9DtRvkfJIK8LhSvfi6JoJ0gCVwcHicQ70gXDz5rPBrFUKBSs5K9Wq6nZbO4IU8QmMee/9mu/9mYe2EtwQeQ4juM4juO8Mi4m2VFCJZ2LpFqtthPVTZ8N7gGuBK4JCWjT6dScDBLvwkZ9NvDr9VpJkqjRaFiqXKPRkCQtFgudnJxYqMN8PreSMITYcrnc6Y2hRI0eKjb19CVRDsa6Q2eGIa30ZNGLVa/XVa1WFcexiQtcJP7OOriH9E3hlMVxrDiOzYHjfhLtXSgU1Gq1LLqbcjtEabFYtNlPlDkScpGmqZrNpvVdEaRA39F8PtdwONxJ4ePe467xXwRk2NtULBb1Mz/zMzf6XD4LF0SO4ziO4zjOayPcxC+XS00mk51QBgSFpJ1kOErT4ji24AB6VnAsiPNGBCG2EEc09jPQlfKuarW6M5/n+Ph4Jy2PCOzRaGS9P/P53OKl6YtptVpar9cajUY7IQW1Ws3K2/h+sVi00jbK8KbTqbkytVrNSvkQFzg5uFFEgYeR2Vw/PU+lUsnECKETlPoRPV6pVMy5k2TDejkWohbxUqvVzOniXNwLerIQrwzS5Rp4PeWPm81G9Xrde4huChdEjuM4juM4tw820SSXseGXZOVeOB2ICcqycFyWy6VKpZJms5myLNNoNNJ4PLYeJ0m2+af0i0jtxWJhTg3x1+1228TY0dGRptOprY+SOPqFQucG0UDZWqPR2BEFCI16vW5CEKcrdJcQL7hWDEeN49hEErN8wvAD3DFisrm/4Qwigi8QnIRdUAIYzgdiHVxXGC9OUl6pVFKj0dgp0yOogmthvdPpVJPJZCcOPYoi/fIv//KNPW/PwwWR4ziO4ziO88bBmaCXJuxFkmQBALgNhAXgIlG6Rf/LZDLR6emplZstl0uVy2W1220TUtJ5GV2WZVaKhxtSqVTU6XRsbV9++aWJEFwn1kCpHSVkYSgCM34QBAgMxEgY2Y1gqVQq5vJIT5w0Zj8hQhCWaZpaPDg9PbPZzHqSEJ+IFvqeQmHEvUWMkczHrCY+nzRN7Z4iMjkmaXyVSsUEIEKKLxyjn/qpn7qZB+sKuCByHMdxHMdxbiU4LJSKEUtN+RylbexZQ4eC4INCoWACAReJdDfK4whUQCThKG02m50hqY1GQ81mU1EUKcsyK7VbLBbmTBGewBDYMByCPp7QVQmFIKV4odCiT4kACgSI9KQ/BweKuO7VaqUkSaxkj16gxWKhs7MzW29Y0sZ7w6AG/h4GJiCQEHOIUsIkuB5EUrVaVbfbtZ6qNE213W710Ucf3dBT9HyeJYhKN70Yx3Ecx3EcxwE26TgOT+tHQiRsNhs1Gg3rgZGezBdqNBrW8yPJRNLp6elO+MNyuVSj0VCv11OxWDSRNJ1OdXJyYv1KiKhWq6Vms6lisagsy9Tv9+0cuD2k3lF6RoBD6HbV63VJ2ukJorwtDEW42F9EqMR4PDZBxVBZhrnSI5Qkifb29qzMrlQq2bBV5kxxPElWtsh958/8jHI+yu5wlxBvDIt98OCB3XPu2W0SRM/CBZHjOI7jOI5za2CGjiQLSZB2nSSGuoYiCScJIYGYYJ7RRZF0cnJiAgH3ptFoqNPpqFwua7FYKIoiLRYLPXz40GYQ0fNTr9d1//59VatVc5JwY4rFoiXqcU5CEnCVWCNuEdfOdeMUSdqZO0SEOOLu7OzMQiAuDkklca7RaKjdbqtQKJhrJMmG2xIowTERZvxsNpspiiITngiksPSuWq3aZ4coelt4e1bqOI7jOI7j3FkuOknSbk8SZWvhLKSw94jQgUKhoFqtplarZSEE2+1WWZbZwNLwWNVq1SK0EUmr1UpHR0f68Y9/bG5NpVJRuVxWr9czB6vf72s+n5tIiqJI7XbbxBqCDDHC2iXZrCTEDqKIWUkck3tAOEQoCim3Q3QRqMA5Dg4OJMnEFj1K4/FYq9VKWZbZGqUnpXZhGl/Yo1StVu1+0Jv1NuCCyHEcx3Ecx3kroY9IehLIEKbbEV/N9/h5o9Gw0ITQSarVaiqXy+b0ENwwHo91dnZmooXysWazKUkmrLIs08nJibbbrQmkUqmker2udrutarWqo6MjZVmm5XJpzhBuS7FYtNAE0ttwsOipYn04QPV6XbPZzEQQ0dwEOOAosUbcH3qF6F2iT6lWq6lWq9n9pQSQMInlcmnroqeKdWdZZq7UeDy+0WfhZXBB5DiO4ziO47wzUDomyWYf0bNzseRusVjYnB3cpPl8bnHUDH394IMPzEGh9G06nVpf0nq9Njem0+lYORzJcoPBQF988YUJEc5VrVb1kz/5k1osFhoMBppOp6pUKprNZtpsNtrf37fyvdVqZf1OuFlhOBoBCOVyWWmampPFdYeR5wRCcB7pSakiAolhrzhr7Xbb7iVlcdPp1NwtQioIXciy7CY/9pfCBZHjOI7jOI7zTkOvjrRbckfAQjgrCdFEOVqapiYqSqWS0jRVkiRqt9s2fBUHZblcWsIdjg0C4969e+bQEBE+HA712WefKUkSE2GVSkUffPCBut2uBoOBhsOhkiTRZrPRcDhUHMc7fVUk7hG/jaOFI1Qul80JqlaryvNc2+12J06b8kC+T5w51xyW3CVJstMDhUtG3xTHoE/pbcAFkeM4juM4jnMniaLoa26S9KTsbrvdajwem1gIhRKDVKMosjS6PM91cHCgUqlks5aWy6Xm87kJFkQGQ17pZaIPZ7Va6eHDh/rjP/5j1Wo16/mJ41gff/yxDYXF5VoulxoMBqpUKhYesVqtbMDtaDSyEr3hcGjx4PT8EBCBg8QaC4WCiZrQ/UFEUXqH4GOeEceh7O5twAWR4ziO4ziO4wSEZXdpmtr3ifrebrc2M4kyOvptcI0kqdPpWCDB/fv3VSqVrGSPsjKGuXJehApCCeGxXC714x//WPP53OYF8bOPP/5Y9XrdjkcP1HA4VKlU0t7enq1DOhcrs9nMQiQGg4EkWVADTlClUrEwCMr/ttutHWe9Xms+nyvLMp2dnUl6kohHT9fbgAsix3Ecx3Ecx7kCxWLRghBCoRQGOVB6l+e5ptOplZFJMheo1+tptVqp1WqZs7RerzWdTrVaraz0jXS8cABqu922VDmOfXR0pB/96Ec7/UNRFOm9995TrVaztazXazv2drtVp9Mx9yvPc1WrVW23Ww2HQ2VZpul0aj/H2UIsIZzq9bo5VThPOExvCy6IHMdxHMdxHOcluCzIQdoNcyCFjb4lRANleKVSyYILVquV3n//fUmykjuCFWazmc0F4twENHBOhFuWZXr8+LHNDqL8rtvtWj+RJIv+5jzMFaIkkGtDtI3HYwtt4DoY4krynztEjuM4juM4jnPHuRjmQACBtNunNJvNzFVChBCKEMexkiSxMAQEyGKxsH4fhMx0OrXEPIajdjodc2twcIrFok5OTmyeUJIkiqJI9XpdzWbT1lwsFi26nPCIarVqYom4bkoJ6ZWSzmcVvS24IHIcx3Ecx3GcG+ZpfUrS13uV6DGip0h6MoMJ8SPJSt8QJRyH8jvOK50Puk2SRIVCwd4vnYu44XBoc5qYV8Tcpc1mY+sN5yRtNhslSWIpdN1u93XduleOCyLHcRzHcRzHuUU8rVdJ2nWWsizTYrGw8jXpXCg1Gg3rMcrzXPfu3bNSvclksnMcUvR4Pa5WHMc2DJbXk7DX7/dtnUmS2PmY61Qul3fCF247Logcx3Ecx3Ec5y3hWc4SJXeU0c3ncwtFoPyu2+3upNrdu3dPURSZWKIsj/S8MIabgIdqtWrzixBaRHDPZjONx2PvIXIcx3Ecx3Ec52aJokhxHEvaDXcAXKHNZqPZbGbhDpvNRpVKRZVKxV4jnZfVIXgQWAgmEvWYeUQwBD1Pl53/tuKCyHEcx3Ecx3HuAKG7dJmDc5lgwllK09SCHpbLpZXWRVGk6XSq5XKp1Wr1tVlFbwMuiBzHcRzHcRzHea5gIkaccjoco0qlYsNomXVUKr09MuPtWanjOI7jOI7jOG8MXCES6i4j7GN6W3BB5DiO4ziO4zjOKyHsY3pbKLzpBTiO4ziO4ziO47wpXBA5juM4juM4jnNncUHkOI7jOI7jOM6dxQWR4ziO4ziO4zh3FhdEjuM4juM4juPcWVwQOY7jOI7jOI5zZ3FB5DiO4ziO4zjOncUFkeM4juM4juM4dxYXRO8wn3766a0+5sVjXeXYL3L+F10z73uZc4bv/fTTT+1Lkr75zW9e+p6rnjM81tOO87z1XVzX63hmnnXuZ63lWe8PX/Mya/7kk0+e+fOr3N+rPMfX/WyvwtOO87o/w+sc/yaep+ed53mf8etex03dA8dxHOfFifI8f9NreCm+/e1v5z/4wQ/e9DJuJVEU6VV/vq/ymBePdZVjv8j5X3TNvO9lzhm+N4oi+/llx7342qvcC4512bmvsr6L67rseK+a513389bxvPv4Mmu5ys+f99w+7z2v6v+hpx3ndfx//6LHf91rucp5bmoNTzvXTZ7fcRzHeTpRFP3feZ5/+7KfuUPkOI7jOI7jOM6dxQWR4ziO4ziO4zh3FhdEjuM4juM4juPcWVwQOc41+PSzz970El6IN7Xumzrv085z2fevsqZPP/vsa697E/eQc4bnvu46nnUdN3FNl13Dq3r9ZdcWfnbPO8bT3v+09z7rexd/9skPf3jtYz2LT374w2u/95v/5J9c6XWXPe9X5W39nSjdrrXfprU4zl3kRgVRFEU/F0XRP4+i6E+iKPqbl/y8EkXR//TVz//PKIq+eZPrc5zn8b0HD970El6IN7Xumzrv085z2fevsqbvPXjwtde9iXvIOcNzX3cdz7qOm7imy67hVb3+smsLP7vnHeNp73/ae5/1vYs/+6Ph8NrHehZ/NBxe+70PFosrve6y5/2qvK2/E6XbtfbbtBbHuYvcmCCKoqgo6e9L+nlJPy3pV6Io+ukLL/v3JZ3lef4vSfqvJP2XN7U+x3Ecx3Ecx3HuHjfpEP05SX+S5/mf5nm+lPQPJP2VC6/5K5L++6/+/LuS/lJ0MRPYcRzHcRzHcRznFXGTgugDST8O/v75V9+79DV5nq8lDSX1bmR1juM4juM4juPcOW5sMGsURb8k6efyPP8bX/39r0n683me/3rwmn/61Ws+/+rv/+Kr1/QvHOu7kr4rSR9++OG3Hnjt7aX4YNYXf48kRd/5jvSd7zz3db/10Uf69OOPLz3nGxnMes11v6rBrJ9+9tnV6uC//33l3/++/fXag1mveH03wW999JG+92f+zCsZzHrl+/eUdXz68ccvdYyLx3oaz3o2r3v+n221dnpj7jrc+09++MNr35dWsajhZvPKXheuB676+T7vGXoT3Ka136a1OM5d4lmDWZXn+Y18SfoLkv5h8PfflPSbF17zDyX9ha/+XJLU11ei7Wlf3/rWt3Lncs4/3tt7zIvHusqxX+T8L7pm3he+X3/wBy/+Xsm+LlvXxdde5RyXve7S711Y99PW9aqfmcvu1/Ou+3nruOw+Pu1zufT8wfeedh79wR+cf13y2T/vuX3eZ3Kde2znDNf8lHU8dT0XP/tLjnUdrrX+4LO58v8713j9xXthn1twjGc+S5fcm2ed/1nfu+x54XtXPdazeJHP7Tqve5Fn4TrnuI3cprXfprU4zruKpB/kT9ETN1ky939J+pejKPo4iqJY0r8j6fcuvOb3JP31r/78S5L+968uwHEcx3Ecx3Ec55VTuqkT5Xm+jqLo13XuAhUl/U6e5/8siqK/pXPF9nuS/ltJ/0MURX8i6VTnoslxHMdxHMdxHOe1cGOCSJLyPP99Sb9/4Xv/WfDnuaS/epNrchzHcRzHcRzn7nKjgshx3nZ+66OP3vQSXog3te6bOu/TznPZ96+yJl7zvWu+71XDOcNzX3cdF1//Msd6ES67hlf1+mddG3//np7Ode/Ns7538Vw/22rpk3Zb37vGsZ7Fz7Za137vR5XKlV73Ms/B2/o7Ubpda79Na3Gcu8iNpcy9Lr797W/nP/jBD970Mm4lnjL34u8J3/cy53wjKXPXvI+vKmXuqjzvup+3jufdx5dZy1V+/rzn9kVT5l7V2l/H//cvevzXvZarnOem1vC0c93k+R3HcZyn86yUuZsMVXAcx3Ecx3Ecx7lVuCByHMdxHMdxHOfO4oLIcRzHcRzHcZw7S/HTTz9902t4KX77t3/70+9+97tvehm3lk8++eRWH/Pisa5y7Bc5/4uumfe9zDnD937yySf29f3vf1+/8Ru/8dR1XvVeXPa6697HcF2v45l51rmftZZnvT98zYuu+Q//8A/1ne9851prvex7V3mOr/vZXoWnHed1f4bXOf5NPE/POs9VPuPXvY6bugeO4zjO0/ne97735aeffvrbl/3MQxUcx3Ecx3Ecx3mn8VAFx3Ecx3Ecx3GcS3BB5DiO4ziO4zjOncUFkeM4juM4juM4dxYXRI7jOI7jOI7j3FlcEDmO4ziO4ziOc2dxQeQ4juM4juM4zp3FBZHjOI7jOI7jOHcWF0SO4ziO4ziO49xZXBA5juM4juM4jnNncUHkOI7jOI7jOM6dJcrz/E2v4aWIouhY0oM3vIyWpOE7eP5XcdwXPcZ133fV11/ldc97zZ6k/hXX9TbxJp/j2/wMv8xxrvO+V/3au/gc++/iV38M/1188/jv4ld/HH+Ob5bb+rv4ozzP9y99R57n/vWSX5J++108/6s47ose47rvu+rrr/K6571G0g/e5Of9ur7e5HN8m5/hlznOdd73ql97F59j/1386o/hv4tv/st/F7/64/hzfLNfb+PvYi+ZezX8L+/o+V/FcV/0GNd931Vff5XXvenP803xJq/7Nj/DL3Oc67zvVb/2Lj7Hb/qab/Nz7L+L3x78d/GrP44/xzfLm77ma5//rS+Zc5ybJoqiH+R5/u03vQ7HeRn8OXbedvwZdt4F/Dm+HbhD5DjX57ff9AIc5xXgz7HztuPPsPMu4M/xLcAdIsdxHMdxHMdx7izuEDmO4ziO4ziOc2dxQeQ4juM4juM4zp3FBZHjOI7jOI7jOHcWF0SO85JEUfRTURT9N1EU/W4URf/hm16P47woURTVoij6QRRFv/Cm1+I41yWKok+iKPrHX/0+/uRNr8dxXoQoigpRFP3tKIr+bhRFf/1Nr+eu4Pu9+jEAAAuZSURBVILIcS4hiqLfiaLoKIqif3rh+z8XRdE/j6LoT6Io+puSlOf5/5vn+X8g6Zcl/cU3sV7HuYzrPMdf8Z9I+p9vdpWO83Su+QznkiaSEkmf3/RaHedpXPM5/iuSviFpJX+ObwwXRI5zOd+X9HPhN6IoKkr6+5J+XtJPS/qVKIp++quf/WVJ/6uk37/ZZTrOM/m+rvgcR1H0b0j6fyQd3fQiHecZfF9X/138j///9u49yKuyjuP4+4OKl8w0tVQUL6iISjJq4AW8jDrqqDWSpnkpCDVLJ++m5ujmqOOFLiqaFulqmVZKXjJtEtyIBLQoFaHAbBUk7yYiqAnf/niejcPht79ld3F/u/w+r5kzcM55znOe85xn2PPd50JEHEoK7L/TxeU0q6aRFW/H/YHHI+JswKNOuogDIrMKImIi8Gbp8GDguYh4PiI+AO4m/SaHiHgg/yA+vmtLata6drbj/YA9gOOAkyX554PVXHvacEQsyeffAtbswmKaVdXOf4vnktowwOKuK2V9W73WBTDrQfoAcwr7c4Eheaz6cNIPYPcQWXdXsR1HxOkAkkYArxc+Ls26m9b+LR4OHAysD4ypRcHM2qFiOwauA26QNAyYWIuC1SMHRGadFBFNQFONi2G2UkREY63LYNYRETEOGFfrcph1RkQsBEbVuhz1xkMizFbcS8AWhf3N8zGznsTt2Ho6t2FbFbgddyMOiMxW3JPAdpK2ltQbOBZ4oMZlMmsvt2Pr6dyGbVXgdtyNOCAyq0DSXcBkoL+kuZJGRcSHwOnA74CZwC8j4tlaltOsGrdj6+nchm1V4Hbc/Skial0GMzMzMzOzmnAPkZmZmZmZ1S0HRGZmZmZmVrccEJmZmZmZWd1yQGRmZmZmZnXLAZGZmZmZmdUtB0RmZmZmZla3HBCZmRmStpIUknavdVm6gqQRkhashHz2y/W20cool5mZdT0HRGZm7SRpY0k3SWqW9L6kVySNl3RQIU2zpHM7kHeTpDErt8QrZA6wKfC3Gty7R2jlnT5Oqrc3alCkj8xH0Q4dPJpZd7V6rQtgZtYD3QusA4wCngM+BewLbFjLQnVGRCwGXq51OXqaiPiAHlxvknrnZzAzq1vuITIzawdJ6wPDgAsiYnxEvBART0bE6Ii4O6dpArYErs2/EY98fENJd0maK2mRpGcljSzk3UgKrE5ruU7SVvncjpIekvSOpFdzPptUKechOe3qeX/bnN/NhTSXS3o0/32ZIXOS1pB0vaR5uRdsjqSrCtf2lnR1fpaFkp6UdHAbddck6WZJ10l6K2/XSupVSLOBpNvzuUWSHpW0U+H8CEkLJB0haZak9yQ9JmmbQpoGSdNL9646RE5SP0n3S3pZ0ruSpkk6vFh2Kr/T5Xo9JA2X9Eyh3r4tSYXzzZIulnSLpPm5Ds9ro+4aJE2XdJKkF3Pd3FfubZE0UtKMXC+zJJ1Vqt+QdJqkcZLeBa6scK9GOtgOJQ1U6i2dn9/TU5L2z9c/lpO9lvNsrPbMZmZdxQGRmVn7LMjb5ySt1Uqa4cBc4DLScKpN8/G1gGnA4cBOwHXALZIOyOfPACYDtxWumyNpU2AiMB0YDBwIrAvcX/zYLZmU79cyJ2g/4PX8J4VjTa1c/03gSOBYYDvgGOAfhfO3kT6ajwN2Bm4HHpS0Syv5tTie9LNnT+BrwCnAmYXzjcAQ4POkZ10IPCJp7UKaNYFLgZE5n9WAccWgowPWBR4GDgJ2IfUCjpO0Qz7f2jtdhqTdgF8B44CBwAXAhcDppaRnAc8AuwJXA9dI2rONMm4FnECqmwNJ7+XWwr1PJgU4lwADgHOAbwHfKOVzKfDbXL4bK9ynM+3w58C/8/lBQAPwHmlI5hdymp1ynme08bxmZl0jIrx58+bNWzs20ofdm6QPvcnAaGBIKU0zcO4K5HU3MLaw3wSMKaW5DBhfOrYBEMDgKnlPAS7Mf/8Z6UN4EeljdB3gfWBoPr9Vzm/3vH89MB5QhXz7AUuAvqXj9wE3VSlPEzCrmCdwMTA3/327XIZ9Cuc/AbwNnJT3R+Q0exfSbAksBg7M+w3A9NK9RwALWtuvUn8XV3unpKAygI3y/p3AhFKahpZnLORzVynN7OK9KpSlIT9j38Kxofne2+X9F4ETS9edCcwo7Adwwwq0yw61Q2A+8JVW8lymrrx58+atu2zuITIza6eIuBfYDDiC1KuwFzBF0kXVrpO0Wh4+9bSkN/IQruFA3zZuuRuwTx6CtCBfNyef6ydpWPGcpOPzuSaW9gjtm8s6NR/bC/gQeKKVezaSfsM/S9KNkg4r9ALsCgiYUSrTYaRgqZopERGF/clAH0nrkXo1luRjAETE26SelB0L1ywpljsiXgDmldK0i6SPSbomDzd7Kz/P7rT9bsoGAH8qHZvE0mds8XQpzTzSXLRqXoqIFwv7U0l1MUDSxsAWpB7H4ju5iuXfyZ9X4DkqqdoO85/fA8ZKmpDb+g4VczIz60a8qIKZWQdExHvA7/N2maSxQIOk0dH6JPVzScOYziB95C8gDXFq60O4F/BQvr7sFVJgM6h0DFJAdLqkAcB6wF/ysf2BV4HJrZU1IqbleR8HAweQhsQ9pbSSXi/Sb/o/C/y3dOmiNp6lo6KN/aIlpICtaI028h8NHEKq49mkoXp3AL3bUca2FMtcrregc8PYW649lbTyXTXvduIe1dohEdEg6U7gUFLbuVTSqRFxa4VrzMy6BQdEZmYrxwzSv6lrAR/kbbVSmqHAgxHxU4A852V74D+FNJWumwZ8EXghIsof0i2eq3BsEmm+zfnApIhYnBcH+DHpA/aRag8UEe8A9wD35AnwU4Btgb+SAo5NIuKx1nOoaIgkFXqJ9gDmRcR8STNZOr9oIkDuVRlIms/SohdpjsrjOU1fUo/dzHz+NeDTpfsUA8ZKhgJ35N4/8vywfqQhfi0qvZuymcDeFfKem+uzM/pI2iIiWnplBpPqYmZEvCJpHtAvIu7o5H2g4+2QiJhNCiqvl/RD4CTSXKeW4LutOjQz61IeMmdm1g5KK8VNkHSCpM9I2lrS0aSgY3xEzM9Jm4FhkvoUVgKbBRwgaWgeSjQG2Lp0i2ZgsNKqbxvlYWo3kubS/ELSEEnbSDpQ0o8kfby1skbEAlKv0AksXeFrCrA5KRBpqvKcZ0v6kqQBkrYlLZ4wn/RhP4s0V6ZR0lG5PLtLOlfS8DaqcDPgB5L6SzoKOA/4fi7vbOB+0rCvYZIGkuY+zSdN1m/xYc5jT0mDSL1XzwKP5vNNwCeBi5RWjxsFHNVGuWYBR0ratXDf8qIZzSz/Tsu+C+yrtCrc9nn44jnANW3cf0UsAm6XNCgvwHAz8FCuN0hzxM5XWlmuv6SdJX1Z0oUduFcz7WyHktbOwyv3y9cNIQWDM3KeL5B6wg5T+r+81u14VZiZrTwOiMzM2mcBKag4A/gD6UP8StIH+zGFdJeQ5nT8k9RjAXA5ae7Lw6QekHdJgUXRaNJv0mfk6/pGxDxSr8MSUq/Os6SP0/fzVk0TqeeqCf4/1G9qvq61+UMA75CClSdIPQODgEMjYmE+P5LUa3MN8HfgN8A+pI/eau4k9RBMJfVU/YQcEBXyfQJ4IP+5DnBIRBSH4r0PXEEa0jaV9LNseEtvUETMBL5OWsHuadLKccstL11yNmkY4R9J72dK/ntRpXe6jIiYBhxNWnhjOmkOz1Wk4LezmkmLcDwITACeJ9VXy73HAl8FTgSeyuU/BfhXB+7VkXa4mLTIQiNpRcJfk+aDnZ3L9xIpaLuC1ENZi/+A2MxsOVp2bquZmdlHIw/Xmx4R5SWo25PHCNLqZ3XVuyCpATgqInaudVnMzFY17iEyMzMzM7O65YDIzMzMzMzqlofMmZmZmZlZ3XIPkZmZmZmZ1S0HRGZmZmZmVrccEJmZmZmZWd1yQGRmZmZmZnXLAZGZmZmZmdUtB0RmZmZmZla3/gdPa2whoob3kwAAAABJRU5ErkJggg==\n",
       "text/plain": [
        "<Figure size 1008x648 with 1 Axes>"
       ]
@@ -8620,22 +1683,6 @@
     "\n",
     "[^1]: Full details about the model are available at:  https://github.com/jwrichar/COVID19-mortality"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "papermill": {
-     "duration": 0.264155,
-     "end_time": "2020-03-22T21:23:18.720952",
-     "exception": false,
-     "start_time": "2020-03-22T21:23:18.456797",
-     "status": "completed"
-    },
-    "tags": []
-   },
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -8654,7 +1701,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.10"
+   "version": "3.6.9"
   },
   "papermill": {
    "duration": 193.595841,


### PR DESCRIPTION
Recently, due to missing data for some of the US states/territories, the actual case counts have been cast to float by pandas and displayed as floats in the dashboard 🤦‍♂ 

This fix casts the counts to int to ensure proper display.

Screenshot:
![image](https://user-images.githubusercontent.com/52940005/77264174-121bfc80-6c57-11ea-8cc8-44004fec3279.png)
