### PR TITLE
Fix: Overflow of Charts on mobile

### DIFF
--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -22,6 +22,10 @@ li {
 }
 
 // Handling large charts on mobile devices
-.output_wrapper{
-  overflow: scroll;
+@media only screen and (max-width: 900px) {
+  /* for mobile phone and tablet devices */
+  .output_wrapper{
+    overflow: scroll;
+  }
 }
+

--- a/_sass/minima/custom-styles.scss
+++ b/_sass/minima/custom-styles.scss
@@ -20,3 +20,8 @@ li {
   width: 23px;
   height: 23px;
 }
+
+// Handling large charts on mobile devices
+.output_wrapper{
+  overflow: scroll;
+}


### PR DESCRIPTION
Fixes #228 

For all outputs cells from the notebook that extend beyond mobile width, this fix adds a scrollbar.
It allows the user to scroll the particular chart/table/output. 
Avoids the horizontal scrollbar on the entire website.
