### PR TITLE
Avoid nesting double quotes in html

### DIFF
--- a/_includes/favicons.html
+++ b/_includes/favicons.html
@@ -1,1 +1,1 @@
-<link rel="shortcut icon" type="image/x-icon" href="{{ "images/favicon.ico" | relative_url }}">
+<link rel="shortcut icon" type="image/x-icon" href="{{ 'images/favicon.ico' | relative_url }}">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
-  <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
   {%- feed_meta -%}
   {%- if jekyll.environment == 'production' and site.google_analytics -%}
     {%- include google-analytics.html -%}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,7 @@
       {%- assign default_paths = site.pages | map: "path" -%}
       {%- assign page_paths = site.header_pages | default: default_paths -%}
       {%- assign titles_size = site.pages | map: 'title' | join: '' | size -%}
-      <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
+      <a class="site-title" rel="author" href="{{ '/' | relative_url }}">{{ site.title | escape }}</a>
   
       {%- if titles_size > 0 -%}
         <nav class="site-nav">

--- a/_includes/notebook_colab_link.html
+++ b/_includes/notebook_colab_link.html
@@ -1,5 +1,5 @@
 <div class="px-2">
     <a href="https://colab.research.google.com/github/{{site.github_username}}/{{site.github_repo | default: site.baseurl | remove: "/" }}/blob/{{page.branch | default: "master"}}/{{page.nb_path}}">
-        <img class="notebook-badge-image" src="{{ "assets/badges/colab.svg" | relative_url }}" alt="Open In Colab"/>
+        <img class="notebook-badge-image" src="{{ 'assets/badges/colab.svg' | relative_url }}" alt="Open In Colab"/>
     </a>
 </div>

--- a/_includes/notebook_github_link.html
+++ b/_includes/notebook_github_link.html
@@ -4,6 +4,6 @@
 {% elsif page.layout == 'post' %}
     <a href="https://github.com/{{site.github_username}}/{{site.github_repo | default: site.baseurl | remove: "/" }}/tree/{{page.branch | default: "master" }}/{{page.path}}" role="button">
 {% endif -%}
-        <img class="notebook-badge-image" src="{{ "assets/badges/github.svg" | relative_url }}" alt="View On GitHub">
+        <img class="notebook-badge-image" src="{{ 'assets/badges/github.svg' | relative_url }}" alt="View On GitHub">
     </a>
 </div>


### PR DESCRIPTION
When browsing the project in my IDE, I get (valid) errors, as most will not correctly parse nested double quotes. This makes for a confusing experience.

This change allows IDEs to parse html correctly by using single quotes instead of nested double quotes, following the existing pattern in `search.html`.