### PR TITLE
Fix broken link to update schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,5 +6,4 @@ image: images/covid-growth.png
 
 ## These dashboards are updated several times a day[^1].  Please [get in touch](https://covid19dashboards.com/about/) if you would like to contribute!
 
-[^1]: The update schedule is specified [here](https://github.com/github/covid19-dashboard/blob/master/.github/workflows/update-growth-nb.yaml#L4).  The data presented in this project carry inherent uncertainties. Use of these data for public health or policy making should only be done after an exploration of the methods and assumptions presented. 
- 
+[^1]: The update schedule is specified [here](https://github.com/github/covid19-dashboard/blob/master/.github/workflows/update-models.yaml#L4).  The data presented in this project carry inherent uncertainties. Use of these data for public health or policy making should only be done after an exploration of the methods and assumptions presented.


### PR DESCRIPTION
Fixes the link to the data update schedule in the footnote on the front page. 