### PR TITLE
Pin Primer CSS to `15.2.0`

### DIFF
--- a/_includes/custom-head.html
+++ b/_includes/custom-head.html
@@ -8,7 +8,7 @@
 
 {%- include favicons.html -%}
 {% seo %}
-<link href="https://unpkg.com/@primer/css/dist/primer.css" rel="stylesheet" />
+<link href="https://unpkg.com/@primer/css@15.2.0/dist/primer.css" rel="stylesheet" />
 <link rel="stylesheet" href="//use.fontawesome.com/releases/v5.0.7/css/all.css">
 {%- feed_meta -%}
 {%- if jekyll.environment == 'production' and site.google_analytics -%}


### PR DESCRIPTION
👋  from `@github/design-systems`. We're about to release a new major version of Primer CSS and noticed that this repo loads the "latest" version from `unpkg.com`. To avoid breaking anything, we recommend to pin the Primer CSS version to `15.2.0`.

In case you like to update to Primer CSS `16.0.0`, you can follow the [migration guide](https://primer-css-git-release-1600-primer.vercel.app/css/support/v16-migration). For any further help feel free to ping `@github/design-systems` or reach out to the [Design Systems team in slack](https://github.slack.com/archives/C0ZCGGGJ2).