### PR TITLE
Prefer href over name

### DIFF
--- a/_pages/tags.html
+++ b/_pages/tags.html
@@ -20,7 +20,7 @@ search_exclude: true
     {% capture category_name %}{{ category | first }}{% endcapture %}
 
     <h3 id ="{{ category_name }}"><i class="fas fa-tags category-tags-icon"></i></i> {{ category_name }}</h3>
-    <a name="{{ category_name | slugize }}"></a>
+    <a href="#{{ category_name | slugize }}"></a>
     {% for post in site.categories[category_name] %}
     {%- assign date_format = site.minima.date_format | default: "%b %-d, %Y" -%}
     <article class="archive-item">


### PR DESCRIPTION
The name attribute of <a> tags is deprecated in HTML5. This change swaps it to use the preferred href method of linking.